### PR TITLE
EDGECLOUD-633: Support for Checksum for Public URL of VM Image

### DIFF
--- a/mexos/uri.go
+++ b/mexos/uri.go
@@ -150,19 +150,18 @@ func GetUrlInfo(fileUrlPath string) (time.Time, string, error) {
 	if err != nil {
 		return time.Time{}, "", fmt.Errorf("Error fetching last modified time of URL %s, %v", fileUrlPath, err)
 	}
+	defer resp.Body.Close()
 	tStr := resp.Header.Get("Last-modified")
 	lastMod, err := time.Parse(time.RFC1123, tStr)
 	if err != nil {
 		return time.Time{}, "", fmt.Errorf("Error parsing last modified time of URL %s, %v", fileUrlPath, err)
 	}
-	md5Sum := resp.Header.Get("X-Checksum-Md5")
-	if md5Sum == "" {
-		urlInfo := strings.Split(fileUrlPath, "#")
-		if len(urlInfo) == 2 {
-			cSum := strings.Split(urlInfo[1], ":")
-			if len(cSum) == 2 {
-				md5Sum = cSum[1]
-			}
+	md5Sum := ""
+	urlInfo := strings.Split(fileUrlPath, "#")
+	if len(urlInfo) == 2 {
+		cSum := strings.Split(urlInfo[1], ":")
+		if len(cSum) == 2 && cSum[0] == "md5" {
+			md5Sum = cSum[1]
 		}
 	}
 	return lastMod, md5Sum, err


### PR DESCRIPTION
* This adds Checksum support for VM images not from Artifactory. For Artifactory we already have Checksum in HTTP Header.
* Please review changes in edge-cloud repo as well
* ImagePath input with Checksum format: `https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img#md5:92a19abfec7c499acc81047ad0ed6ba1`