### PR TITLE
EDGECLOUD-72 infra changes to fix helm charts

### DIFF
--- a/mexos/manifest.go
+++ b/mexos/manifest.go
@@ -352,9 +352,10 @@ func GetKubeManifest(mf *Manifest) (string, error) {
 		base = GetDefaultRegistryBase(mf, base)
 	}
 	mani := mf.Config.ConfigDetail.Manifest
+	deployment := mf.Config.ConfigDetail.Deployment
 	//XXX controlling pass full yaml text in parameter of another yaml
 	log.DebugLog(log.DebugLevelMexos, "getting kubernetes manifest", "base", base, "manifest", mani)
-	if !strings.HasPrefix(mani, "apiVersion: v1") {
+	if deployment != cloudcommon.AppDeploymentTypeHelm && !strings.HasPrefix(mani, "apiVersion: v1") {
 		fn := fmt.Sprintf("%s/%s", base, mani)
 		log.DebugLog(log.DebugLevelMexos, "getting manifest file", "uri", fn)
 		res, err := GetURIFile(mf, fn)


### PR DESCRIPTION
Fixed some helm parts that were not working:
   - purge flag needs to be passed along for tiller to forget about a particular chart
   - init of tiller needs to happen only once
   - tiller needs to have a service account to install charts
   - if deployment type is helm skip the manifest pull