### PR TITLE
EDGECLOUD-663: MC Artifactory integration should support distinct deployment environments

### DIFF
--- a/mc/mc.go
+++ b/mc/mc.go
@@ -26,6 +26,7 @@ var gitlabAddr = flag.String("gitlabAddr", "http://127.0.0.1:80", "Gitlab server
 var artifactoryAddr = flag.String("artifactoryAddr", "http://127.0.0.1:80", "Artifactory server address")
 var pingInterval = flag.Duration("pingInterval", 20*time.Second, "SQL database ping keep-alive interval")
 var skipVerifyEmail = flag.Bool("skipVerifyEmail", false, "skip email verification, for testing only")
+var tag = flag.String("tag", "mc", "Tag to identify mc server")
 
 var sigChan chan os.Signal
 
@@ -49,6 +50,7 @@ func main() {
 		ClientCert:      *clientCert,
 		PingInterval:    *pingInterval,
 		SkipVerifyEmail: *skipVerifyEmail,
+		Tag:             *tag,
 	}
 	server, err := orm.RunServer(&config)
 	if err != nil {

--- a/mc/orm/artifactory.go
+++ b/mc/orm/artifactory.go
@@ -11,11 +11,6 @@ import (
 	"github.com/mobiledgex/edge-cloud/log"
 )
 
-const (
-	ArtifactoryRepoPrefix string = "mc-repo-"
-	ArtifactoryPermPrefix string = "mc-perm-"
-)
-
 func artifactoryClient() (*artifactory.Artifactory, error) {
 	artifactoryApiKey, err := rtf.GetArtifactoryApiKey()
 	if err != nil {
@@ -33,16 +28,24 @@ func artifactoryClient() (*artifactory.Artifactory, error) {
 	return client, nil
 }
 
+func getArtifactoryRepoPrefix() string {
+	return serverConfig.Tag + "-repo-"
+}
+
+func getArtifactoryPermPrefix() string {
+	return serverConfig.Tag + "-perm-"
+}
+
 func getArtifactoryRepoName(orgName string) string {
-	return ArtifactoryRepoPrefix + orgName
+	return getArtifactoryRepoPrefix() + orgName
 }
 
 func getArtifactoryPermName(orgName string) string {
-	return ArtifactoryPermPrefix + orgName
+	return getArtifactoryPermPrefix() + orgName
 }
 
 func getArtifactoryRealmAttr(orgName string) string {
-	return "ldapGroupName=" + orgName + ";groupsStrategy=STATIC;groupDn=cn=" + orgName + ",ou=orgs"
+	return "ldapGroupName=" + orgName + ";groupsStrategy=STATIC;groupDn=cn=" + orgName + ",ou=orgs,dc=" + serverConfig.Tag
 }
 
 func artifactoryListGroups() (map[string]bool, error) {
@@ -116,7 +119,7 @@ func artifactoryListRepos() (map[string]bool, error) {
 	tmp := make(map[string]bool)
 	for _, repo := range *repos {
 		repoName := *repo.Key
-		if strings.HasPrefix(repoName, ArtifactoryRepoPrefix) {
+		if strings.HasPrefix(repoName, getArtifactoryRepoPrefix()) {
 			tmp[repoName] = true
 		}
 	}
@@ -180,7 +183,7 @@ func artifactoryListPerms() (map[string]bool, error) {
 	tmp := make(map[string]bool)
 	for _, perm := range perms {
 		permName := *perm.Name
-		if strings.HasPrefix(permName, ArtifactoryPermPrefix) {
+		if strings.HasPrefix(permName, getArtifactoryPermPrefix()) {
 			tmp[permName] = true
 		}
 	}
@@ -201,7 +204,7 @@ func artifactoryCreateRepoPerms(orgName string) error {
 		Repositories: &[]string{repoName},
 		Principals: &v1.Principals{
 			Groups: &map[string][]string{
-				groupName: []string{"m", "w", "n", "d", "r"},
+				groupName: []string{"w", "d", "r"},
 			},
 		},
 	}

--- a/mc/orm/artifactory_sync.go
+++ b/mc/orm/artifactory_sync.go
@@ -95,7 +95,7 @@ func (s *AppStoreSync) syncArtifactoryObjects() {
 		log.DebugLog(log.DebugLevelApi,
 			"Artifactory Sync delete extra repository",
 			"name", repo)
-		err = artifactoryDeleteRepo(strings.TrimPrefix(repo, ArtifactoryRepoPrefix))
+		err = artifactoryDeleteRepo(strings.TrimPrefix(repo, getArtifactoryRepoPrefix()))
 		if err != nil {
 			s.syncErr(err)
 		}
@@ -104,7 +104,7 @@ func (s *AppStoreSync) syncArtifactoryObjects() {
 		log.DebugLog(log.DebugLevelApi,
 			"Artifactory Sync delete extra permission target",
 			"name", perm)
-		err = artifactoryDeleteRepoPerms(strings.TrimPrefix(perm, ArtifactoryPermPrefix))
+		err = artifactoryDeleteRepoPerms(strings.TrimPrefix(perm, getArtifactoryPermPrefix()))
 		if err != nil {
 			s.syncErr(err)
 		}

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -44,6 +44,7 @@ type ServerConfig struct {
 	ClientCert      string
 	PingInterval    time.Duration
 	SkipVerifyEmail bool
+	Tag             string
 }
 
 var DefaultDBUser = "mcuser"


### PR DESCRIPTION
* Fixed to code to handle multiple instances on MC (demo & staging)
* Have added `dc` domain-component to LDAP search output to distinguish between mc & mc-stage
* Have added new optional argument to mc called `--tag` (defaults to `mc`). For staging, we will start mc with arg: `--tag mc-stage`
* Groups are identified based on LDAP realm attributes ( which will have `dc`)
* Repos & Perms are identified by their prefixes (which now has tag as their prefix)
* Removed "managed & annotate" permissions for groups as it is not required to have those