### PR TITLE
EDGECLOUD-573 locked users to await approval

### DIFF
--- a/mc/orm/auditlog.go
+++ b/mc/orm/auditlog.go
@@ -82,6 +82,10 @@ func logger(next echo.HandlerFunc) echo.HandlerFunc {
 		if nexterr != nil {
 			kvs = append(kvs, "err")
 			kvs = append(kvs, nexterr)
+			he, ok := nexterr.(*echo.HTTPError)
+			if ok && he.Internal != nil {
+				kvs = append(kvs, "ierr", he.Internal)
+			}
 		}
 		if len(reqBody) > 0 {
 			kvs = append(kvs, "req")

--- a/mc/orm/config.go
+++ b/mc/orm/config.go
@@ -1,0 +1,73 @@
+package orm
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo"
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud/log"
+)
+
+const configID = 1
+
+func InitConfig() error {
+	log.DebugLog(log.DebugLevelApi, "init config")
+
+	// create config if it doesn't exist
+	config := ormapi.Config{}
+	config.ID = configID
+	config.NotifyEmailAddress = "support@mobiledgex.com"
+	err := db.FirstOrCreate(&config, &config).Error
+	if err != nil {
+		return err
+	}
+	log.DebugLog(log.DebugLevelApi, "using config", "config", config)
+	return nil
+}
+
+func UpdateConfig(c echo.Context) error {
+	claims, err := getClaims(c)
+	if err != nil {
+		return err
+	}
+	if !enforcer.Enforce(claims.Username, "", ResourceConfig, ActionManage) {
+		return echo.ErrForbidden
+	}
+	config, err := getConfig()
+	if err != nil {
+		return err
+	}
+	// calling bind after doing lookup will overwrite only the
+	// fields specified in the request body, keeping existing fields intact.
+	if err := c.Bind(&config); err != nil {
+		return bindErr(c, err)
+	}
+	err = db.Save(&config).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ShowConfig(c echo.Context) error {
+	claims, err := getClaims(c)
+	if err != nil {
+		return err
+	}
+	if !enforcer.Enforce(claims.Username, "", ResourceConfig, ActionManage) {
+		return echo.ErrForbidden
+	}
+	config, err := getConfig()
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, config)
+}
+
+func getConfig() (*ormapi.Config, error) {
+	config := ormapi.Config{}
+	config.ID = configID
+	err := db.First(&config).Error
+	// note: should always exist
+	return &config, err
+}

--- a/mc/orm/postgres.go
+++ b/mc/orm/postgres.go
@@ -62,7 +62,7 @@ func InitData(superuser, superpass string, pingInterval time.Duration, stop *boo
 
 		// create or update tables
 		err := db.AutoMigrate(&ormapi.User{}, &ormapi.Organization{},
-			&ormapi.Controller{}).Error
+			&ormapi.Controller{}, &ormapi.Config{}).Error
 		if err != nil {
 			log.DebugLog(log.DebugLevelApi, "automigrate", "err", err)
 			continue
@@ -76,6 +76,11 @@ func InitData(superuser, superpass string, pingInterval time.Duration, stop *boo
 		err = InitAdmin(superuser, superpass)
 		if err != nil {
 			log.DebugLog(log.DebugLevelApi, "init admin", "err", err)
+			continue
+		}
+		err = InitConfig()
+		if err != nil {
+			log.DebugLog(log.DebugLevelApi, "init config", "err", err)
 			continue
 		}
 		log.DebugLog(log.DebugLevelApi, "init data done")

--- a/mc/orm/reply.go
+++ b/mc/orm/reply.go
@@ -28,6 +28,11 @@ func dbErr(err error) error {
 	return fmt.Errorf("database error, %s", err.Error())
 }
 
+func bindErr(c echo.Context, err error) error {
+	msg := "Invalid POST data, " + err.Error()
+	return c.JSON(http.StatusBadRequest, Msg(msg))
+}
+
 func setReply(c echo.Context, err error, successReply interface{}) error {
 	if err == echo.ErrForbidden {
 		return err

--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -25,6 +25,7 @@ const ResourceCloudlets = "cloudlets"
 const ResourceCloudletAnalytics = "cloudletanalytics"
 const ResourceClusterFlavors = "clusterflavors"
 const ResourceFlavors = "flavors"
+const ResourceConfig = "config"
 
 var DeveloperResources = []string{
 	ResourceApps,
@@ -60,6 +61,8 @@ func InitRolePerms() error {
 	enforcer.AddPolicy(RoleAdminManager, ResourceClusterFlavors, ActionView)
 	enforcer.AddPolicy(RoleAdminManager, ResourceFlavors, ActionManage)
 	enforcer.AddPolicy(RoleAdminManager, ResourceFlavors, ActionView)
+	enforcer.AddPolicy(RoleAdminManager, ResourceConfig, ActionManage)
+	enforcer.AddPolicy(RoleAdminManager, ResourceConfig, ActionView)
 
 	enforcer.AddPolicy(RoleDeveloperManager, ResourceUsers, ActionManage)
 	enforcer.AddPolicy(RoleDeveloperManager, ResourceUsers, ActionView)

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -201,6 +201,9 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	auth.POST("/data/delete", DeleteData)
 	auth.POST("/data/show", ShowData)
 	auth.POST("/gitlab/resync", GitlabResync)
+	auth.POST("/config/update", UpdateConfig)
+	auth.POST("/config/show", ShowConfig)
+	auth.POST("/restricted/user/update", RestrictedUserUpdate)
 	addControllerApis(auth)
 	go func() {
 		var err error

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -21,6 +21,7 @@ type User struct {
 	Nickname      string
 	CreatedAt     time.Time `json:",omitempty"`
 	UpdatedAt     time.Time `json:",omitempty"`
+	Locked        bool
 }
 
 type Organization struct {
@@ -38,6 +39,12 @@ type Controller struct {
 	Address   string    `gorm:"unique;not null"`
 	CreatedAt time.Time `json:",omitempty"`
 	UpdatedAt time.Time `json:",omitempty"`
+}
+
+type Config struct {
+	ID                 int `gorm:"primary_key;auto_increment:false"`
+	LockNewAccounts    bool
+	NotifyEmailAddress string
 }
 
 // Structs used for API calls

--- a/mc/ormclient/rest_client.go
+++ b/mc/ormclient/rest_client.go
@@ -119,6 +119,20 @@ func (s *Client) ShowData(uri, token string) (*ormapi.AllData, int, error) {
 	return &data, status, err
 }
 
+func (s *Client) UpdateConfig(uri, token string, config map[string]interface{}) (int, error) {
+	return s.PostJson(uri+"/auth/config/update", token, config, nil)
+}
+
+func (s *Client) ShowConfig(uri, token string) (*ormapi.Config, int, error) {
+	config := ormapi.Config{}
+	status, err := s.PostJson(uri+"/auth/config/show", token, nil, &config)
+	return &config, status, err
+}
+
+func (s *Client) RestrictedUserUpdate(uri, token string, user map[string]interface{}) (int, error) {
+	return s.PostJson(uri+"/auth/restricted/user/update", token, user, nil)
+}
+
 func (s *Client) PostJsonSend(uri, token string, reqData interface{}) (*http.Response, error) {
 	var body io.Reader
 	if reqData != nil {


### PR DESCRIPTION
To implement restricting new user accounts, the MC can be configured to lock all new accounts. New accounts that are created locked will trigger an email to support@mobiledgex.com notifying support that a new locked account needs attention. The mobiledgex admin can then modify the user account to unlock it.
- new config entry in sql database to store various config
- new apis to manage config (admin only)
- new restricted user update api (admin only) to unlock user (can also lock user, change any user fields, etc)