### PR TITLE
TMO poland fix for using non-default network

### DIFF
--- a/openstack-prov/oscliapi/tdg.go
+++ b/openstack-prov/oscliapi/tdg.go
@@ -165,7 +165,7 @@ func PrepNetwork() error {
 		}
 		err = SetRouter(eMEXExternalRouter, eMEXExternalNetwork)
 		if err != nil {
-			return fmt.Errorf("cannot set default network to router %s, %v", eMEXExternalRouter, err)
+			return fmt.Errorf("cannot set network: %s to router: %s, %v", eMEXExternalNetwork, eMEXExternalRouter, err)
 		}
 	}
 


### PR DESCRIPTION
The Openstack router was using the default network "external-network-shared" even if the env var was set differently and that network did not exist.