### PR TITLE
Switch to external IP for InfluxDB service

### DIFF
--- a/ansible/templates/mexplat/mex-cluster-svc-deploy.yml.j2
+++ b/ansible/templates/mexplat/mex-cluster-svc-deploy.yml.j2
@@ -29,7 +29,7 @@ spec:
          - "--tls"
          - "/root/tls/mex-server.crt"
          - "--influxdb"
-         - "{{ influxdb_name }}:8086"
+         - "https://{{ influxdb_dns }}.{{ cloudflare_zone }}:8086"
          - "--flavor"
          - "x1.medium"
       imagePullSecrets:

--- a/ansible/templates/mexplat/mex-controller-deploy.yml.j2
+++ b/ansible/templates/mexplat/mex-controller-deploy.yml.j2
@@ -33,7 +33,7 @@ spec:
          - "--vaultAddr"
          - "https://{{ vault_vm_hostname }}:{{ vault_port }}"
          - "--influxAddr"
-         - "https://{{ influxdb_name }}:8086"
+         - "https://{{ influxdb_dns }}.{{ cloudflare_zone }}:8086"
          - "--tls"
          - "/root/tls/mex-server.crt"
          - "-autoUpgrade"


### PR DESCRIPTION
InfluxDB now has public letsencrypt certs.