### PR TITLE
add clusterinst to platform-client

### DIFF
--- a/crm-platforms/azure/azure-appinst.go
+++ b/crm-platforms/azure/azure-appinst.go
@@ -17,7 +17,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	if err = s.SetupKconf(clusterInst); err != nil {
 		return fmt.Errorf("can't set up kconf, %s", err.Error())
 	}
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	if err = s.SetupKconf(clusterInst); err != nil {
 		return fmt.Errorf("can't set up kconf, %s", err.Error())
 	}
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (s *Platform) GetAppInstRuntime(clusterInst *edgeproto.ClusterInst, app *ed
 	if err := s.SetupKconf(clusterInst); err != nil {
 		return nil, fmt.Errorf("can't set up kconf, %s", err.Error())
 	}
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return nil, err
 	}

--- a/crm-platforms/azure/azure-cluster.go
+++ b/crm-platforms/azure/azure-cluster.go
@@ -45,7 +45,7 @@ func (s *Platform) CreateCluster(clusterInst *edgeproto.ClusterInst, flavor *edg
 	}
 	//race condition exists where the config file is not ready until just after the cluster create is done
 	time.Sleep(3 * time.Second)
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/azure/azure.go
+++ b/crm-platforms/azure/azure.go
@@ -134,6 +134,6 @@ func (s *Platform) GatherCloudletInfo(info *edgeproto.CloudletInfo) error {
 	return nil
 }
 
-func (s *Platform) GetPlatformClient() (pc.PlatformClient, error) {
+func (s *Platform) GetPlatformClient(clusterInst *edgeproto.ClusterInst) (pc.PlatformClient, error) {
 	return &pc.LocalClient{}, nil
 }

--- a/crm-platforms/gcp/gcp-appinst.go
+++ b/crm-platforms/gcp/gcp-appinst.go
@@ -17,7 +17,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	if err = SetupKconf(clusterInst); err != nil {
 		return fmt.Errorf("can't set up kconf, %s", err.Error())
 	}
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	if err = SetupKconf(clusterInst); err != nil {
 		return fmt.Errorf("can't set up kconf, %s", err.Error())
 	}
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func (s *Platform) GetAppInstRuntime(clusterInst *edgeproto.ClusterInst, app *ed
 	if err := SetupKconf(clusterInst); err != nil {
 		return nil, fmt.Errorf("can't set up kconf, %s", err.Error())
 	}
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return nil, err
 	}

--- a/crm-platforms/gcp/gcp-cluster.go
+++ b/crm-platforms/gcp/gcp-cluster.go
@@ -27,7 +27,7 @@ func (s *Platform) CreateCluster(clusterInst *edgeproto.ClusterInst, flavor *edg
 	}
 	//race condition exists where the config file is not ready until just after the cluster create is done
 	time.Sleep(3 * time.Second)
-	client, err := s.GetPlatformClient()
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/gcp/gcp.go
+++ b/crm-platforms/gcp/gcp.go
@@ -122,6 +122,6 @@ func (s *Platform) GatherCloudletInfo(info *edgeproto.CloudletInfo) error {
 	return nil
 }
 
-func (s *Platform) GetPlatformClient() (pc.PlatformClient, error) {
+func (s *Platform) GetPlatformClient(clusterInst *edgeproto.ClusterInst) (pc.PlatformClient, error) {
 	return &pc.LocalClient{}, nil
 }

--- a/crm-platforms/mexdind/mexdind-appinst.go
+++ b/crm-platforms/mexdind/mexdind-appinst.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, flavor *edgeproto.Flavor) error {
-	client, err := s.generic.GetPlatformClient()
+	client, err := s.generic.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 
 func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) error {
 	var err error
-	client, err := s.generic.GetPlatformClient()
+	client, err := s.generic.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/mexdind/mexdind-cluster.go
+++ b/crm-platforms/mexdind/mexdind-cluster.go
@@ -12,7 +12,7 @@ func (s *Platform) CreateCluster(clusterInst *edgeproto.ClusterInst, flavor *edg
 	if err != nil {
 		return err
 	}
-	client, err := s.generic.GetPlatformClient()
+	client, err := s.generic.GetPlatformClient(clusterInst)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/mexdind/mexdind.go
+++ b/crm-platforms/mexdind/mexdind.go
@@ -67,6 +67,6 @@ func (s *Platform) GatherCloudletInfo(info *edgeproto.CloudletInfo) error {
 	return s.generic.GatherCloudletInfo(info)
 }
 
-func (s *Platform) GetPlatformClient() (pc.PlatformClient, error) {
-	return s.generic.GetPlatformClient()
+func (s *Platform) GetPlatformClient(clusterInst *edgeproto.ClusterInst) (pc.PlatformClient, error) {
+	return s.generic.GetPlatformClient(clusterInst)
 }

--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -26,7 +26,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 			rootLBName = cloudcommon.GetDedicatedLBFQDN(s.cloudletKey, &clusterInst.Key.ClusterKey)
 			log.DebugLog(log.DebugLevelMexos, "using dedicated RootLB to create app", "rootLBName", rootLBName)
 		}
-		client, err := s.GetPlatformClientRootLB(rootLBName)
+		client, err := s.GetPlatformClient(clusterInst)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 			rootLBName = cloudcommon.GetDedicatedLBFQDN(s.cloudletKey, &clusterInst.Key.ClusterKey)
 			log.DebugLog(log.DebugLevelMexos, "using dedicated RootLB to create app", "rootLBName", rootLBName)
 		}
-		client, err := s.GetPlatformClientRootLB(rootLBName)
+		client, err := s.GetPlatformClient(clusterInst)
 		if err != nil {
 			return err
 		}
@@ -175,7 +175,7 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 			rootLBName = cloudcommon.GetDedicatedLBFQDN(s.cloudletKey, &clusterInst.Key.ClusterKey)
 			log.DebugLog(log.DebugLevelMexos, "using dedicated RootLB to delete app", "rootLBName", rootLBName)
 		}
-		client, err := s.GetPlatformClientRootLB(rootLBName)
+		client, err := s.GetPlatformClient(clusterInst)
 		if err != nil {
 			return err
 		}
@@ -208,12 +208,7 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 		}
 		return nil
 	case cloudcommon.AppDeploymentTypeDocker:
