### PR TITLE
use new Image version

### DIFF
--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -16,6 +16,9 @@ import (
 var CloudletInfraCommon edgeproto.CloudletInfraCommon
 var OpenstackProps edgeproto.OpenStackProperties
 
+var MEXInfraVersion = "v2.0.0" //Stratus
+var defaultOSImageName = "mobiledgex-" + MEXInfraVersion
+
 func InitInfraCommon() error {
 	mexEnvURL := os.Getenv("MEXENV_URL")
 	if mexEnvURL == "" {
@@ -54,7 +57,7 @@ func InitOpenstackProps() error {
 
 	OpenstackProps.OSImageName = os.Getenv("MEX_OS_IMAGE")
 	if OpenstackProps.OSImageName == "" {
-		OpenstackProps.OSImageName = "mobiledgex"
+		OpenstackProps.OSImageName = defaultOSImageName
 	}
 
 	// defaulting some value

--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -168,6 +168,12 @@ func getClusterParams(clusterInst *edgeproto.ClusterInst, flavor *edgeproto.Clus
 	cp.MEXNetworkName = GetCloudletMexNetwork()
 	cp.ImageName = GetCloudletOSImage()
 
+	if clusterInst.MasterFlavor == "" {
+		return nil, fmt.Errorf("Master Flavor is not set")
+	}
+	if clusterInst.NodeFlavor == "" {
+		return nil, fmt.Errorf("Node Flavor is not set")
+	}
 	cp.MasterFlavor = clusterInst.MasterFlavor
 	cp.NodeFlavor = clusterInst.NodeFlavor
 	for i := uint32(1); i <= flavor.NumNodes; i++ {

--- a/mexos/rootlb.go
+++ b/mexos/rootlb.go
@@ -151,7 +151,7 @@ func WaitForRootLB(rootLB *MEXRootLB) error {
 	running := false
 	for i := 0; i < 10; i++ {
 		log.DebugLog(log.DebugLevelMexos, "waiting for rootlb...")
-		_, err := client.Output("sudo grep 'all done' /var/log/mobiledgex.log") //XXX beware of use of word done
+		_, err := client.Output("sudo grep 'Finished mobiledgex init' /var/log/mobiledgex.log")
 		if err == nil {
 			log.DebugLog(log.DebugLevelMexos, "rootlb is running", "name", rootLB.Name)
 			running = true


### PR DESCRIPTION
Venky has pushed a new mobiledgex image to all the Germany servers, called mobiledgex-v2.0.0. 

Since we're going to start using version names, the default OS image of 'mobiledgex' is no longer valid.  While it is still possible to override this with MEX_OS_IMAGE, we want to use the right default.

The new image has a different string it outputs in the logfile when it finishes, the code is tweaked to check for that.

We also are versioning the mexosagent binary as part of this.  

This will enable Andy to test Venky's fix for EDGECLOUD-385 (long cluster inst names)

