### PR TITLE
remove calls to GetSubnetDetail which get run many times and have no …

### DIFF
--- a/mexos/kvm.go
+++ b/mexos/kvm.go
@@ -382,12 +382,8 @@ func CreateMEXKVM(name, role, netSpec, tags, tenant string, id int, clusterInst 
 				return fmt.Errorf("can't get a list of subnets, %v", err)
 			}
 			for _, sn := range sl {
-				sd, err := GetSubnetDetail(sn.ID)
-				if err != nil {
-					return fmt.Errorf("can't get subnet detail, %s, %v", sn.Name, err)
-				}
-				if sd.CIDR == ni.CIDR {
-					log.DebugLog(log.DebugLevelMexos, "subnet exists with the same CIDR, find another range", "CIDR", sd.CIDR)
+				if sn.Subnet == ni.CIDR {
+					log.DebugLog(log.DebugLevelMexos, "subnet exists with the same CIDR, find another range", "CIDR", ni.CIDR)
 					cidr, err := getNewSubnetRange(id, v4a, sits, sl)
 					if err != nil {
 						return fmt.Errorf("failed to get a new subnet range, %v", err)
@@ -510,11 +506,7 @@ func getNewSubnetRange(id int, v4a []byte, sits []string, sl []OSSubnet) (*strin
 		cidr = fmt.Sprintf("%d.%d.%d.%d/%s", v4a[0], v4a[1], v4a[2], newID, sits[1])
 		found := false
 		for _, snn := range sl {
-			sdd, err := GetSubnetDetail(snn.ID)
-			if err != nil {
-				return nil, fmt.Errorf("cannot get subnet detail %s, %v", snn.Name, err)
-			}
-			if sdd.CIDR == cidr {
+			if snn.Subnet == cidr {
 				found = true
 			}
 		}

--- a/mexos/network.go
+++ b/mexos/network.go
@@ -3,7 +3,6 @@ package mexos
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/mobiledgex/edge-cloud/log"
@@ -41,28 +40,6 @@ func GetExternalGateway(extNetName string) (string, error) {
 	}
 	log.DebugLog(log.DebugLevelMexos, "get external gatewayIP", "gatewayIP", sd.GatewayIP, "subnet detail", sd)
 	return sd.GatewayIP, nil
-}
-
-//GetNextSubnetRange will find the CIDR for the next range of subnet that can be created. For example,
-// if the subnet detail we get has 10.101.101.0/24 then the next one can be 10.101.102.0/24
-func GetNextSubnetRange(subnetName string) (string, error) {
-	sd, err := GetSubnetDetail(subnetName)
-	if err != nil {
-		return "", err
-	}
-	if sd.CIDR == "" {
-		return "", fmt.Errorf("missing CIDR in subnet %s", subnetName)
-	}
-	_, ipv4Net, err := net.ParseCIDR(sd.CIDR)
-	if err != nil {
-		return "", fmt.Errorf("can't parse CIDR %s, %v", sd.CIDR, err)
-	}
-	i := strings.Index(sd.CIDR, "/")
-	suffix := sd.CIDR[i:]
-	v4 := ipv4Net.IP.To4()
-	ipnew := net.IPv4(v4[0], v4[1], v4[2]+1, v4[3])
-	log.DebugLog(log.DebugLevelMexos, "get next subnet range", "new ip range", ipnew, "suffix", suffix)
-	return ipnew.String() + suffix, nil
 }
 
 //GetRouterDetailExternalGateway is different than GetExternalGateway.  This function gets


### PR DESCRIPTION
When CRM is looking for a free subnet for CreateClusterInst, the code does GetSubnetDetail looking for the CIDR for every existing subnet provided by ListSubnets.   This makes an OpenStack "show subnet" call each time.   If we have a lot of subnets this can take a long time.

There is no need for this call since the OSSubnet returned by ListSubnet already has the CIDR.  

Also removing GetNextSubnetRange which is not used anywhere.