### PR TITLE
Fix crm failure to start with DIND

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -268,8 +268,6 @@ replace github.com/mattn/go-sqlite3 => github.com/mattn/go-sqlite3 v1.10.0
 
 replace github.com/mitchellh/copystructure => github.com/mitchellh/copystructure v1.0.0
 
-replace github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.0.0
-
 replace github.com/mitchellh/go-testing-interface => github.com/mitchellh/go-testing-interface v1.0.0
 
 replace github.com/mitchellh/mapstructure => github.com/mitchellh/mapstructure v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=


### PR DESCRIPTION
Removed github.com/mitchellh/go-homedir requirement, should just use the latest of the package, since edge-cloud doesn't have a requirement anymore