### PR TITLE
fix case in which 2 clusters on different cloudlets have the same name

### DIFF
--- a/mexos/cluster.go
+++ b/mexos/cluster.go
@@ -183,7 +183,7 @@ func IsClusterReady(clusterInst *edgeproto.ClusterInst, flavorName, rootLBName s
 
 //FindClusterWithKey finds cluster given a key string
 func FindClusterMaster(key string, srvs []OSServer) (string, error) {
-	//log.DebugLog(log.DebugLevelMexos, "find cluster with key", "key", key)
+	log.DebugLog(log.DebugLevelMexos, "FindClusterMaster", "key", key)
 	if key == "" {
 		return "", fmt.Errorf("empty key")
 	}

--- a/mexos/kubernetes.go
+++ b/mexos/kubernetes.go
@@ -15,13 +15,14 @@ import (
 )
 
 type KubeNames struct {
-	appName      string
-	appURI       string
-	appImage     string
-	clusterName  string
-	operatorName string
-	kconfName    string
-	serviceNames []string
+	appName           string
+	appURI            string
+	appImage          string
+	clusterName       string
+	k8sNodeNameSuffix string
+	operatorName      string
+	kconfName         string
+	serviceNames      []string
 }
 
 func (k *KubeNames) containsService(svc string) bool {
@@ -45,6 +46,7 @@ func GetKubeNames(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appIns
 		return fmt.Errorf("nil app inst")
 	}
 	kubeNames.clusterName = clusterInst.Key.ClusterKey.Name
+	kubeNames.k8sNodeNameSuffix = GetK8sNodeNameSuffix(clusterInst)
 	kubeNames.appName = NormalizeName(app.Key.Name)
 	kubeNames.appURI = appInst.Uri
 	kubeNames.appImage = NormalizeName(app.ImagePath)
@@ -238,9 +240,9 @@ func ValidateKubernetesParameters(rootLB *MEXRootLB, kubeNames *KubeNames, clust
 		return nil, fmt.Errorf("error getting server list: %v", err)
 
 	}
-	master, err := FindClusterMaster(kubeNames.clusterName, srvs)
+	master, err := FindClusterMaster(kubeNames.k8sNodeNameSuffix, srvs)
 	if err != nil {
-		return nil, fmt.Errorf("can't find cluster with key %s, %v", kubeNames.clusterName, err)
+		return nil, fmt.Errorf("can't find cluster with key %s, %v", kubeNames.k8sNodeNameSuffix, err)
 	}
 	ipaddr, err := FindNodeIP(master, srvs)
 	if err != nil {


### PR DESCRIPTION
If 2 clusters have different cloudlet names but the same cluster name, the wrong k8s master IP address may be used.  

The reason is ValidateKubernetesParameters passes only the cluster name into FindClusterMaster to locate the VM.   This is a subnet of the whole name, and so it fill find either master node randomly if there are 2 with the same cluster name.

Fix is to use the entire k8s node suffix, which we will now store in the kubeNames.  This includes both cloudlet and cluster name.