### PR TITLE
update version of golang-ssh to pick up leak fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/lib/pq v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mobiledgex/edge-cloud v1.0.1
-	github.com/mobiledgex/golang-ssh v0.0.2
+	github.com/mobiledgex/golang-ssh v0.0.3
 	github.com/mobiledgex/yaml v2.1.0+incompatible
 	github.com/mobiledgex/yaml/v2 v2.2.4
 	github.com/modern-go/reflect2 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -302,6 +302,8 @@ github.com/mobiledgex/golang-ssh v0.0.1 h1:4Y2lgwrUHTKgAgijSUPRZpj93STVcWJzio5zt
 github.com/mobiledgex/golang-ssh v0.0.1/go.mod h1:lOpuGpjEhPMO4gxtlLkeC04vN+pB1xmZsYeQZWg0mMI=
 github.com/mobiledgex/golang-ssh v0.0.2 h1:7gdr5BYsttW9QKCf1uZB5f6IQvCI0uJ/wXkbS3SUBt0=
 github.com/mobiledgex/golang-ssh v0.0.2/go.mod h1:lOpuGpjEhPMO4gxtlLkeC04vN+pB1xmZsYeQZWg0mMI=
+github.com/mobiledgex/golang-ssh v0.0.3 h1:8F0IfpfmbKeuMpxJPyWTA2St8fXchDQkXrCTBFhbr4I=
+github.com/mobiledgex/golang-ssh v0.0.3/go.mod h1:lOpuGpjEhPMO4gxtlLkeC04vN+pB1xmZsYeQZWg0mMI=
 github.com/mobiledgex/yaml v2.1.0+incompatible h1:DCHKWrHE/SSObImB116B++3HK9Ndv5iW317wgJxpdyU=
 github.com/mobiledgex/yaml v2.1.0+incompatible/go.mod h1:GpldZ1HpZK00hDwW4RRAs958Yu26Kqyd1nMfztJrx8M=
 github.com/mobiledgex/yaml/v2 v2.2.3/go.mod h1:9xwjeLnIOTcA1fPBSAYKGRjeRy/bP/LnodFNfuZ9kqE=


### PR DESCRIPTION
For EDGECLOUD-839.  update to new version of golang-ssh 