### PR TITLE
Full edge-cloud-infra build takes longer than 15 minutes

### DIFF
--- a/jenkins/nightly.Jenkinsfile
+++ b/jenkins/nightly.Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     options {
-        timeout(time: 15, unit: 'MINUTES')
+        timeout(time: 30, unit: 'MINUTES')
     }
     agent any
     stages {


### PR DESCRIPTION
Sorry, turns out the edge-cloud-infra build can sometimes take longer than 15 minutes now.