### PR TITLE
Include heat error reason for failure cases

### DIFF
--- a/ansible/standalone-inventory.yml
+++ b/ansible/standalone-inventory.yml
@@ -1,0 +1,14 @@
+## Example inventory file for standalone deployment
+
+mexservers:
+   hosts:
+        34.73.3.63
+   vars:
+      ansible_ssh_private_key_file: ~/.mobiledgex/id_rsa_mex
+      ansible_ssh_user: ubuntu
+      crm:
+        name: crm1
+        ctrladdr: mexdemo.ctrl.mobiledgex.net:37001
+        operator: ATT
+        cloudlet: eastus-cloudlet
+

--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -326,7 +326,7 @@ func waitForStack(stackname string, action string) error {
 			continue
 		case action + "_FAILED":
 			log.InfoLog("Heat Stack failed", "action", action, "stackName", stackname)
-			return fmt.Errorf("Heat Stack failed")
+			return fmt.Errorf("Heat Stack failed: %s", hd.StackStatusReason)
 		default:
 			log.InfoLog("Unexpected Heat Stack status", "status", stackname)
 			return fmt.Errorf("Stack create unexpected status: %s", hd.StackStatus)


### PR DESCRIPTION
EDGECLOUD-631

Include the heat error reason when returning errors to the controller.

Also checkin my standalone DIND example inventory file for ansible.