### PR TITLE
EDGECLOUD-595: store openstack certs in Vault

### DIFF
--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -58,6 +58,14 @@ func InitOpenstackProps() error {
 			return fmt.Errorf("failed to InternVaultEnv %s: %v", openRcURL, err)
 		}
 	}
+	cacert_URL := os.Getenv("OS_CACERT_URL")
+	if cacert_URL != "" {
+		err := GetVaultDataToFile(cacert_URL, "/tmp/os_cacert.cert")
+		if err != nil {
+			return fmt.Errorf("failed to GetVaultDataToFile %s: %v", cacert_URL, err)
+		}
+		os.Setenv("OS_CACERT", "/tmp/os_cacert.cert")
+	}
 	OpenstackProps.OpenRcVars = make(map[string]string)
 
 	OpenstackProps.OsExternalNetworkName = os.Getenv("MEX_EXT_NETWORK")

--- a/mexos/vault.go
+++ b/mexos/vault.go
@@ -2,6 +2,7 @@ package mexos
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -18,6 +19,10 @@ type EnvData struct {
 
 type VaultEnvData struct {
 	Env []EnvData `json:"env"`
+}
+
+type VaultData struct {
+	Data string `json:"data"`
 }
 
 func GetVaultData(keyURL string) (map[string]interface{}, error) {
@@ -95,5 +100,27 @@ func InternVaultEnv(keyURL string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func GetVaultDataToFile(keyURL, fileName string) error {
+	log.DebugLog(log.DebugLevelMexos, "get vault data to file", "keyURL", keyURL, "file", fileName)
+	dat, err := GetVaultData(keyURL)
+	if err != nil {
+		return err
+	}
+	vaultData := &VaultData{}
+	err = mapstructure.WeakDecode(dat["data"], vaultData)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(fileName, []byte(vaultData.Data), 0644)
+	if err != nil {
+		return err
+	}
+
+	log.DebugLog(log.DebugLevelMexos, "vault data imported to file successfully")
+
 	return nil
 }


### PR DESCRIPTION
* Moves crt to Vault
* `OS_CACERT_URL` variable is set in openrc.json:
```
    {
      "name": "OS_CACERT_URL",
      "value": "https://vault.mobiledgex.net/v1/secret/data/cloudlet/openstack/frankfurt/os_cacert.json"
    },
```
* Cert data is stored in `os_cacert.json` with key as `data` and value as cert data

* **Note**: Yet to change Yaml files and certs for all the cloudlets. Post initial review, will do these changes