### PR TITLE
cli util for parsing args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mobiledgex/edge-cloud v1.0.1
 	github.com/mobiledgex/golang-ssh v0.0.2
+	github.com/mobiledgex/yaml/v2 v2.2.4
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/moul/http2curl v1.0.0 // indirect
 	github.com/nanobox-io/golang-ssh v0.0.0-20190309194042-12ea65d3a59d

--- a/mc/mcctl/cli/input.go
+++ b/mc/mcctl/cli/input.go
@@ -1,0 +1,261 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/mitchellh/mapstructure"
+	yaml "github.com/mobiledgex/yaml/v2"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+type Input struct {
+	// Required argument names
+	RequiredArgs []string
+	// Alias argument names, format is alias=real
+	AliasArgs []string
+	// Password arg will prompt for password if not in args list
+	PasswordArg string
+	// Verify password if prompting
+	VerifyPassword bool
+	// Mapstructure DecodeHook functions
+	DecodeHook mapstructure.DecodeHookFunc
+	// Allow extra args that were not mapped to target object.
+	AllowUnused bool
+}
+
+// Args are format name=val, where name could be a hierarchical name
+// separated by ., i.e. appdata.key.name.
+// Arg names should be all lowercase.
+// NOTE: arrays and maps not supported yet.
+func (s *Input) ParseArgs(args []string, obj interface{}) (map[string]interface{}, error) {
+	dat := make(map[string]interface{})
+
+	// resolve aliases first
+	aliases := make(map[string]string)
+	reals := make(map[string]string)
+	if s.AliasArgs != nil {
+		for _, alias := range s.AliasArgs {
+			ar := strings.SplitN(alias, "=", 2)
+			if len(ar) != 2 {
+				fmt.Printf("skipping invalid alias %s\n", alias)
+				continue
+			}
+			aliases[ar[0]] = ar[1]
+			reals[ar[1]] = ar[0]
+		}
+	}
+	required := make(map[string]struct{})
+	if s.RequiredArgs != nil {
+		for _, req := range s.RequiredArgs {
+			req = resolveAlias(req, aliases)
+			required[req] = struct{}{}
+		}
+	}
+
+	// create generic data map from args
+	passwordFound := false
+	for _, arg := range args {
+		arg = strings.TrimSpace(arg)
+		kv := strings.SplitN(arg, "=", 2)
+		if len(kv) != 2 {
+			return dat, fmt.Errorf("arg \"%s\" not name=val format", arg)
+		}
+		key := resolveAlias(kv[0], aliases)
+		delete(required, key)
+		setKeyVal(dat, key, kv[1])
+		if key == s.PasswordArg {
+			passwordFound = true
+		}
+	}
+
+	// ensure required args are present
+	if len(required) != 0 {
+		missing := []string{}
+		for k, _ := range required {
+			k = resolveAlias(k, reals)
+			missing = append(missing, k)
+		}
+		return dat, fmt.Errorf("missing required args: %s", strings.Join(missing, " "))
+	}
+
+	// prompt for password if not in arg list
+	if s.PasswordArg != "" && !passwordFound {
+		pw, err := getPassword(s.VerifyPassword)
+		if err != nil {
+			return dat, err
+		}
+		setKeyVal(dat, resolveAlias(s.PasswordArg, aliases), pw)
+	}
+
+	// Specifying obj is used for two purposes.
+	// First is to ensure user has specified valid arguments.
+	// Second is to convert the values for any non-string fields
+	// to their appropriate type.
+	if obj != nil {
+		unused, err := WeakDecode(dat, obj, s.DecodeHook)
+		if err != nil {
+			return dat, err
+		}
+		if !s.AllowUnused && len(unused) > 0 {
+			return dat, fmt.Errorf("invalid args: %s",
+				strings.Join(unused, " "))
+		}
+
+		// This back and forth between yaml is to generate another
+		// set of generic map[string]interface{} data that contains
+		// typed values instead of string values. The json body
+		// values need to be properly typed to be unmarshalled
+		// properly, so we replace the specified untyped (string)
+		// values with properly typed (bool, int, etc) values.
+		// We can't use the typedMap directly because it may
+		// contain empty fields that were not specified by the
+		// user in the args list, which will mess up updates.
+		yaml.AlwaysOmitEmpty = false
+		byt, err := yaml.Marshal(obj)
+		if err != nil {
+			return dat, err
+		}
+		yaml.AlwaysOmitEmpty = true
+
+		typedDat := make(map[string]interface{})
+		err = yaml.Unmarshal(byt, &typedDat)
+		if err != nil {
+			return dat, err
+		}
+		replaceMapVals(typedDat, dat)
+	}
+	return dat, nil
+}
+
+func WeakDecode(input, output interface{}, hook mapstructure.DecodeHookFunc) ([]string, error) {
+	// use mapstructure.ComposeDecodeHookFunc if we need multiple
+	// decode hook functions.
+	config := &mapstructure.DecoderConfig{
+		Result:           output,
+		WeaklyTypedInput: true,
+		DecodeHook:       hook,
+		Metadata:         &mapstructure.Metadata{},
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return []string{}, err
+	}
+	err = decoder.Decode(input)
+	return config.Metadata.Unused, err
+}
+
+func resolveAlias(name string, aliases map[string]string) string {
+	if real, ok := aliases[name]; ok {
+		return real
+	}
+	return name
+}
+
+func setKeyVal(dat map[string]interface{}, key, val string) {
+	parts := strings.Split(key, ".")
+	for ii, part := range parts {
+		if ii == len(parts)-1 {
+			// values passed in on the command line that
+			// have spaces will be quoted.
+			valnew, err := strconv.Unquote(val)
+			if err == nil {
+				dat[part] = valnew
+			} else {
+				dat[part] = val
+			}
+		} else {
+			var submap map[string]interface{}
+			sub, ok := dat[part]
+			if !ok {
+				submap = make(map[string]interface{})
+				dat[part] = submap
+			} else {
+				submap, ok = sub.(map[string]interface{})
+				if !ok {
+					// conflict, overwrite
+					submap = make(map[string]interface{})
+					dat[part] = submap
+				}
+			}
+			dat = submap
+		}
+	}
+}
+
+func getPassword(verify bool) (string, error) {
+	fmt.Printf("password: ")
+	pw, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", err
+	}
+	fmt.Println()
+	if verify {
+		fmt.Print("verify password: ")
+		pw2, err := terminal.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return "", err
+		}
+		fmt.Println()
+		if string(pw) != string(pw2) {
+			return "", fmt.Errorf("passwords don't match")
+		}
+	}
+	return string(pw), nil
+}
+
+func replaceMapVals(src map[string]interface{}, dst map[string]interface{}) {
+	for key, dstVal := range dst {
+		srcVal, found := src[key]
+		if !found {
+			continue
+		}
+		subSrc, ok := srcVal.(map[string]interface{})
+		subDst, ok2 := dstVal.(map[string]interface{})
+		if ok && ok2 {
+			replaceMapVals(subSrc, subDst)
+			continue
+		}
+		//fmt.Printf("replace %s %#v with %#v\n", key, dst[key], src[key])
+		dst[key] = src[key]
+	}
+}
+
+func MarshalArgs(obj interface{}) ([]string, error) {
+	args := []string{}
+	if obj == nil {
+		return args, nil
+	}
+
+	// use mobiledgex yaml here since it always omits empty
+	byt, err := yaml.Marshal(obj)
+	if err != nil {
+		return args, err
+	}
+	dat := make(map[string]interface{})
+	err = yaml.Unmarshal(byt, &dat)
+
+	return MapToArgs([]string{}, dat), nil
+}
+
+func MapToArgs(prefix []string, dat map[string]interface{}) []string {
+	args := []string{}
+	for k, v := range dat {
+		if sub, ok := v.(map[string]interface{}); ok {
+			subargs := MapToArgs(append(prefix, k), sub)
+			args = append(args, subargs...)
+			continue
+		}
+		keys := append(prefix, k)
+		val := fmt.Sprintf("%v", v)
+		if strings.ContainsAny(val, " \t\r\n") {
+			val = strconv.Quote(val)
+		}
+		arg := fmt.Sprintf("%s=%s", strings.Join(keys, "."), val)
+		args = append(args, arg)
+	}
+	return args
+}

