### PR TITLE
Console VMs need more disk space

### DIFF
--- a/terraform/mexplat/qa/main.tf
+++ b/terraform/mexplat/qa/main.tf
@@ -57,6 +57,7 @@ module "console" {
 
   instance_name       = "${var.console_instance_name}"
   zone                = "${var.gcp_zone}"
+  boot_disk_size      = 100
   tags                = [ "http-server", "https-server", "console-debug", "mc" ]
 }
 

--- a/terraform/mexplat/stage/main.tf
+++ b/terraform/mexplat/stage/main.tf
@@ -106,6 +106,7 @@ module "console" {
 
   instance_name       = "${var.console_instance_name}"
   zone                = "${var.gcp_zone}"
+  boot_disk_size      = 100
   tags                = [ "http-server", "https-server", "console-debug" ]
 }
 


### PR DESCRIPTION
Dockerising console increased the disk space requirements for the VMs.