### PR TITLE
EDGECLOUD-684 CRMs need the new vaultAddr parameter

### DIFF
--- a/ansible/roles/crm/tasks/main.yml
+++ b/ansible/roles/crm/tasks/main.yml
@@ -9,6 +9,10 @@
       - "0.0.0.0:{{ crm_api_port }}"
       - "--cloudletKey"
       - "{\\\"operator_key\\\":{\\\"name\\\":\\\"{{ item.operator_key | mandatory }}\\\"},\\\"name\\\":\\\"{{ deploy_target }}-{{ item.openstack_instance | mandatory }}-cloudlet\\\"}"
+      - "--physicalName"
+      - "{{ item.openstack_instance }}"
+      - "--vaultAddr"
+      - "{{ vault_vm_hostname }}:{{ vault_port }}"
       - "--notifyAddrs"
       - "{{ item.controller }}.ctrl.{{ cloudflare_zone }}:37001"
       - "--tls"
@@ -16,11 +20,10 @@
       - "-d"
       - "api,notify,mexos"
     env:
-      OPENRC_URL: "https://vault.mobiledgex.net/v1/secret/data/cloudlet/openstack/{{ item.openstack_instance | mandatory }}/openrc.json"
-      MEXENV_URL: https://vault.mobiledgex.net/v1/secret/data/cloudlet/openstack/mexenv.json
       PLATFORM: openstack
       MEX_EXT_NETWORK: "{{ item.mex_ext_network | default(mex_ext_network) }}"
       VAULT_ROLE_ID: "{{ crm_vault_role_id }}"
       VAULT_SECRET_ID: "{{ crm_vault_secret_id }}"
       MEX_SECURITY_GROUP: "{{ item.mex_security_group | default(mex_security_group) }}"
   with_items: "{{ crm_instances }}"
+  tags: deploy

--- a/ansible/roles/gcp_firewall/tasks/vault.yml
+++ b/ansible/roles/gcp_firewall/tasks/vault.yml
@@ -6,7 +6,7 @@
     allowed:
       - ip_protocol: tcp
         ports:
-          - '8200'        # Vault server
+          - "{{ vault_port }}"
     target_tags:
       - vault-ac
     project: "{{ gcp_project }}"

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -45,6 +45,7 @@
   become: yes
   become_user: postgres
   with_items: "{{ postgres_users }}"
+  no_log: true
 
 - name: Create users
   postgresql_user:
@@ -55,6 +56,7 @@
   become: yes
   become_user: postgres
   with_items: "{{ postgres_users }}"
+  no_log: true
 
 - name: Remove unnecessary privileges
   postgresql_user:
@@ -63,3 +65,4 @@
   become: yes
   become_user: postgres
   with_items: "{{ postgres_users }}"
+  no_log: true

--- a/ansible/roles/vault/handlers/main.yml
+++ b/ansible/roles/vault/handlers/main.yml
@@ -16,5 +16,5 @@
   debug:
     msg: |
       Initialize vault using the command:
-      VAULT_ADDR=https://{{ vault_vm_hostname }}:8200 vault operator init -key-shares=5 -key-threshold=3 -format json
+      VAULT_ADDR=https://{{ vault_vm_hostname }}:{{ vault_port }} vault operator init -key-shares=5 -key-threshold=3 -format json
 

--- a/ansible/roles/vault/tasks/main.yml
+++ b/ansible/roles/vault/tasks/main.yml
@@ -156,7 +156,7 @@
 
 - name: Check if vault is initialized
   uri:
-    url: "https://{{ vault_vm_hostname }}:8200/v1/sys/init"
+    url: "https://{{ vault_vm_hostname }}:{{ vault_port }}/v1/sys/init"
     return_content: yes
     status_code: 200
     body_format: json

--- a/ansible/roles/vault/templates/vault.hcl.j2
+++ b/ansible/roles/vault/templates/vault.hcl.j2
@@ -1,7 +1,7 @@
 ui = true
-api_addr = "https://{{ vault_vm_hostname }}:8200"
+api_addr = "https://{{ vault_vm_hostname }}:{{ vault_port }}"
 listener "tcp" {
-  address = "0.0.0.0:8200"
+  address = "0.0.0.0:{{ vault_port }}"
   tls_disable = 0
   tls_cert_file = "/etc/letsencrypt/live/{{ vault_vm_hostname }}/fullchain.pem"
   tls_key_file = "/etc/letsencrypt/live/{{ vault_vm_hostname }}/privkey.pem"

--- a/ansible/staging
+++ b/ansible/staging
@@ -15,6 +15,7 @@ mc_superuser=mexadmin
 mc_superuser_password=mexadmin123
 postgres_hostname=postgres-stage.mobiledgex.net
 vault_vm_hostname=vault-stage.mobiledgex.net
+vault_port=8200
 gitlab_vm_hostname=gitlab-stage.mobiledgex.net
 crm_vm_hostname=crm-stage.mobiledgex.net
 mc_vm_hostname=mc-stage.mobiledgex.net
@@ -28,7 +29,7 @@ gitlab_docker_hostname="docker-{{ deploy_environ }}.mobiledgex.net"
 localhost	ansible_connection=local
 
 [crms]
-crm-stage.mobiledgex.net
+crm-stage.mobiledgex.net	vault_vm_hostname=vault.mobiledgex.net vault_port=443
 
 [mc]
 mc-stage.mobiledgex.net	


### PR DESCRIPTION
The current setup in staging still uses the primary vault instance, and
so the computed CRM vault parameters are being overridden in the staging
inventory file right now.  The overrides will go away once staging
switches to its own vault instance at vault-stage.

Also includes an unrelated change to avoid printing out postgres
credentials in ansible log output.