### PR TITLE
OpenStack client version in container

### DIFF
--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -1,4 +1,5 @@
 FROM ubuntu:18.04
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
 	apt-transport-https \
         ca-certificates \


### PR DESCRIPTION
Use the pip installed version of OpenStack client which is more recent than the one apt-get gives.

This resolves some problems in the packet openstack cloud with the limits api.

One question I have on this is that I had to add:
     ENV DEBIAN_FRONTEND=noninteractive

..to the Dockerfile to avoid being prompted for timezone.  I removed it now as I imagine the CICD build process handles this somehow but I wasn't quite sure about it.