### PR TITLE
EC-679: VM based Deployment fails for few Openstack Environments

### DIFF
--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -76,6 +76,7 @@ var vmTemplateResources = `
          flavor: {{.Flavor}}
         {{if .AuthPublicKey}} key_name: { get_resource: ssh_key_pair } {{- end}}
          config_drive: true       
+         user_data_format: RAW
          networks:
         {{if .FloatingIPAddressID}}
           - port: { get_resource: vm-port }
@@ -89,17 +90,14 @@ var vmTemplateResources = `
             edgeproxy: {{.GatewayIP}}
             mex-flavor: {{.Flavor}}
             privaterouter: {{.MEXRouterIP}}
-         user_data_format: RAW
          user_data: |
 ` + reindent(vmCloudConfig, 12) + `
         {{- end}}
         {{if .DeploymentManifest}}
-         user_data_format: RAW
          user_data: |
 {{ Indent .DeploymentManifest 13 }}
         {{- end}}
         {{if .Command}}
-         user_data_format: RAW
          user_data: |
             #cloud-config
             runcmd:


### PR DESCRIPTION
Stack creation fails on some Openstack environments like Munich and Frankfurt.
```
Error:Heat Stack failed: Resource CREATE failed: EndpointNotFound: resources.AshishVM: publicURL endpoint for cloudformation service in RegionOne region not found
```

Seems to be following bug:
https://bugs.launchpad.net/fuel-ccp/+bug/1620594

Having `user_data_format:RAW`, field fixes this issue.