### PR TITLE
improve error handling for scp to registry

### DIFF
--- a/mexos/letsencrypt.go
+++ b/mexos/letsencrypt.go
@@ -81,7 +81,7 @@ func AcquireCertificates(fqdn string) error {
 			// perhaps permission problem or other error.  Do not continue as this may be a problem
 			// which will cause us to  exhaust our letsencrypt API limits
 			log.InfoLog("Unexpected error attempting to get cached cert", "registry", GetCloudletRegistryFileServer(), "out", string(out))
-			return fmt.Errorf("Unable to SCP to registry: %s", GetCloudletRegistryFileServer())
+			return fmt.Errorf("Unable to SCP to registry: %s, %v", GetCloudletRegistryFileServer(), err)
 		}
 
 	} else if checkPEMCert(certfile, fqdn) == nil {


### PR DESCRIPTION
Venky just fixed a problem (539) in which the CRM was unable to SSH back to the registry due to the private RSA key having incorrect permissions.  But in the process it uncovered a CRM error as follows:

If the scp the the registry fails, it is treated the same as if the scp was OK but the cert was missing, and so it created a new cert.  But if there is a problem with ssh itself (e.g. key problem or other) the problem is masked until we run out of LetsEncrypt API calls which are throttled at 20 per week.  As a result we have exhausted our LetsEncrypt calls for the week.

Fix is just to check the error from the SCP attempt.  Only if the file was not found should we continue with generating the cert.  Other errors need to be flagged and fail the attempt.