### PR TITLE
fix docker build to work cross platform

### DIFF
--- a/openstack-tenant/agent/Dockerfile
+++ b/openstack-tenant/agent/Dockerfile
@@ -1,6 +1,17 @@
+FROM mobiledgex/build AS build
+
+WORKDIR /go/src/github.com/mobiledgex/edge-cloud-infra/
+COPY . .
+ENV CGO_ENABLED=0
+ENV GOPATH=/go
+ENV PATH="/go/bin:${PATH}"
+WORKDIR /go/src/github.com/mobiledgex/edge-cloud-infra/openstack-tenant/agent
+RUN go get -d -v ./...
+RUN go install -v ./...
+RUN ls -l /go/bin
 FROM alpine:latest
 
-ADD build/mexosagent /usr/local/bin/mexosagent
+COPY --from=build /go/bin/agent /usr/local/bin/mexosagent
 
 ENTRYPOINT [ "mexosagent" ]
 CMD []

--- a/openstack-tenant/agent/Makefile
+++ b/openstack-tenant/agent/Makefile
@@ -9,7 +9,7 @@ API_FILES = api/mexosagent.pb.go api/mexosagent.pb.gw.go api/mexosagent.swagger.
 default: build docker-build docker-push
 
 docker-build:
-	docker build -t mobiledgex/mexosagent .
+	./docker-build.sh
 
 # docker login first!
 docker-push:

--- a/openstack-tenant/agent/docker-build.sh
+++ b/openstack-tenant/agent/docker-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# this has to be in shell script because we have to run at top level
+cd ../..
+pwd
+docker build -t mobiledgex/mexosagent -f openstack-tenant/agent/Dockerfile .


### PR DESCRIPTION
I noticed that some docker images were build on a macosx laptops and pushed darwin mach-o 64 binaries which fail to launch in kubernetes (linux amd64 elf).

fixed dockerfiles and added a script to makefile to build correctly on different platforms.