### PR TITLE
DNS audit and delete tool

### DIFF
--- a/openstack-tenant/agent/cloudflare/dnsaudit/dnsaudit.go
+++ b/openstack-tenant/agent/cloudflare/dnsaudit/dnsaudit.go
@@ -78,7 +78,6 @@ func doAudit() error {
 	records, err := api.DNSRecords(zoneID, cloudflare.DNSRecord{Type: "A"})
 	for _, r := range records {
 		if reg.MatchString(r.Name) {
-			//	fmt.Printf("Found a DNS record %s matching %s\n", r.Name, *matchPattern)
 			recordsFound = append(recordsFound, r)
 		}
 	}


### PR DESCRIPTION
For EDGECLOUD-781:

Implement a simple tool to:
- print cloudflare DNS records matching a pattern
- optionally delete the matching records after confirmation 