### PR TITLE
fix rootlb flavor

### DIFF
--- a/crm-platforms/openstack/openstack.go
+++ b/crm-platforms/openstack/openstack.go
@@ -25,6 +25,7 @@ func (s *Platform) Init(key *edgeproto.CloudletKey) error {
 	rootLBName := cloudcommon.GetRootLBFQDN(key)
 	log.DebugLog(log.DebugLevelMexos, "init openstack", "rootLB", rootLBName)
 
+	// OPENRC_URL is required for OpenStack, but optional in InitInfraCommon
 	if os.Getenv("OPENRC_URL") == "" {
 		return fmt.Errorf("Env OPENRC_URL not set")
 	}
@@ -44,7 +45,11 @@ func (s *Platform) Init(key *edgeproto.CloudletKey) error {
 	for _, f := range osflavors {
 		finfo = append(
 			finfo,
-			&edgeproto.FlavorInfo{f.Name, uint64(f.VCPUs), uint64(f.RAM), uint64(f.Disk)},
+			&edgeproto.FlavorInfo{
+				Name:  f.Name,
+				Vcpus: uint64(f.VCPUs),
+				Ram:   uint64(f.RAM),
+				Disk:  uint64(f.Disk)},
 		)
 	}
 

--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -8,7 +8,6 @@ package mexos
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -130,40 +129,6 @@ func GetCleanupOnFailure() bool {
 		return false
 	}
 	return true
-}
-
-// GetCloudletSharedRootLBFlavor gets the flavor from defaults
-// or environment variables
-func GetCloudletSharedRootLBFlavor(flavor *edgeproto.Flavor) error {
-	ram := os.Getenv("MEX_SHARED_ROOTLB_RAM")
-	var err error
-	if ram != "" {
-		flavor.Ram, err = strconv.ParseUint(ram, 10, 64)
-		if err != nil {
-			return err
-		}
-	} else {
-		flavor.Ram = 4096
-	}
-	vcpus := os.Getenv("MEX_SHARED_ROOTLB_VCPUS")
-	if vcpus != "" {
-		flavor.Vcpus, err = strconv.ParseUint(vcpus, 10, 64)
-		if err != nil {
-			return err
-		}
-	} else {
-		flavor.Vcpus = 2
-	}
-	disk := os.Getenv("MEX_SHARED_ROOTLB_DISK")
-	if disk != "" {
-		flavor.Disk, err = strconv.ParseUint(disk, 10, 64)
-		if err != nil {
-			return err
-		}
-	} else {
-		flavor.Disk = 40
-	}
-	return nil
 }
 
 // These not in the proto file yet because they may not change for a while

--- a/mexos/rootlb.go
+++ b/mexos/rootlb.go
@@ -2,6 +2,8 @@ package mexos
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -165,5 +167,39 @@ func WaitForRootLB(rootLB *MEXRootLB) error {
 	}
 	log.DebugLog(log.DebugLevelMexos, "done waiting for rootlb", "name", rootLB.Name)
 
+	return nil
+}
+
+// GetCloudletSharedRootLBFlavor gets the flavor from defaults
+// or environment variables
+func GetCloudletSharedRootLBFlavor(flavor *edgeproto.Flavor) error {
+	ram := os.Getenv("MEX_SHARED_ROOTLB_RAM")
+	var err error
+	if ram != "" {
+		flavor.Ram, err = strconv.ParseUint(ram, 10, 64)
+		if err != nil {
+			return err
+		}
+	} else {
+		flavor.Ram = 4096
+	}
+	vcpus := os.Getenv("MEX_SHARED_ROOTLB_VCPUS")
+	if vcpus != "" {
+		flavor.Vcpus, err = strconv.ParseUint(vcpus, 10, 64)
+		if err != nil {
+			return err
+		}
+	} else {
+		flavor.Vcpus = 2
+	}
+	disk := os.Getenv("MEX_SHARED_ROOTLB_DISK")
+	if disk != "" {
+		flavor.Disk, err = strconv.ParseUint(disk, 10, 64)
+		if err != nil {
+			return err
+		}
+	} else {
+		flavor.Disk = 40
+	}
 	return nil
 }


### PR DESCRIPTION
Fix for EDGECLOUD-537.

Fix RootLB startup failures due to the platform flavor being selected randomly form an unsorted list.  

The platform flavor name was being taken from the first entry in the list of flavors returned from OpenStack.  This is an unsorted list and some of the flavors cannot be used to create Mex VMs.  Also it is problematic to get a randomly sized rootLB even if it does work.

This makes use of the GetClosestFlavor utility to find an available flavor.  The edge-cloud PR of this fix moves that to an exportable package for this purpose.

By default the shared root LB will ask for 4GB RAM, 2VCPU and 40GB disk, this is equivalent to the m4.medium in DT.  Env variables can be used to change these values and get a different flavor; we might later chose to move those fields to the cloudlet info sent by the controller 