### PR TITLE
Add security rule to enable access in a new cloudlet. Avoid fatal err…

### DIFF
--- a/openstack-prov/oscliapi/mex.go
+++ b/openstack-prov/oscliapi/mex.go
@@ -350,7 +350,7 @@ func CreateMEXKVM(name, role, netSpec, tags, tenant string, id int) error {
 			//return fmt.Errorf("can't get router detail external gateway, %v", regerr)
 			log.DebugLog(log.DebugLevelMexos, "can't get router detail, not fatal")
 		}
-		if len(reg.ExternalFixedIPs) > 0 {
+		if reg != nil && len(reg.ExternalFixedIPs) > 0 {
 			fip := reg.ExternalFixedIPs[0]
 			log.DebugLog(log.DebugLevelMexos, "external fixed ips", "ips", fip)
 			// router IP for the private network to the external side, which

--- a/openstack-prov/oscliapi/oscli.go
+++ b/openstack-prov/oscliapi/oscli.go
@@ -764,3 +764,12 @@ func SetServerProperty(name, property string) error {
 	log.DebugLog(log.DebugLevelMexos, "set server property", "name", name, "property", property)
 	return nil
 }
+
+func AddSecurityRule(name string, port int) error {
+	portStr := fmt.Sprintf("%d", port)
+	out, err := sh.Command("openstack", "security", "group", "rule", "create", "--proto", "tcp", "--dst-port", portStr, name).Output()
+	if err != nil {
+		return fmt.Errorf("can't add security group rule for port %d to %s,%s,%v", port, name, out, err)
+	}
+	return nil
+}

--- a/openstack-prov/oscliapi/oscli_test.go
+++ b/openstack-prov/oscliapi/oscli_test.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
-
-	log "github.com/sirupsen/logrus"
+	//log "github.com/sirupsen/logrus"
 )
 
 var mexTestInfra2 = os.Getenv("MEX_TEST_INFRA")
@@ -31,7 +30,7 @@ func TestInit(t *testing.T) {
 	if mexTestInfra2 == "" {
 		return
 	}
-	log.SetLevel(log.DebugLevel)
+	//log.SetLevel(log.DebugLevel)
 }
 
 func TestGetLimits(t *testing.T) {
@@ -161,7 +160,7 @@ func TestDeleteServer(t *testing.T) {
 		t.Errorf("name mismatch")
 	}
 
-	log.Debugln("delete server %s %s", sd.Name, sd.ID)
+	//log.Debugln("delete server %s %s", sd.Name, sd.ID)
 
 	err = DeleteServer(sd.ID)
 	if err != nil {


### PR DESCRIPTION
…or in the case of different cloudlet network conditions that disallow retrieval of router data.