### PR TITLE
remove OpenRcVars from InternVaultEnv

### DIFF
--- a/mexos/vault.go
+++ b/mexos/vault.go
@@ -101,11 +101,6 @@ func InternVaultEnv(openrc string, mexenv string) error {
 		if err != nil {
 			return err
 		}
-		if u == openrc {
-			for _, e := range vr.Data.Detail.Env {
-				OpenstackProps.OpenRcVars[e.Name] = e.Value
-			}
-		}
 		//log.DebugLog(log.DebugLevelMexos, "interning vault data", "data", vr)
 		err = internEnv(vr.Data.Detail.Env)
 		if err != nil {


### PR DESCRIPTION
With some last minute changes from yesterday, the openstack crm platform was segfaulting because OpenRcVars was nil when being assigned from InternVaultEnv. But actually that assignment doesn't make sense, that array is supposed to be used to set env vars, not be set from env vars. OpenRcVars are also not used anywhere, so just removed the offending code.