### PR TITLE
EDGECLOUD-582 allow admin roles to be removed

### DIFF
--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -303,9 +303,6 @@ func RemoveUserRoleObj(claims *UserClaims, role *ormapi.Role) error {
 	if role.Username == "" {
 		return fmt.Errorf("Username not specified")
 	}
-	if role.Org == "" {
-		return fmt.Errorf("Organization not specified")
-	}
 	if role.Role == "" {
 		return fmt.Errorf("Role not specified")
 	}


### PR DESCRIPTION
This allows Admin roles to be removed. They were not allowed before because the code was requiring the Org to non-empty, but all Admin roles are tied to the empty Org.