### PR TITLE
fix appinst create with no ports, add new Bonn settings

### DIFF
--- a/mexos/util.go
+++ b/mexos/util.go
@@ -17,6 +17,10 @@ func AddProxySecurityRulesAndPatchDNS(rootLB *MEXRootLB, kp *kubeParam, kubeName
 	if err != nil {
 		return err
 	}
+	if len(ports) == 0 {
+		log.DebugLog(log.DebugLevelMexos, "no ports for application, no DNS, LB or Security rules needed", "appname", kubeNames.appName)
+		return nil
+	}
 	go func() {
 		err = AddNginxProxy(rootLB.Name, kubeNames.appName, kp.ipaddr, ports, "")
 		if err == nil {

--- a/mgmt/cloudlets/bonn/openrc.json
+++ b/mgmt/cloudlets/bonn/openrc.json
@@ -1,12 +1,17 @@
 {
-    "data": {
-	"env": [
-	    { "name": "OS_CACERT", "value": "$HOME/.mobiledgex/bonnedgecloudtelekomde.crt"},
-	    { "name": "OS_AUTH_URL", "value": "https://bonnedgecloud.telekom.de:5000/v2.0"},
-	    { "name": "OS_USERNAME", "value": "mexadmin"},
-	    { "name": "OS_PASSWORD", "value": "kj&shy2%Jt5F4$Wz"},
-	    { "name": "OS_REGION_NAME", "value": "RegionOne"},
-	    { "name": "OS_TENANT_NAME", "value": "mex"}
-	]
+    "data":{
+        "env":[
+            { "name": "OS_CACERT", "value": "$HOME/.mobiledgex/bonnedgecloudtelekomde.crt"},
+            { "name": "OS_AUTH_URL", "value": "https://bonnedgecloud.telekom.de:5000/v3"},
+            { "name": "OS_PROJECT_ID", "value": "041a0a2f3b5d4d13b35759982ed64fe7"},
+            { "name": "OS_PROJECT_NAME", "value": "mex"},
+            { "name": "OS_USER_DOMAIN_NAME", "value": "Default"},
+            { "name": "OS_PROJECT_DOMAIN_ID", "value": "default"},
+            { "name": "OS_USERNAME", "value": "mexadmin"},
+            { "name": "OS_PASSWORD", "value": "kj&shy2%Jt5F4$Wz"},
+            { "name": "OS_REGION_NAME", "value": "RegionOne"},
+            { "name": "OS_INTERFACE", "value": "public"},
+            { "name": "OS_IDENTITY_API_VERSION", "value": "3"}
+        ]
     }
 }


### PR DESCRIPTION
Andy discovered that metrics exporter (which exposes no ports) was no longer working.  It fails when trying to add nginx and patching the k8s service due to no ports.  

Also add new Bonn provisioning for updated cloudlet.  Bonn is back working again with these settings, which are in the vault now.