### PR TITLE
Cleanup on failure

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -76,7 +76,6 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	// Clean up DNS entries
 	if err := mexos.DeleteAppDNS(client, names); err != nil {
 		log.DebugLog(log.DebugLevelMexos, "cannot clean up DNS entries", "name", names.AppName, "rootlb", rootLBName, "error", err)
-		return err
 	}
 
 	switch deployment := app.Deployment; deployment {

--- a/mexos/util.go
+++ b/mexos/util.go
@@ -53,14 +53,6 @@ func AddProxySecurityRulesAndPatchDNS(client pc.PlatformClient, kubeNames *k8smg
 	dnserr := <-dnschan
 
 	if proxyerr != "" || secerr != "" || dnserr != "" {
-		if proxyerr == "" {
-			// delete the nginx proxy if it worked but something else failed because it can cause subequent attempts to fail
-			// cleanup of security rules and DNS we should do but not as important
-			err := DeleteNginxProxy(rootLBName, kubeNames.AppName)
-			if err != nil {
-				log.InfoLog("cleanup nginx proxy Failed", "err", err)
-			}
-		}
 		return fmt.Errorf("AddProxySecurityRulesAndPatchDNS error -- proxyerr: %v secerr: %v dnserr: %v", proxyerr, secerr, dnserr)
 	}
 	return nil

--- a/openstack-tenant/agent/server/handlers.go
+++ b/openstack-tenant/agent/server/handlers.go
@@ -663,12 +663,18 @@ func writeFile(confname string, confbytes []byte) error {
 	return nil
 }
 
+// TODO: This function and many others seem unused and redundant nearly identical functions for LB and KCP
 func DeleteNginx(name string) error {
-	log.Debugln("deleting nginx containers", name)
+
+	log.Debugln("deleting nginx LB containers", name)
 	name = name + lbproxySuffix
-	out, err := sh.Command("docker", "kill", name).Output()
+	out, err := sh.Command("docker", "kill", name).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("can't kill nginx container %s, %s, %v", name, out, err)
+		if strings.Contains(string(out), "No such container") {
+			log.Debugln("nginx LB container already gone", name)
+		} else {
+			return fmt.Errorf("can't kill nginx LB container %s, %s, %v", name, out, err)
+		}
 	}
 	log.Debugln("deleted nginx container", name)
 	return nil
@@ -788,8 +794,16 @@ func CreateNginxKCP(name string, port string) error {
 
 func DeleteNginxKCP(name string) error {
 	name = name + kcproxySuffix
-	log.Debugln("deleting nginx kubectl proxy container", name)
-	out, err := sh.Command("docker", "kill", name).Output()
+	log.Debugln("deleting nginx kubectl KCP container", name)
+	out, err := sh.Command("docker", "kill", name).CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "No such container") {
+			log.Debugln("nginx KC container already gone", name)
+		} else {
+			return fmt.Errorf("can't kill nginx KC container %s, %s, %v", name, out, err)
+		}
+	}
+
 	if err != nil {
 		return fmt.Errorf("can't kill nginx kubectl proxy container %s, %s, %v", name, out, err)
 	}


### PR DESCRIPTION
Related to EDGEDCLOUD-208; there is also an edge-cloud portion.

When Creation of AppInst fails it often leaves things hanging around which make it impossible to fix without manual intervention.   Also deletion of appinst fails when part of the appinst is already gone.

Included here:
- In DeleteAppInst, keep going if deletion of DNS entry does not work for whatever reason
- remove code in AddProxySecurityRulesAndPatchDNS that did cleanup of just the nginx proxy because this will be handled more generically in the edge-cloud fix
- in mexosagent, consider it a success to delete the nginx proxy if it is already gone.  This has to be done here because otherwise the service will return a 500 error which cannot be deciphered externally.  Note there is a lot of duplicated code here that needs to be addressed later.