### PR TITLE
helm prometheus on dind

### DIFF
--- a/mexos/dns.go
+++ b/mexos/dns.go
@@ -150,6 +150,13 @@ func KubePatchServiceLocal(servicename string, ipaddr string) error {
 	return nil
 }
 
+// TODO: This function and createAppDNS share a lot of duplicate code,
+// but are subtly different. It'd be good to consolidate and remove
+// duplicate code and highlight what the different use cases are,
+// since it's not clear when to use one or the other.
+// This should be easier to consolidate now that kubeParam can issue
+// commands locally for DIND or other cases.
+// Same for KubeDeleteDNSRecords and deleteAppDNS.
 func KubeAddDNSRecords(rootLB *MEXRootLB, mf *Manifest, kp *kubeParam) error {
 	log.DebugLog(log.DebugLevelMexos, "adding dns records for kubenernets app", "name", mf.Metadata.Name)
 	rootLBIPaddr, err := GetServerIPAddr(mf, mf.Values.Network.External, rootLB.Name)

--- a/mexos/helm.go
+++ b/mexos/helm.go
@@ -2,6 +2,7 @@ package mexos
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -22,14 +23,26 @@ func DeleteHelmAppManifest(mf *Manifest) error {
 	if err != nil {
 		return err
 	}
-	// remove DNS entries
-	if err = KubeDeleteDNSRecords(rootLB, mf, kp); err != nil {
-		log.DebugLog(log.DebugLevelMexos, "warning, cannot delete DNS record", "error", err)
+	if IsLocalDIND(mf) {
+		// remove DNS entries
+		kconf, err := GetKconf(mf, false)
+		if err != nil {
+			return fmt.Errorf("error creating app due to kconf missing, %v, %v", mf, err)
+		}
+		if err = deleteAppDNS(mf, kconf); err != nil {
+			log.DebugLog(log.DebugLevelMexos, "warning, cannot delete DNS record", "error", err)
+		}
+	} else {
+		// remove DNS entries
+		if err = KubeDeleteDNSRecords(rootLB, mf, kp); err != nil {
+			log.DebugLog(log.DebugLevelMexos, "warning, cannot delete DNS record", "error", err)
+		}
+		// remove Security rules
+		if err = DeleteProxySecurityRules(rootLB, mf, kp.ipaddr); err != nil {
+			log.DebugLog(log.DebugLevelMexos, "warning, cannot delete security rules", "error", err)
+		}
 	}
-	// remove Security rules
-	if err = DeleteProxySecurityRules(rootLB, mf, kp.ipaddr); err != nil {
-		log.DebugLog(log.DebugLevelMexos, "warning, cannot delete security rules", "error", err)
-	}
+
 	cmd := fmt.Sprintf("%s helm delete --purge %s", kp.kubeconfig, mf.Metadata.Name)
 	out, err := kp.client.Output(cmd)
 	if err != nil {
@@ -85,22 +98,43 @@ func CreateHelmAppManifest(mf *Manifest) error {
 		log.DebugLog(log.DebugLevelMexos, "helm tiller initialized")
 	}
 
-	cmd = fmt.Sprintf("%s helm install %s --name %s", kp.kubeconfig, mf.Spec.Image, mf.Metadata.Name)
+	helmOpts := ""
+	// XXX This gets helm's prometheus able to query kubelet metrics.
+	// This can be removed once Lev passes in an option in the yaml to
+	// set the helm command line options.
+	prom, err := regexp.MatchString("prometheus", mf.Metadata.Name)
+	if err == nil && prom {
+		log.DebugLog(log.DebugLevelMexos, "setting helm prometheus option")
+		helmOpts = "--set kubelet.serviceMonitor.https=true"
+	}
+	cmd = fmt.Sprintf("%s helm install %s --name %s %s", kp.kubeconfig, mf.Spec.Image, mf.Metadata.Name, helmOpts)
 	out, err = kp.client.Output(cmd)
 	if err != nil {
 		return fmt.Errorf("error deploying helm chart, %s, %s, %v", cmd, out, err)
 	}
 	log.DebugLog(log.DebugLevelMexos, "applied helm chart")
-	// Add security rules
-	if err = AddProxySecurityRules(rootLB, mf, kp.ipaddr); err != nil {
-		log.DebugLog(log.DebugLevelMexos, "cannot create security rules", "error", err)
-		return err
-	}
-	log.DebugLog(log.DebugLevelMexos, "add spec ports", "ports", mf.Spec.Ports)
-	// Add DNS Zone
-	if err = KubeAddDNSRecords(rootLB, mf, kp); err != nil {
-		log.DebugLog(log.DebugLevelMexos, "cannot add DNS entries", "error", err)
-		return err
+	if IsLocalDIND(mf) {
+		kconf, err := GetKconf(mf, false)
+		if err != nil {
+			return fmt.Errorf("error creating app due to kconf missing, %v, %v", mf, err)
+		}
+		// Add DNS Zone
+		if err = createAppDNS(mf, kconf); err != nil {
+			log.DebugLog(log.DebugLevelMexos, "cannot add DNS entries", "error", err)
+			return err
+		}
+	} else {
+		// Add security rules
+		if err = AddProxySecurityRules(rootLB, mf, kp.ipaddr); err != nil {
+			log.DebugLog(log.DebugLevelMexos, "cannot create security rules", "error", err)
+			return err
+		}
+		log.DebugLog(log.DebugLevelMexos, "add spec ports", "ports", mf.Spec.Ports)
+		// Add DNS Zone
+		if err = KubeAddDNSRecords(rootLB, mf, kp); err != nil {
+			log.DebugLog(log.DebugLevelMexos, "cannot add DNS entries", "error", err)
+			return err
+		}
 	}
 	return nil
 }

--- a/mexos/kubernetes.go
+++ b/mexos/kubernetes.go
@@ -81,6 +81,9 @@ func ValidateKubernetesParameters(mf *Manifest, rootLB *MEXRootLB, clustName str
 	if mf.Values.Network.External == "" {
 		return nil, fmt.Errorf("validate kubernetes parameters, missing external network in platform config")
 	}
+	if IsLocalDIND(mf) {
+		return &kubeParam{client: &sshLocal{}}, nil
+	}
 	client, err := GetSSHClient(mf, rootLB.Name, mf.Values.Network.External, sshUser)
 	if err != nil {
 		return nil, err

--- a/mexos/manifest.go
+++ b/mexos/manifest.go
@@ -159,14 +159,23 @@ func MEXAppCreateAppManifest(mf *Manifest) error {
 
 	if IsLocalDIND(mf) {
 		masteraddr := dind.GetMasterAddr()
-		log.DebugLog(log.DebugLevelMexos, "call AddNginxProxy for dind")
 
-		if err = AddNginxProxy(mf, "localhost", mf.Metadata.Name, masteraddr, mf.Spec.Ports, dind.GetDockerNetworkName(mf.Values.Cluster.Name)); err != nil {
-			log.DebugLog(log.DebugLevelMexos, "cannot add nginx proxy", "name", mf.Metadata.Name, "ports", mf.Spec.Ports)
-			return err
+		if len(mf.Spec.Ports) > 0 {
+			log.DebugLog(log.DebugLevelMexos, "call AddNginxProxy for dind", "ports", mf.Spec.Ports)
+			if err = AddNginxProxy(mf, "localhost", mf.Metadata.Name, masteraddr, mf.Spec.Ports, dind.GetDockerNetworkName(mf.Values.Cluster.Name)); err != nil {
+				log.DebugLog(log.DebugLevelMexos, "cannot add nginx proxy", "name", mf.Metadata.Name, "ports", mf.Spec.Ports)
+				return err
+			}
 		}
 		log.DebugLog(log.DebugLevelMexos, "call runKubectlCreateApp for dind")
-		err := runKubectlCreateApp(mf, kubeManifest)
+		var err error
+		if appDeploymentType == cloudcommon.AppDeploymentTypeKubernetes {
+			err = runKubectlCreateApp(mf, kubeManifest)
+		} else if appDeploymentType == cloudcommon.AppDeploymentTypeHelm {
+			err = CreateHelmAppManifest(mf)
+		} else {
+			err = fmt.Errorf("invalid deployment type %s for dind", appDeploymentType)
+		}
 		if err != nil {
 			log.DebugLog(log.DebugLevelMexos, "error creating dind app", "mf", mf)
 			return err
@@ -213,18 +222,25 @@ func MEXAppDeleteAppManifest(mf *Manifest) error {
 	}
 	if IsLocalDIND(mf) {
 		log.DebugLog(log.DebugLevelMexos, "run kubectl delete app for dind")
-		err := runKubectlDeleteApp(mf, kubeManifest)
+		var err error
+		if appDeploymentType == cloudcommon.AppDeploymentTypeKubernetes {
+			err = runKubectlDeleteApp(mf, kubeManifest)
+		} else if appDeploymentType == cloudcommon.AppDeploymentTypeHelm {
+			err = DeleteHelmAppManifest(mf)
+		} else {
+			err = fmt.Errorf("invalid deployment type %s for dind", appDeploymentType)
+		}
 		if err != nil {
 			return err
 		}
 
-		log.DebugLog(log.DebugLevelMexos, "call DeleteNginxProxy for dind")
-
-		if err = DeleteNginxProxy(mf, "localhost", mf.Metadata.Name); err != nil {
-			log.DebugLog(log.DebugLevelMexos, "cannot delete nginx proxy", "name", mf.Metadata.Name)
-			return err
+		if len(mf.Spec.Ports) > 0 {
+			log.DebugLog(log.DebugLevelMexos, "call DeleteNginxProxy for dind")
+			if err = DeleteNginxProxy(mf, "localhost", mf.Metadata.Name); err != nil {
+				log.DebugLog(log.DebugLevelMexos, "cannot delete nginx proxy", "name", mf.Metadata.Name)
+				return err
+			}
 		}
-
 		return nil
 
 	}

--- a/mexos/sshlocal.go
+++ b/mexos/sshlocal.go
@@ -1,0 +1,63 @@
+package mexos
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+// Implements nanobox-io's ssh.Client interface, but runs commands locally.
+// This is used for kubernetes DIND or other local testing.
+type sshLocal struct {
+	cmd *exec.Cmd
+}
+
+// Output returns the output of the command run on the remote host.
+func (s *sshLocal) Output(command string) (string, error) {
+	cmd := exec.Command("sh", "-c", command)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// Shell requests a shell from the remote. If an arg is passed, it tries to
+// exec them on the server.
+func (s *sshLocal) Shell(args ...string) error {
+	cmd := exec.Command("sh", "-c", strings.Join(args, " "))
+	return cmd.Run()
+}
+
+// Start starts the specified command without waiting for it to finish. You
+// have to call the Wait function for that.
+//
+// The first two io.ReadCloser are the standard output and the standard
+// error of the executing command respectively. The returned error follows
+// the same logic as in the exec.Cmd.Start function.
+func (s *sshLocal) Start(command string) (io.ReadCloser, io.ReadCloser, error) {
+	cmd := exec.Command("sh", "-c", command)
+	sout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	errout, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	err = cmd.Start()
+	if err != nil {
+		return nil, nil, err
+	}
+	s.cmd = cmd
+	return sout, errout, nil
+}
+
+// Wait waits for the command started by the Start function to exit. The
+// returned error follows the same logic as in the exec.Cmd.Wait function.
+func (s *sshLocal) Wait() error {
+	if s.cmd == nil {
+		return fmt.Errorf("no command started")
+	}
+	err := s.cmd.Wait()
+	s.cmd = nil
+	return err
+}


### PR DESCRIPTION
Changes to allow helm's prometheus to run on DIND.
- avoid calling security rules for dind manifests
- call the appropriate dns funcs for dind manifests
- call helm funcs for helm deployments for dind
- added sshLocal which implements the ssh.Client interface, but runs commands locally instead. This allows us to use the same code that currently uses kubeParam to run commands over ssh as-is for local/dind cases (so we can reduce code duplication).

There's a few minor changes to edge-cloud as well. With all of this I can run Jim's local dind test and check out Prometheus metrics.