--- a/mc/mcctl/cli/input_test.go
+++ b/mc/mcctl/cli/input_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseArgs(t *testing.T) {
+	input := &Input{}
+
+	rf := ormapi.RegionFlavor{
+		Region: "local",
+		Flavor: edgeproto.Flavor{
+			Key: edgeproto.FlavorKey{
+				Name: "x1.tiny",
+			},
+			Vcpus: 1,
+			Disk:  2,
+			Ram:   3,
+		},
+	}
+	args := []string{"region=local", "flavor.vcpus=1", "flavor.disk=2", "flavor.key.name=\"x1.tiny\"", "flavor.ram=3"}
+	// basic parsing
+	testParseArgs(t, input, args, &rf, &ormapi.RegionFlavor{})
+
+	// required args
+	input.RequiredArgs = []string{"regionx"}
+	_, err := input.ParseArgs(args, &ormapi.RegionFlavor{})
+	require.NotNil(t, err)
+
+	input.RequiredArgs = []string{"region"}
+	testParseArgs(t, input, args, &rf, &ormapi.RegionFlavor{})
+
+	// alias args
+	input.AliasArgs = []string{"name=flavor.key.name"}
+	args = []string{"region=local", "flavor.vcpus=1", "flavor.disk=2", "name=x1.tiny", "flavor.ram=3"}
+	testParseArgs(t, input, args, &rf, &ormapi.RegionFlavor{})
+
+	// test extra args
+	args = []string{"region=local", "flavor.vcpus=1", "flavor.disk=2", "name=x1.tiny", "flavor.ram=3", "extra.arg=foo"}
+	_, err = input.ParseArgs(args, &ormapi.RegionFlavor{})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid args")
+
+	// test enum
+	input = &Input{
+		DecodeHook: edgeproto.EnumDecodeHook,
+	}
+
+	rc := ormapi.RegionCloudlet{
+		Region: "local",
+		Cloudlet: edgeproto.Cloudlet{
+			IpSupport: edgeproto.IpSupport_IpSupportDynamic,
+		},
+	}
+	args = []string{"region=local", "cloudlet.ipsupport=IpSupportDynamic"}
+	testParseArgs(t, input, args, &rc, &ormapi.RegionCloudlet{})
+}
+
+func testParseArgs(t *testing.T, input *Input, args []string, expected, buf1 interface{}) {
+	_, err := input.ParseArgs(args, buf1)
+	require.Nil(t, err)
+	require.Equal(t, expected, buf1)
+}
+
+func TestConversion(t *testing.T) {
+	// test converting obj to args and then back to obj
+
+	for _, flavor := range testutil.FlavorData {
+		testConversion(t, &flavor, &edgeproto.Flavor{})
+	}
+	for _, dev := range testutil.DevData {
+		testConversion(t, &dev, &edgeproto.Developer{})
+	}
+	for _, app := range testutil.AppData {
+		testConversion(t, &app, &edgeproto.App{})
+	}
+	for _, op := range testutil.OperatorData {
+		testConversion(t, &op, &edgeproto.Operator{})
+	}
+	for _, cloudlet := range testutil.CloudletData {
+		testConversion(t, &cloudlet, &edgeproto.Cloudlet{})
+	}
+	for _, cinst := range testutil.ClusterInstData {
+		testConversion(t, &cinst, &edgeproto.ClusterInst{})
+	}
+	for _, appinst := range testutil.AppInstData {
+		testConversion(t, &appinst, &edgeproto.AppInst{})
+	}
+	// CloudletInfo and CloudletRefs have arrays which aren't supported yet.
+}
+
+func testConversion(t *testing.T, obj interface{}, buf interface{}) {
+	args, err := MarshalArgs(obj)
+	require.Nil(t, err, "marshal %v", obj)
+	input := Input{
+		DecodeHook: edgeproto.EnumDecodeHook,
+	}
+	_, err = input.ParseArgs(args, buf)
+	require.Nil(t, err, "parse args %v", args)
+	require.Equal(t, obj, buf)
+}