-		rootLBName := s.rootLBName
-		if clusterInst.IpAccess == edgeproto.IpAccess_IpAccessDedicated {
-			rootLBName = cloudcommon.GetDedicatedLBFQDN(s.cloudletKey, &clusterInst.Key.ClusterKey)
-			log.DebugLog(log.DebugLevelMexos, "using dedicated RootLB to delete docker app", "rootLBName", rootLBName)
-		}
-		client, err := s.GetPlatformClientRootLB(rootLBName)
+		client, err := s.GetPlatformClient(clusterInst)
 		if err != nil {
 			return err
 		}
@@ -224,13 +219,8 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 }
 
 func (s *Platform) GetAppInstRuntime(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) (*edgeproto.AppInstRuntime, error) {
-	// TODO: rootLB may be specific to clusterInst for dedicated IP configs
-	rootLBName := s.rootLBName
-	if clusterInst.IpAccess == edgeproto.IpAccess_IpAccessDedicated {
-		rootLBName = cloudcommon.GetDedicatedLBFQDN(s.cloudletKey, &clusterInst.Key.ClusterKey)
-		log.DebugLog(log.DebugLevelMexos, "using dedicated RootLB to get runtime", "rootLBName", rootLBName)
-	}
-	client, err := s.GetPlatformClientRootLB(rootLBName)
+
+	client, err := s.GetPlatformClient(clusterInst)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- add cluster instance to GetPlatformClient.  This is part of a 2 part change including edge-cloud.  This is to allow dedicated clusters to do shell access.  Also avoids bugs in dedicated lb cases because the logic to deal with the dedicated root lb is inside GetPlatformClient now rather than outside.  
- update GetK8sNodeNameSuffix to avoid adding a blank dash if there is no developer name, otherwise existing clusterinst deployments cannot be deleted