### PR TITLE
Cert expiry monitor script

### DIFF
--- a/monitoring/certs/cert-expiry.jenkinsfile
+++ b/monitoring/certs/cert-expiry.jenkinsfile
@@ -1,0 +1,40 @@
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+def closeToExpiry = ''
+properties([parameters([
+    string(name: 'HOSTNAMES',
+           defaultValue: 'registry.mobiledgex.net:5000 vault.mobiledgex.net')
+])])
+
+node {
+    stage('Checkout') {
+        git branch: 'master',
+            url: 'git@github.com:mobiledgex/edge-cloud-infra.git'
+    }
+    stage('Check') {
+        closeToExpiry = sh label: 'check expiry',
+                            returnStdout: true,
+                            script: '''#!/bin/bash
+OUT=
+for HOSTNAME in $HOSTNAMES; do
+    EXP=$( monitoring/certs/cert-expiry.sh "$HOSTNAME" )
+    echo "$HOSTNAME: cert expiry: $EXP days" >&2
+    if [[ "$EXP" -lt 28 ]]; then
+        OUT="${OUT}- $HOSTNAME   $EXP days|"
+    fi
+done
+echo $OUT
+                        '''
+        if (closeToExpiry?.trim()) {
+            JSONArray attachments = new JSONArray();
+            JSONObject attachment = new JSONObject();
+
+            attachment.put('title', 'Certs close to expiry')
+            attachment.put('text', closeToExpiry.replace("|", "\n"));
+            attachment.put('color', '#ff0000')
+            attachments.add(attachment)
+            slackSend channel: "#devops", color: 'warning', attachments: attachments.toString()
+        }
+    }
+}

--- a/monitoring/certs/cert-expiry.sh
+++ b/monitoring/certs/cert-expiry.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+PATH='/usr/bin:/bin:/usr/local/bin'; export PATH
+
+HOSTPORT="$1"
+if [[ -z "$HOSTPORT" ]]; then
+	echo "usage: $( basename $0 ) <host>[:<port>]" >&2
+	exit 1
+fi
+
+[[ $( uname ) == "Darwin" ]] && DATE='gdate' || DATE='date'
+$DATE --version 2>&1 | head -n 1 | grep GNU >/dev/null
+if [[ $? -ne 0 ]]; then
+	echo "ERROR: GNU coreutils date command not found" >&2
+	exit 2
+fi
+
+HOST="${HOSTPORT%:*}"
+PORT="${HOSTPORT#*:}"
+[[ "$PORT" == "$HOSTPORT" ]] && PORT=443
+
+EXPIRY=$( openssl s_client -connect "${HOST}:${PORT}" -servername "$HOST" </dev/null 2>/dev/null \
+	| openssl x509 -noout -dates \
+	| grep '^notAfter' \
+	| cut -d= -f2- )
+
+EXPIRY_EPOCH=$( $DATE --date="$EXPIRY" +'%s' )
+NOW=$( $DATE '+%s' )
+
+NDAYS=$(( ( EXPIRY_EPOCH - NOW ) / ( 24 * 60 * 60 ) ))
+echo $NDAYS


### PR DESCRIPTION
Simple script and Jenkins job to monitor certs for impending expiries.
The script alerts on the #devops Slack channel when a cert is less than
four weeks away from its expiry date.  And the Jenkins job for this will
be configured to run once a day.

The Jenkins job is currently configured to monitor registry and vault.

The infra repo seemed like the right place to push this, but if people feel utilities like this belong in a separate repo, that's okay by me too.