### PR TITLE
mc stream results from controller reform

### DIFF
--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -1,9 +1,11 @@
 package orm
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormclient"
@@ -274,6 +276,56 @@ func TestController(t *testing.T) {
 	require.Nil(t, err, "show controllers")
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, 0, len(ctrls))
+
+	// Test Streaming APIs
+	dc2 := grpc.NewServer()
+	ctrlAddr2 := "127.0.0.1:9997"
+	lis2, err := net.Listen("tcp", ctrlAddr2)
+	require.Nil(t, err)
+	sds := StreamDummyServer{}
+	sds.next = make(chan int, 1)
+	edgeproto.RegisterClusterInstApiServer(dc2, &sds)
+	go func() {
+		dc2.Serve(lis2)
+	}()
+	defer dc2.Stop()
+
+	ctrl = ormapi.Controller{
+		Region:  "Stream",
+		Address: ctrlAddr2,
+	}
+	// create controller
+	status, err = mcClient.CreateController(uri, token, &ctrl)
+	require.Nil(t, err, "create controller")
+	require.Equal(t, http.StatusOK, status)
+	dat := RegionClusterInst{
+		Region: ctrl.Region,
+	}
+	out := edgeproto.Result{}
+	count = 0
+	// check that we get intermediate results.
+	// the callback func is only called when data is read back.
+	status, err = mcClient.PostJsonStreamOut(uri+"/auth/ctrl/CreateClusterInst",
+		token, &dat, &out, func() {
+			// got a result, trigger next result
+			count++
+			require.Equal(t, count, int(out.Code))
+			sds.next <- 1
+		})
+	require.Nil(t, err, "stream test create cluster inst")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, 3, count)
+	// check that we hit timeout if we don't trigger the next one.
+	count = 0
+	sds.next = make(chan int, 1)
+	status, err = mcClient.PostJsonStreamOut(uri+"/auth/ctrl/CreateClusterInst",
+		token, &dat, &out, func() {
+			count++
+		})
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "timedout")
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, 1, count)
 }
 
 func testCreateUser(t *testing.T, mcClient *ormclient.Client, uri, name string) (*ormapi.User, string) {
@@ -365,4 +417,37 @@ func addDummyObjs(d *testutil.DummyServer, org string, num int) {
 		cloudlet.Key.OperatorKey.Name = org
 		d.Cloudlets = append(d.Cloudlets, cloudlet)
 	}
+}
+
+type StreamDummyServer struct {
+	next chan int
+	fail bool
+}
+
+func (s *StreamDummyServer) CreateClusterInst(in *edgeproto.ClusterInst, server edgeproto.ClusterInstApi_CreateClusterInstServer) error {
+	server.Send(&edgeproto.Result{Code: 1})
+	for ii := 2; ii < 4; ii++ {
+		select {
+		case <-s.next:
+		case <-time.After(1 * time.Second):
+			return fmt.Errorf("timedout")
+		}
+		server.Send(&edgeproto.Result{Code: int32(ii)})
+	}
+	if s.fail {
+		return fmt.Errorf("fail")
+	}
+	return nil
+}
+
+func (s *StreamDummyServer) DeleteClusterInst(in *edgeproto.ClusterInst, server edgeproto.ClusterInstApi_DeleteClusterInstServer) error {
+	return nil
+}
+
+func (s *StreamDummyServer) UpdateClusterInst(in *edgeproto.ClusterInst, server edgeproto.ClusterInstApi_UpdateClusterInstServer) error {
+	return nil
+}
+
+func (s *StreamDummyServer) ShowClusterInst(in *edgeproto.ClusterInst, server edgeproto.ClusterInstApi_ShowClusterInstServer) error {
+	return nil
 }

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -25,7 +25,7 @@ func CreateOrg(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, Msg("Invalid POST data"))
 	}
 	err = CreateOrgObj(claims, &org)
-	return setReply(c, err, MsgName("Organization created", org.Name))
+	return setReply(c, err, Msg("Organization created"))
 }
 
 func CreateOrgObj(claims *UserClaims, org *ormapi.Organization) error {

--- a/mc/orm/reply.go
+++ b/mc/orm/reply.go
@@ -19,20 +19,6 @@ func MsgErr(err error) *ormapi.Result {
 	return &ormapi.Result{Message: err.Error()}
 }
 
-func MsgID(msg string, id int64) *ormapi.ResultID {
-	return &ormapi.ResultID{
-		Message: msg,
-		ID:      id,
-	}
-}
-
-func MsgName(msg, name string) *ormapi.ResultName {
-	return &ormapi.ResultName{
-		Message: msg,
-		Name:    name,
-	}
-}
-
 func ctrlErr(c echo.Context, err error) error {
 	msg := "controller connect error, " + err.Error()
 	return c.JSON(http.StatusBadRequest, Msg(msg))

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -66,17 +66,18 @@ type NewPassword struct {
 // Structs used in replies
 
 type Result struct {
-	Message string `json:"message"`
+	Message string `json:"message,omitempty"`
+	Code    int    `json:"code,omitempty"`
 }
 
-type ResultID struct {
-	Message string `json:"message"`
-	ID      int64  `json:"id"`
-}
+// Data struct sent back for streaming (chunked) commands.
+// Contains a data payload for incremental data, and a result
+// payload for an error result. Only one of the two will be used
+// in each chunk.
 
-type ResultName struct {
-	Message string `json:"message"`
-	Name    string `json:"name"`
+type StreamPayload struct {
+	Data   interface{} `json:"data,omitempty"`
+	Result *Result     `json:"result,omitempty"`
 }
 
 // all data is for full create/delete


### PR DESCRIPTION
This fixes the way MC streams back data from Controller to make it easier for the UI team.
In particular, previously an error after streaming back data was not easily identifiable. This is because the way HTTP works, the header must be sent first (which contains the http status code). Once that's sent, then there's no way to send back an error code outside of the body.

To fix, rather than sending the controller api-specific object in each chunked message, we send back a StreamPayload, which contains either the api-specific object (typically edgeproto.Result, but could be something like AppInst for show commands), or ormapi.Result. We use ormapi.Result with an error code inside of it to indicate there was an error after starting the stream. This happens for commands like CreateClusterInst which stream back status like "creating", but then hit an error later.