### PR TITLE
EDGECLOUD-372 updated azure plugin to account for cluster period removal in appinsts

### DIFF
--- a/crm-platforms/azure/azure-appinst.go
+++ b/crm-platforms/azure/azure-appinst.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/mobiledgex/edge-cloud-infra/mexos"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt"
@@ -98,7 +97,7 @@ func (s *Platform) SetupKconf(clusterInst *edgeproto.ClusterInst) error {
 	if err := s.AzureLogin(); err != nil {
 		return err
 	}
-	clusterName := strings.NewReplacer(".", "").Replace(clusterInst.Key.ClusterKey.Name)
+	clusterName := AzureSanitize(clusterInst.Key.ClusterKey.Name)
 	rg := GetResourceGroupForCluster(clusterInst)
 	if err := GetAKSCredentials(rg, clusterName); err != nil {
 		return fmt.Errorf("unable to get AKS credentials %v", err)

--- a/crm-platforms/azure/azure-cluster.go
+++ b/crm-platforms/azure/azure-cluster.go
@@ -31,7 +31,7 @@ func (s *Platform) CreateCluster(clusterInst *edgeproto.ClusterInst, flavor *edg
 	var err error
 
 	resourceGroup := GetResourceGroupForCluster(clusterInst)
-	clusterName := strings.NewReplacer(".", "").Replace(clusterInst.Key.ClusterKey.Name)
+	clusterName := AzureSanitize(clusterInst.Key.ClusterKey.Name)
 	location := s.props.Location
 
 	if err = s.AzureLogin(); err != nil {
@@ -73,4 +73,8 @@ func (s *Platform) DeleteCluster(clusterInst *edgeproto.ClusterInst) error {
 	}
 	return DeleteAKSCluster(resourceGroup)
 
+}
+
+func AzureSanitize(clusterName string) string {
+	return strings.NewReplacer(".", "").Replace(clusterName)
 }


### PR DESCRIPTION
Silently removing periods in clusters for azure broke the appinst api, updated it so that it accounts for removed periods