### PR TITLE
Deletion of an appinst with no accessports doesn't delete deployment

### DIFF
--- a/mexos/dns.go
+++ b/mexos/dns.go
@@ -261,13 +261,6 @@ func KubeDeleteDNSRecords(rootLB *MEXRootLB, mf *Manifest, kp *kubeParam) error 
 			}
 		}
 	}
-	cmd = fmt.Sprintf("%s kubectl delete -f %s.yaml", kp.kubeconfig, mf.Metadata.Name)
-	// cmd = fmt.Sprintf("%s kubectl delete deploy %s", kp.kubeconfig, mf.Metadata.Name+"-deployment")
-	out, err = kp.client.Output(cmd)
-	if err != nil {
-		return fmt.Errorf("error deleting kuberknetes app, %s, %s, %s, %v", mf.Metadata.Name, cmd, out, err)
-	}
-
 	return nil
 }
 

--- a/mexos/kubernetes.go
+++ b/mexos/kubernetes.go
@@ -272,6 +272,12 @@ func DeleteKubernetesAppManifest(mf *Manifest, kubeManifest string) error {
 			return err
 		}
 	}
+	cmd := fmt.Sprintf("%s kubectl delete -f %s.yaml", kp.kubeconfig, mf.Metadata.Name)
+	// cmd = fmt.Sprintf("%s kubectl delete deploy %s", kp.kubeconfig, mf.Metadata.Name+"-deployment")
+	out, err := kp.client.Output(cmd)
+	if err != nil {
+		return fmt.Errorf("error deleting kuberknetes app, %s, %s, %s, %v", mf.Metadata.Name, cmd, out, err)
+	}
 	log.DebugLog(log.DebugLevelMexos, "deleted deployment", "name", mf.Metadata.Name)
 	return nil
 }


### PR DESCRIPTION
Moved the code that deletes the deployment out of KubeDeleteDNSRecords 