### PR TITLE
per region vault paths

### DIFF
--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -174,6 +174,7 @@ var AppOptionalArgs = []string{
 	"delopt",
 	"configs.kind",
 	"configs.config",
+	"scalewithcluster",
 }
 var AppAliasArgs = []string{
 	"developer=app.key.developerkey.name",
@@ -194,4 +195,5 @@ var AppAliasArgs = []string{
 	"delopt=app.delopt",
 	"configs.kind=app.configs.kind",
 	"configs.config=app.configs.config",
+	"scalewithcluster=app.scalewithcluster",
 }

--- a/mc/orm/alldata_test.go
+++ b/mc/orm/alldata_test.go
@@ -34,7 +34,7 @@ func TestAllData(t *testing.T) {
 	require.Nil(t, err, "run server")
 	defer server.Stop()
 
-	Jwks.Init("addr", "mcorm", "roleID", "secretID")
+	Jwks.Init("addr", "region", "mcorm", "roleID", "secretID")
 	Jwks.Meta.CurrentVersion = 1
 	Jwks.Keys[1] = &vault.JWK{
 		Secret:  "12345",

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -37,7 +37,7 @@ func TestController(t *testing.T) {
 	require.Nil(t, err, "run server")
 	defer server.Stop()
 
-	Jwks.Init("addr", "mcorm", "roleID", "secretID")
+	Jwks.Init("addr", "region", "mcorm", "roleID", "secretID")
 	Jwks.Meta.CurrentVersion = 1
 	Jwks.Keys[1] = &vault.JWK{
 		Secret:  "12345",

--- a/mc/orm/ldap_test.go
+++ b/mc/orm/ldap_test.go
@@ -30,7 +30,7 @@ func TestLDAPServer(t *testing.T) {
 	require.Nil(t, err, "run server")
 	defer server.Stop()
 
-	Jwks.Init("addr", "mcorm", "roleID", "secretID")
+	Jwks.Init("addr", "region", "mcorm", "roleID", "secretID")
 	Jwks.Meta.CurrentVersion = 1
 	Jwks.Keys[1] = &vault.JWK{
 		Secret:  "12345",

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -105,15 +105,18 @@ func RunServer(config *ServerConfig) (*Server, error) {
 			Common: process.Common{
 				Name: "vault",
 			},
-			DmeSecret:   "123456",
-			McormSecret: "987664",
+			DmeSecret: "123456",
 		}
-		roles, err := vault.StartLocalRoles()
+		_, err := vault.StartLocalRoles()
 		if err != nil {
 			return nil, err
 		}
-		roleID = roles.MCORMRoleID
-		secretID = roles.MCORMSecretID
+		roles, err := intprocess.SetupVault(&vault)
+		if err != nil {
+			return nil, err
+		}
+		roleID = roles.MCRoleID
+		secretID = roles.MCSecretID
 		config.VaultAddr = process.VaultAddress
 		server.vault = &vault
 	}

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -29,7 +29,7 @@ func TestServer(t *testing.T) {
 	require.Nil(t, err, "run server")
 	defer server.Stop()
 
-	Jwks.Init("addr", "mcorm", "roleID", "secretID")
+	Jwks.Init("addr", "region", "mcorm", "roleID", "secretID")
 	Jwks.Meta.CurrentVersion = 1
 	Jwks.Keys[1] = &vault.JWK{
 		Secret:  "12345",

--- a/mc/orm/userauth.go
+++ b/mc/orm/userauth.go
@@ -30,7 +30,7 @@ var PasshashSaltBytes = 8
 var Jwks vault.JWKS
 
 func InitVault(addr, roleID, secretID string) {
-	Jwks.Init(addr, "mcorm", roleID, secretID)
+	Jwks.Init(addr, "", "mcorm", roleID, secretID)
 	Jwks.GoUpdate()
 }
 


### PR DESCRIPTION
Infra changes for per-region Vault paths. The infra vault setup is now used to set up the MC approle, for which it leverages the edge-cloud Vault code. Note that paths here do not overlaps with paths from edge-cloud vault/setup.sh.