### PR TITLE
EDGECLOUD-583 added a check for flavor sizes in cluster create

### DIFF
--- a/crm-platforms/openstack/openstack-cluster.go
+++ b/crm-platforms/openstack/openstack-cluster.go
@@ -22,9 +22,9 @@ func (s *Platform) CreateClusterInst(clusterInst *edgeproto.ClusterInst) error {
 	}
 	//find the flavor and check the disk size
 	for _, flavor := range s.flavorList {
-		if flavor.Name == clusterInst.NodeFlavor && flavor.Disk < 20 {
+		if flavor.Name == clusterInst.NodeFlavor && flavor.Disk < MINIMUM_DISK_SIZE {
 
-			return fmt.Errorf("Insufficient disk size, please specify a flavor with at least 20gb")
+			return fmt.Errorf("Insufficient disk size, please specify a flavor with at least %dgb", MINIMUM_DISK_SIZE)
 		}
 	}
 	return mexos.CreateCluster(lbName, clusterInst)

--- a/crm-platforms/openstack/openstack.go
+++ b/crm-platforms/openstack/openstack.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mobiledgex/edge-cloud/log"
 )
 
+const MINIMUM_DISK_SIZE uint64 = 20
+
 type Platform struct {
 	rootLBName  string
 	rootLB      *mexos.MEXRootLB


### PR DESCRIPTION
The mobiledgex openstack image requires 20gb of disk, this check allows clusterinstcreate to fail faster so that failure is immediate rather than waiting for openstack to actually try to unsuccessfully create the cluster