### PR TITLE
EDGECLOUD-427 InfluxDB is open to the world - need to at least passwo…

### DIFF
--- a/influxdb/Dockerfile
+++ b/influxdb/Dockerfile
@@ -1,0 +1,2 @@
+FROM k8s.gcr.io/heapster-influxdb-amd64:v1.5.2
+COPY config.toml /etc

--- a/influxdb/config.toml
+++ b/influxdb/config.toml
@@ -1,0 +1,120 @@
+reporting-disabled = true
+bind-address = "localhost:8088"
+
+[meta]
+  dir = "/data/meta"
+  retention-autocreate = true
+  logging-enabled = true
+
+[data]
+  dir = "/data/data"
+  wal-dir = "/data/wal"
+  query-log-enabled = true
+  cache-max-memory-size = 1073741824
+  cache-snapshot-memory-size = 26214400
+  cache-snapshot-write-cold-duration = "10m0s"
+  compact-full-write-cold-duration = "4h0m0s"
+  max-series-per-database = 1000000
+  max-values-per-tag = 100000
+  trace-logging-enabled = false
+
+[coordinator]
+  write-timeout = "10s"
+  max-concurrent-queries = 0
+  query-timeout = "0s"
+  log-queries-after = "0s"
+  max-select-point = 0
+  max-select-series = 0
+  max-select-buckets = 0
+
+[retention]
+  enabled = true
+  check-interval = "30m0s"
+
+[shard-precreation]
+  enabled = true
+  check-interval = "10m0s"
+  advance-period = "30m0s"
+
+[monitor]
+  store-enabled = true
+  store-database = "_internal"
+  store-interval = "10s"
+
+[subscriber]
+  enabled = true
+  http-timeout = "30s"
+  insecure-skip-verify = false
+  ca-certs = ""
+  write-concurrency = 40
+  write-buffer-size = 1000
+
+[http]
+  enabled = true
+  bind-address = ":8086"
+  auth-enabled = true
+  log-enabled = true
+  write-tracing = false
+  pprof-enabled = false
+  https-enabled = false
+  https-certificate = "/etc/ssl/influxdb.pem"
+  https-private-key = ""
+  max-row-limit = 0
+  max-connection-limit = 0
+  shared-secret = ""
+  realm = "InfluxDB"
+  unix-socket-enabled = false
+  bind-socket = "/var/run/influxdb.sock"
+
+[[graphite]]
+  enabled = false
+  bind-address = ":2003"
+  database = "graphite"
+  retention-policy = ""
+  protocol = "tcp"
+  batch-size = 5000
+  batch-pending = 10
+  batch-timeout = "1s"
+  consistency-level = "one"
+  separator = "."
+  udp-read-buffer = 0
+
+[[collectd]]
+  enabled = false
+  bind-address = ":25826"
+  database = "collectd"
+  retention-policy = ""
+  batch-size = 5000
+  batch-pending = 10
+  batch-timeout = "10s"
+  read-buffer = 0
+  typesdb = "/usr/share/collectd/types.db"
+
+[[opentsdb]]
+  enabled = false
+  bind-address = ":4242"
+  database = "opentsdb"
+  retention-policy = ""
+  consistency-level = "one"
+  tls-enabled = false
+  certificate = "/etc/ssl/influxdb.pem"
+  batch-size = 1000
+  batch-pending = 5
+  batch-timeout = "1s"
+  log-point-errors = true
+
+[[udp]]
+  enabled = false
+  bind-address = ":8089"
+  database = "udp"
+  retention-policy = ""
+  batch-size = 5000
+  batch-pending = 10
+  read-buffer = 0
+  batch-timeout = "1s"
+  precision = ""
+
+[continuous_queries]
+  log-enabled = true
+  enabled = true
+  run-interval = "1s"

--- a/influxdb/docker-compose.yml
+++ b/influxdb/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  influxdb:
+    build: .
+    image: "registry.mobiledgex.net:5000/mobiledgex/influxdb:v1.0.0"
+    network_mode: "host"
+    volumes:
+     - influxdb-storage:/data
+    restart: unless-stopped
+
+volumes:
+  influxdb-storage:


### PR DESCRIPTION
The upstream docker image we were using for influxdb does not enable http auth.
Wrapping that image in another which imports a custom config with the
"http/auth-enabled" parameter set to true.

Note that this still needs an admin user to be created in the influxdb instance.
The code looks like it is using "root/root" as the default account, and I have 
created an admin account in the mexdemo.influxdb.mobiledgex.net instance
with those credentials.  Once we replace the influxdb instance running there
with the one from this PR, auth will be enforced.