### PR TITLE
EDGECLOUD-572 allow all users to see controllers

### DIFF
--- a/mc/orm/ctrl.go
+++ b/mc/orm/ctrl.go
@@ -105,9 +105,6 @@ func ShowController(c echo.Context) error {
 
 func ShowControllerObj(claims *UserClaims) ([]ormapi.Controller, error) {
 	ctrls := []ormapi.Controller{}
-	if !enforcer.Enforce(claims.Username, "", ResourceControllers, ActionView) {
-		return nil, echo.ErrForbidden
-	}
 	err := db.Find(&ctrls).Error
 	if err != nil {
 		return nil, dbErr(err)

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -143,7 +143,9 @@ func TestController(t *testing.T) {
 	testAddUserRole(t, mcClient, uri, tokenOper3, org3, "OperatorViewer", user5.Name, Fail)
 	testAddUserRole(t, mcClient, uri, tokenOper4, org3, "OperatorViewer", user5.Name, Fail)
 
-	// make sure developer and operator cannot see or modify controllers
+	// make sure developer and operator cannot modify controllers
+	// all users can see controllers (required for UI to be able to
+	// fork requests to each controller as the user).
 	ctrlNew := ormapi.Controller{
 		Region:  "Bad",
 		Address: "bad.mobiledgex.net",
@@ -153,11 +155,11 @@ func TestController(t *testing.T) {
 	status, err = mcClient.CreateController(uri, tokenOper, &ctrlNew)
 	require.Equal(t, http.StatusForbidden, status)
 	ctrls, status, err = mcClient.ShowController(uri, tokenDev)
-	require.Equal(t, http.StatusForbidden, status)
-	require.Equal(t, 0, len(ctrls))
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, 1, len(ctrls))
 	ctrls, status, err = mcClient.ShowController(uri, tokenOper)
-	require.Equal(t, http.StatusForbidden, status)
-	require.Equal(t, 0, len(ctrls))
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, 1, len(ctrls))
 
 	// admin can do everything
 	goodPermTestFlavor(t, mcClient, uri, tokenAd, ctrl.Region, "", icnt)


### PR DESCRIPTION
This allows all users to see all controller regions (and addresses). This is needed for the UI to distribute controller apis initiated by the user to all regions.