### PR TITLE
Jenkins builds needs to clean up stale files

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -35,6 +35,12 @@ make clean
                     '''
                 }
                 dir(path: 'go/src/github.com/mobiledgex/edge-cloud') {
+                    sh label: 'git clean edge-cloud', script: 'git clean -f -d'
+                }
+                dir(path: 'go/src/github.com/mobiledgex/edge-cloud-infra') {
+                    sh label: 'git clean edge-cloud-infra', script: 'git clean -f -d'
+                }
+                dir(path: 'go/src/github.com/mobiledgex/edge-cloud') {
                     sh label: 'go mod download', script: '''#!/bin/bash
 export PATH=$PATH:$HOME/go/bin:$WORKSPACE/go/bin
 export GOPATH=$WORKSPACE/go

--- a/jenkins/nightly.Jenkinsfile
+++ b/jenkins/nightly.Jenkinsfile
@@ -35,6 +35,16 @@ make edge-cloud-version-set
                 }
             }
         }
+        stage('Force Clean') {
+            steps {
+                dir(path: 'go/src/github.com/mobiledgex/edge-cloud') {
+                    sh label: 'git clean edge-cloud', script: 'git clean -f -d'
+                }
+                dir(path: 'go/src/github.com/mobiledgex/edge-cloud-infra') {
+                    sh label: 'git clean edge-cloud-infra', script: 'git clean -f -d'
+                }
+            }
+        }
         stage('Docker Image') {
             steps {
                 dir(path: 'go/src/github.com/mobiledgex/edge-cloud') {


### PR DESCRIPTION
Files removed using git stick around in a workspace.  These untracked
files can still affect builds.