### PR TITLE
EDGECLOUD-712 mcctl run command fix and e2e-test

### DIFF
--- a/e2e-tests/data/mc_cloudlets_flavors.yml
+++ b/e2e-tests/data/mc_cloudlets_flavors.yml
@@ -20,6 +20,13 @@ regiondata:
         longitude: -91
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: tmus
@@ -30,6 +37,13 @@ regiondata:
         longitude: -95
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: azure
@@ -40,6 +54,13 @@ regiondata:
         longitude: -91
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: gcp
@@ -50,6 +71,13 @@ regiondata:
         longitude: -95
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     flavors:
     - key:
         name: x1.tiny

--- a/e2e-tests/data/mc_runcommand.yml
+++ b/e2e-tests/data/mc_runcommand.yml
@@ -1,0 +1,19 @@
+request:
+  region: local
+  execrequest:
+    appinstkey:
+      appkey:
+        developerkey:
+          name: AcmeAppCo
+        name: someapplication1
+        version: "1.0"
+      clusterinstkey:
+        clusterkey:
+          name: SmallCluster
+        cloudletkey:
+          operatorkey:
+            name: tmus
+          name: tmus-cloud-1
+        developer: AcmeAppCo
+    command: echo foo
+expectedoutput: foo

--- a/e2e-tests/data/mc_user1_data_show.yml
+++ b/e2e-tests/data/mc_user1_data_show.yml
@@ -46,6 +46,13 @@ regiondata:
         longitude: -91
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: tmus
@@ -56,6 +63,13 @@ regiondata:
         longitude: -95
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: azure
@@ -66,6 +80,13 @@ regiondata:
         longitude: -91
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: gcp
@@ -76,6 +97,13 @@ regiondata:
         longitude: -95
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     flavors:
     - key:
         name: x1.tiny

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -38,6 +38,13 @@ regiondata:
         longitude: -91
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: tmus
@@ -48,6 +55,13 @@ regiondata:
         longitude: -95
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: azure
@@ -58,6 +72,13 @@ regiondata:
         longitude: -91
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     - key:
         operatorkey:
           name: gcp
@@ -68,6 +89,13 @@ regiondata:
         longitude: -95
       ipsupport: IpSupportDynamic
       numdynamicips: 254
+      timelimits:
+        createclusterinsttimeout: 3000000000
+        updateclusterinsttimeout: 2000000000
+        deleteclusterinsttimeout: 2000000000
+        createappinsttimeout: 3000000000
+        updateappinsttimeout: 2000000000
+        deleteappinsttimeout: 2000000000
     flavors:
     - key:
         name: x1.tiny

--- a/e2e-tests/testfiles/mc_add_delete.yml
+++ b/e2e-tests/testfiles/mc_add_delete.yml
@@ -41,6 +41,10 @@ tests:
     yaml1: '{{outputdir}}/show-commands.yml'
     yaml2: '{{datadir2}}/mc_user2_data_show.yml'
     filetype: mcdata
+- name: test RunCommand
+  actions: [mcapi-runcommand]
+  apifile: '{{datadir2}}/mc_runcommand.yml'
+  curuserfile: '{{datadir2}}/mc_user2.yml'
 - name: user2 deletes apps; verify it is empty
   actions: [mcapi-delete, mcapi-show]
   apifile: '{{datadir2}}/mc_user2_data.yml'

--- a/mc/mcctl/cliwrapper/exec.go
+++ b/mc/mcctl/cliwrapper/exec.go
@@ -1,0 +1,15 @@
+package cliwrapper
+
+import (
+	"strings"
+
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+)
+
+func (s *Client) RunCommandOut(uri, token string, in *ormapi.RegionExecRequest) (string, error) {
+	args := []string{"ctrl", "RunCommand"}
+	var out string
+	noconfig := strings.Split("Offer,Answer,Err", ",")
+	_, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
+	return out, err
+}

--- a/mc/mcctl/cliwrapper/wrapcli.go
+++ b/mc/mcctl/cliwrapper/wrapcli.go
@@ -55,7 +55,9 @@ func (s *Client) runObjs(uri, token string, args []string, in, out interface{}, 
 	}
 	str := strings.TrimSpace(string(byt))
 	if out != nil && len(str) > 0 {
-		if opts.streamOutIncremental {
+		if strp, ok := out.(*string); ok {
+			*strp = str
+		} else if opts.streamOutIncremental {
 			// each line is a separate object, join together in a json array
 			lines := strings.Split(str, "\n")
 			arr := "[" + strings.Join(lines, ",") + "]"

--- a/mc/mcctl/ormctl/execreq.go
+++ b/mc/mcctl/ormctl/execreq.go
@@ -16,7 +16,7 @@ import (
 // We don't use the auto-generated Command because the client
 // must implement the webrtc protocol.
 
-const runCommandRequiredArgs = "region command appname appvers developer clustername clusterdeveloper cloudlet operator"
+const runCommandRequiredArgs = "region command appname appvers developer cluster cloudlet operator"
 
 var runCommandAliasArgs = []string{
 	"appname=execrequest.appinstkey.appkey.name",
@@ -44,6 +44,22 @@ func runExecRequest(cmd *cobra.Command, args []string) error {
 		AliasArgs:    runCommandAliasArgs,
 	}
 	req := ormapi.RegionExecRequest{}
+
+	var developer string
+	var clusterdeveloper string
+	for _, arg := range args {
+		parts := strings.Split(arg, "=")
+		if parts[0] == "developer" {
+			developer = parts[1]
+		}
+		if parts[1] == "clusterdeveloper" {
+			clusterdeveloper = parts[1]
+		}
+	}
+	if clusterdeveloper == "" && developer != "" {
+		args = append(args, fmt.Sprintf("clusterdeveloper=%s", developer))
+	}
+
 	_, err := input.ParseArgs(args, &req)
 	if err != nil {
 		return err

--- a/mc/mcctl/ormctl/user.go
+++ b/mc/mcctl/ormctl/user.go
@@ -76,7 +76,7 @@ func GetUserCommand() *cobra.Command {
 func GetLoginCmd() *cobra.Command {
 	cmd := genCmd(&Command{
 		Use:          "login",
-		RequiredArgs: "username",
+		RequiredArgs: "name",
 		Run:          runLogin,
 	})
 	return cmd
@@ -84,8 +84,9 @@ func GetLoginCmd() *cobra.Command {
 
 func runLogin(cmd *cobra.Command, args []string) error {
 	input := cli.Input{
-		RequiredArgs: []string{"username"},
+		RequiredArgs: []string{"name"},
 		PasswordArg:  "password",
+		AliasArgs:    []string{"name=username"},
 	}
 	login := ormapi.UserLogin{}
 	_, err := input.ParseArgs(args, &login)


### PR DESCRIPTION
Fixes "clustername" arg to mcctl run command. Remove need for "clusterdeveloper" arg, since it's redundant with "developer" arg. Adds e2e-test for mcctl runcommand.
Also fixed EDGECLOUD-729 to alias name to username for login.