### PR TITLE
Master only k8s

### DIFF
--- a/mexos/cluster.go
+++ b/mexos/cluster.go
@@ -159,7 +159,6 @@ func CreateCluster(rootLBName string, clusterInst *edgeproto.ClusterInst) (reter
 		if err != nil {
 			return err
 		}
-
 	}
 	if err := SeedDockerSecret(client, clusterInst, singleNodeCluster); err != nil {
 		return err


### PR DESCRIPTION
If a cluster is created with --numnodes 0, we need to run the pods on the master.  To prevent this by default, k8s applies a "NoSchedule taint" to the master node.  

The rationale for this is that the master needs to run unimpeded by worker jobs or it can destabilize the cluster.     But for a single-node cluster, there's no other choice.   Whether we choose to deploy clusters like this in a live environment in the future is TBD, but for now it is useful to be able to make the clusters run on a single master node.  

When the cluster first reaches Ready state, remove the taint from the master is numnodes =0