### PR TITLE
Fix metrics api unit test failue

### DIFF
--- a/mc/orm/influx_test.go
+++ b/mc/orm/influx_test.go
@@ -16,6 +16,7 @@ func testPermShowClusterMetrics(mcClient *ormclient.Client, uri, token, region, 
 
 	in := &edgeproto.ClusterInstKey{}
 	in.Developer = org
+	in.ClusterKey.Name = "testcluster"
 	dat := &ormapi.RegionClusterInstMetrics{}
 	dat.Region = region
 	dat.ClusterInst = *in
@@ -31,6 +32,7 @@ func testPermShowAppInstMetrics(mcClient *ormclient.Client, uri, token, region, 
 
 	in := &edgeproto.AppInstKey{}
 	in.AppKey.DeveloperKey.Name = org
+	in.ClusterInstKey.ClusterKey.Name = "testcluster"
 	dat := &ormapi.RegionAppInstMetrics{}
 	dat.Region = region
 	dat.AppInst = *in


### PR DESCRIPTION
Jon noticed that I forgot to fill out the required elements of the unit test request.
Fixed:
```
/usr/local/go/bin/go test -timeout 30s github.com/mobiledgex/edge-cloud-infra/mc/orm -run ^(TestController)$

ok  	github.com/mobiledgex/edge-cloud-infra/mc/orm	4.631s
Success: Tests passed.
```