--- a/mc/mcctl/cli/output.go
+++ b/mc/mcctl/cli/output.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mobiledgex/edge-cloud/protoc-gen-cmd/cmdsup"
+	yaml "github.com/mobiledgex/yaml/v2"
+)
+
+// note slightly different function in cmdsup.WriteOutputGeneric,
+// perhaps we can consolidate them.
+func WriteOutput(objs interface{}, format string) error {
+	switch format {
+	case cmdsup.OutputFormatYaml:
+		output, err := yaml.Marshal(objs)
+		if err != nil {
+			return fmt.Errorf("yaml failed to marshal: %v\n", err)
+		}
+		fmt.Print(string(output))
+	case cmdsup.OutputFormatJson:
+		output, err := json.MarshalIndent(objs, "", "  ")
+		if err != nil {
+			return fmt.Errorf("json failed to marshal: %v\n", err)
+		}
+		fmt.Println(string(output))
+	case cmdsup.OutputFormatJsonCompact:
+		output, err := json.Marshal(objs)
+		if err != nil {
+			return fmt.Errorf("json failed to marshal: %v\n", err)
+		}
+		fmt.Println(string(output))
+	default:
+		return fmt.Errorf("invalid output format %s", format)
+	}
+	return nil
+}


### PR DESCRIPTION
This is a cli library for parsing and dealing with command line arguments, to be use for mcctl (CLI). Because we don't have protobufs to generate cli flags for most of the MC REST APIs, and because I don't like specifying -- for every arg, the MC CLI (mcctl) will use args of the format "name=val" to specify fields. For example, ```mcctl user create name=jon email=jon@mail.com```. This library deals with converting those types of args to objects and maps that are used to pass data via the REST API calls.

I've actually already written mcctl but I'm trying to break out smaller pieces to make reviewing easier.

ParseArgs is the workhorse function here. It can also prompt for passwords, check for required args, and deal with aliased args (i.e. alias password=passhash). MarshalArgs is the inverse function to ParseArgs (maybe I should rename ParseArgs to UnmarshalArgs).