### PR TITLE
Pick the latest console version from git tags

### DIFF
--- a/ansible/filter_plugins/semver_sort.py
+++ b/ansible/filter_plugins/semver_sort.py
@@ -1,0 +1,50 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleFilterError
+from ansible.utils import helpers
+
+from distutils.version import LooseVersion
+import re
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+}
+
+def semver_sort(versions, re_filter=None, reverse=False):
+    full_ver_map = {}
+    ver_list = []
+    if re_filter:
+        ngroups = re.compile(re_filter).groups
+        if ngroups > 1:
+            raise AnsibleFilterError("Too many capture groups in re_filter: {0}".format(
+                re_filter))
+
+        for v in versions:
+            m = re.search(re_filter, v)
+            if not m:
+                continue
+            if ngroups > 0:
+                ver_list.append(m.group(1))
+                full_ver_map[m.group(1)] = v
+            else:
+                ver_list.append(v)
+    else:
+        ver_list = versions
+
+    try:
+        sorted_ver_list = sorted(ver_list, key=LooseVersion, reverse=reverse)
+    except ValueError as e:
+        raise AnsibleFilterError("{0}: need an re_filter, perhaps?".format(
+            str(e)))
+
+    return [ full_ver_map[x] if x in full_ver_map else x for x in sorted_ver_list ]
+
+# ---- Ansible filters ----
+class FilterModule(object):
+    ''' Semver sort '''
+
+    def filters(self):
+        return {
+            'semver_sort': semver_sort
+        }

--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -21,24 +21,34 @@
         github_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
       when: github_token is not defined or not github_token
 
-    - name: Pick latest release from Github
+    - set_fact:
+        console_version_not_provided: true
+      when: console_version is not defined
+
+    - name: Get list of edge-cloud-ui tags from Github
       uri:
-        url: https://api.github.com/repos/mobiledgex/edge-cloud-ui/releases/latest
+        url: https://api.github.com/repos/mobiledgex/edge-cloud-ui/tags
         user: "{{ github_user }}"
         password: "{{ github_token }}"
         force_basic_auth: yes
         return_content: yes
-      register: console_release
-      when: console_version is not defined
+      register: console_tags
+      check_mode: false
+      when: console_version_not_provided | default(false)
 
-    - set_fact:
-        console_version: "{{ console_release.json.tag_name }}"
-      when: console_version is not defined
+    - name: Pick newest tag by semver
+      set_fact:
+        console_version: "{{ console_tags.json | json_query('[*].name') | semver_sort(re_filter='^v[0-9]') | last }}"
+      when: console_version_not_provided | default(false)
+
+    - assert:
+        that:
+          - console_version is defined
 
     - pause:
         prompt: "Installing the latest console release: {{ console_version }}"
         seconds: 30
-      when: console_release is defined
+      when: console_version_not_provided | default(false)
 
 - hosts: platform
   tasks:


### PR DESCRIPTION
Switch from requiring a Github release for each console deployment to
picking the latest tag directly from git.