### PR TITLE
Fix openstack JSON error in WWT

### DIFF
--- a/mexos/openstack.go
+++ b/mexos/openstack.go
@@ -60,7 +60,7 @@ type OSNetworkDetail struct {
 	ProviderPhysicalNetwork string `json:"provider:physical_network"`
 	IPv6AddressScope        string `json:"ipv6_address_scope"`
 	DNSDomain               string `json:"dns_domain"`
-	IsVLANTransparent       string `json:"is_vlan_transparent"`
+	IsVLANTransparent       bool   `json:"is_vlan_transparent"`
 	ProviderNetworkType     string `json:"provider:network_type"`
 	External                string `json:"router:external"`
 	AvailabilityZoneHints   string `json:"availability_zone_hints"`
@@ -73,7 +73,7 @@ type OSNetworkDetail struct {
 	Description             string `json:"description"`
 	Tags                    string `json:"tags"`
 	UpdatedAt               string `json:"updated_at"`
-	ProviderSegmentationID  string `json:"provider:segmentation_id"`
+	ProviderSegmentationID  int    `json:"provider:segmentation_id"`
 	QOSPolicyID             string `json:"qos_policy_id"`
 	AdminStateUp            string `json:"admin_state_up"`
 	CreatedAt               string `json:"created_at"`


### PR DESCRIPTION
EDGECLOUD-417 
A json marshal error from CRM was seen in WWT's Openstack environment when trying to create a cluster.  The reason is that the type for ProviderSegmentationID (VLAN) was incorrectly defined as a string.  In TDG this value is always null so it does not matter, but in WWT there was an actual VLAN and so it threw an error.

I looked through the rest of the fields in OSNetworkDetail and found also that IsVLANTransparent is wrongly typed.  This has not created a problem yet because it so far has always been null.

There's likely to be more of this in the code we may eventually consider looking to find a ready made golang library for this rather than defining all of this ourselves.