### PR TITLE
Userdata updates

### DIFF
--- a/docker/edge-cloud-base-image.root/_mobiledgex/userdata.txt
+++ b/docker/edge-cloud-base-image.root/_mobiledgex/userdata.txt
@@ -9,7 +9,7 @@ ssh_authorized_keys:
  - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCrHlOJOJUqvd4nEOXQbdL8ODKzWaUxKVY94pF7J3diTxgZ1NTvS6omqOjRS3loiU7TOlQQU4cKnRRnmJW8QQQZSOMIGNrMMInGaEYsdm6+tr1k4DDfoOrkGMj3X/I2zXZ3U+pDPearVFbczCByPU0dqs16TWikxDoCCxJRGeeUl7duzD9a65bI8Jl+zpfQV+I7OPa81P5/fw15lTzT4+F9MhhOUVJ4PFfD+d6/BLnlUfZ94nZlvSYnT+GoZ8xTAstM7+6pvvvHtaHoV4YqRf5CelbWAQ162XNa9/pW5v/RKDrt203/JEk3e70tzx9KAfSw2vuO1QepkCZAdM9rQoCd ubuntu@registry
 chpasswd: { expire: False }
 ssh_pwauth: False
-timezone: US/Pacific
+timezone: UTC
 runcmd:
  - [ echo, MOBILEDGEX, doing, ifconfig ]
  - [ ifconfig, -a ]


### PR DESCRIPTION
Cluster creation is sometimes slow; when logging into newly create VMs they are often sluggish.  The culprit seems to be unattended updates that start automatically after boot.

We don't want to do auto upgrades anyway as we need to manage this separately in a controlled fashion.  This update changes the user data to remove this stuff at boot up.   Also remove personalized name from the rsa key and set the timezone to UTC.