### PR TITLE
EDGECLOUD-827 customizable registry

### DIFF
--- a/crm-platforms/azure/azure-appinst.go
+++ b/crm-platforms/azure/azure-appinst.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, flavor *edgeproto.Flavor, updateCallback edgeproto.CacheUpdateCallback) error {
@@ -23,6 +23,10 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	}
 
 	names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
+	if err != nil {
+		return err
+	}
+	err = mexos.CreateDockerRegistrySecret(client, clusterInst, app, s.config.VaultAddr)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/azure/azure-cluster.go
+++ b/crm-platforms/azure/azure-cluster.go
@@ -63,7 +63,7 @@ func (s *Platform) CreateClusterInst(clusterInst *edgeproto.ClusterInst, updateC
 		return err
 	}
 	log.DebugLog(log.DebugLevelMexos, "created aks", "name", clusterName)
-	return mexos.CreateDockerRegistrySecret(client, clusterInst)
+	return nil
 }
 
 func (s *Platform) DeleteClusterInst(clusterInst *edgeproto.ClusterInst) error {

--- a/crm-platforms/azure/azure.go
+++ b/crm-platforms/azure/azure.go
@@ -16,7 +16,8 @@ import (
 
 type Platform struct {
 	// AzureProperties should be moved to edge-cloud-infra
-	props edgeproto.AzureProperties
+	props  edgeproto.AzureProperties
+	config platform.PlatformConfig
 }
 
 func (s *Platform) GetType() string {
@@ -27,6 +28,7 @@ func (s *Platform) Init(platformConfig *platform.PlatformConfig) error {
 	if err := mexos.InitInfraCommon(platformConfig.VaultAddr); err != nil {
 		return err
 	}
+	s.config = *platformConfig
 	s.props.Location = os.Getenv("MEX_AZURE_LOCATION")
 	if s.props.Location == "" {
 		return fmt.Errorf("Env variable MEX_AZURE_LOCATION not set")

--- a/crm-platforms/gcp/gcp-appinst.go
+++ b/crm-platforms/gcp/gcp-appinst.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, flavor *edgeproto.Flavor, updateCallback edgeproto.CacheUpdateCallback) error {
@@ -23,6 +23,10 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	}
 
 	names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
+	if err != nil {
+		return err
+	}
+	err = mexos.CreateDockerRegistrySecret(client, clusterInst, app, s.config.VaultAddr)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/gcp/gcp-cluster.go
+++ b/crm-platforms/gcp/gcp-cluster.go
@@ -72,7 +72,7 @@ func (s *Platform) CreateClusterInst(clusterInst *edgeproto.ClusterInst, updateC
 		return err
 	}
 	log.DebugLog(log.DebugLevelMexos, "created gke", "name", clusterName)
-	return mexos.CreateDockerRegistrySecret(client, clusterInst)
+	return nil
 }
 
 func (s *Platform) DeleteClusterInst(clusterInst *edgeproto.ClusterInst) error {

--- a/crm-platforms/gcp/gcp.go
+++ b/crm-platforms/gcp/gcp.go
@@ -19,6 +19,7 @@ var GCPServiceAccount string //temp
 type Platform struct {
 	// GcpProperties needs to move to edge-cloud-infra
 	props        edgeproto.GcpProperties
+	config       platform.PlatformConfig
 	clusterCache *edgeproto.ClusterInstInfoCache
 }
 
@@ -46,6 +47,7 @@ func (s *Platform) Init(platformConfig *platform.PlatformConfig) error {
 	if err := mexos.InitInfraCommon(platformConfig.VaultAddr); err != nil {
 		return err
 	}
+	s.config = *platformConfig
 	s.props.Project = os.Getenv("MEX_GCP_PROJECT")
 	if s.props.Project == "" {
 		//default

--- a/crm-platforms/mexdind/mexdind-appinst.go
+++ b/crm-platforms/mexdind/mexdind-appinst.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, flavor *edgeproto.Flavor, updateCallback edgeproto.CacheUpdateCallback) error {
@@ -21,6 +21,10 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	}
 
 	names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
+	if err != nil {
+		return err
+	}
+	err = mexos.CreateDockerRegistrySecret(client, clusterInst, app, s.config.VaultAddr)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/mexdind/mexdind-cluster.go
+++ b/crm-platforms/mexdind/mexdind-cluster.go
@@ -23,10 +23,6 @@ func (s *Platform) CreateClusterInst(clusterInst *edgeproto.ClusterInst, updateC
 	}
 	clusterName := clusterInst.Key.ClusterKey.Name
 
-	err = mexos.CreateDockerRegistrySecret(client, clusterInst)
-	if err != nil {
-		return fmt.Errorf("cannot create mexreg secret for: %s, err: %v", clusterName, err)
-	}
 	err = mexos.CreateClusterConfigMap(client, clusterInst)
 	if err != nil {
 		return fmt.Errorf("cannot create ConfigMap for: %s, err: %v", clusterName, err)

--- a/crm-platforms/mexdind/mexdind.go
+++ b/crm-platforms/mexdind/mexdind.go
@@ -19,6 +19,7 @@ import (
 
 type Platform struct {
 	generic       dind.Platform
+	config        platform.PlatformConfig
 	NetworkScheme string
 }
 
@@ -28,6 +29,7 @@ func (s *Platform) GetType() string {
 
 func (s *Platform) Init(platformConfig *platform.PlatformConfig) error {
 	err := s.generic.Init(platformConfig)
+	s.config = *platformConfig
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/openstack/openstack.go
+++ b/crm-platforms/openstack/openstack.go
@@ -21,6 +21,7 @@ type Platform struct {
 	rootLB      *mexos.MEXRootLB
 	cloudletKey *edgeproto.CloudletKey
 	flavorList  []*edgeproto.FlavorInfo
+	config      platform.PlatformConfig
 }
 
 func (s *Platform) GetType() string {
@@ -30,6 +31,7 @@ func (s *Platform) GetType() string {
 func (s *Platform) Init(platformConfig *platform.PlatformConfig) error {
 	rootLBName := cloudcommon.GetRootLBFQDN(platformConfig.CloudletKey)
 	s.cloudletKey = platformConfig.CloudletKey
+	s.config = *platformConfig
 	log.DebugLog(
 		log.DebugLevelMexos, "init openstack",
 		"rootLB", rootLBName,

--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mobiledgex/edge-cloud/deploygen"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -45,14 +44,7 @@ func InitInfraCommon(vaultAddr string) error {
 	if CloudletInfraCommon.CfKey == "" {
 		return fmt.Errorf("Env variable MEX_CF_USER not set")
 	}
-	CloudletInfraCommon.DockerRegPass = os.Getenv("MEX_DOCKER_REG_PASS")
-	if CloudletInfraCommon.DockerRegPass == "" {
-		return fmt.Errorf("Env variable MEX_DOCKER_REG_PASS not set")
-	}
 	CloudletInfraCommon.DnsZone = "mobiledgex.net"
-	CloudletInfraCommon.DockerRegistry = deploygen.MexRegistry
-	CloudletInfraCommon.DockerRegistrySecret = deploygen.MexRegistrySecret
-
 	CloudletInfraCommon.RegistryFileServer = "registry.mobiledgex.net"
 	return nil
 }
@@ -128,14 +120,6 @@ func GetCloudletOSImage() string {
 	return OpenstackProps.OsImageName
 }
 
-func GetCloudletDockerRegistry() string {
-	return CloudletInfraCommon.DockerRegistry
-}
-
-func GetCloudletDockerRegistrySecret() string {
-	return CloudletInfraCommon.DockerRegistrySecret
-}
-
 func GetCloudletRegistryFileServer() string {
 	return CloudletInfraCommon.RegistryFileServer
 }
@@ -146,10 +130,6 @@ func GetCloudletCFKey() string {
 
 func GetCloudletCFUser() string {
 	return CloudletInfraCommon.CfUser
-}
-
-func GetCloudletDockerPass() string {
-	return CloudletInfraCommon.DockerRegPass
 }
 
 // GetCleanupOnFailure should be true unless we want to debug the failure,

--- a/mexos/cluster.go
+++ b/mexos/cluster.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -144,17 +145,11 @@ func CreateCluster(rootLBName string, clusterInst *edgeproto.ClusterInst, update
 	}
 
 	var err error
-	singleNodeCluster := false
-	if clusterInst.NumMasters == 0 {
-		if clusterInst.IpAccess == edgeproto.IpAccess_IP_ACCESS_DEDICATED {
-			//suitable for docker only
-			log.DebugLog(log.DebugLevelMexos, "creating single VM cluster with just rootLB and no k8s")
-			singleNodeCluster = true
-			updateCallback(edgeproto.UpdateTask, "Creating Dedicated VM for Docker")
-			err = HeatCreateRootLBVM(dedicatedRootLBName, k8smgmt.GetK8sNodeNameSuffix(&clusterInst.Key), clusterInst.NodeFlavor, updateCallback)
-		} else {
-			err = fmt.Errorf("NumMasters cannot be 0 for shared access")
-		}
+	if clusterInst.Deployment == cloudcommon.AppDeploymentTypeDocker {
+		//suitable for docker only
+		log.DebugLog(log.DebugLevelMexos, "creating single VM cluster with just rootLB and no k8s")
+		updateCallback(edgeproto.UpdateTask, "Creating Dedicated VM for Docker")
+		err = HeatCreateRootLBVM(dedicatedRootLBName, k8smgmt.GetK8sNodeNameSuffix(&clusterInst.Key), clusterInst.NodeFlavor, updateCallback)
 	} else {
 		err = HeatCreateClusterKubernetes(clusterInst, dedicatedRootLBName, updateCallback)
 	}
@@ -180,7 +175,7 @@ func CreateCluster(rootLBName string, clusterInst *edgeproto.ClusterInst, update
 	if err != nil {
 		return fmt.Errorf("can't get rootLB client, %v", err)
 	}
-	if !singleNodeCluster {
+	if clusterInst.Deployment == cloudcommon.AppDeploymentTypeKubernetes {
 		elapsed := time.Since(start)
 		// subtract elapsed time from total time to get remaining time
 		timeout -= elapsed
@@ -189,15 +184,7 @@ func CreateCluster(rootLBName string, clusterInst *edgeproto.ClusterInst, update
 		if err != nil {
 			return err
 		}
-	}
-	updateCallback(edgeproto.UpdateTask, "Updating Docker Credentials for cluster")
-	if err := SeedDockerSecret(client, clusterInst, singleNodeCluster); err != nil {
-		return err
-	}
-	if !singleNodeCluster {
-		if err := CreateDockerRegistrySecret(client, clusterInst); err != nil {
-			return err
-		}
+		updateCallback(edgeproto.UpdateTask, "Creating config map")
 		if err := CreateClusterConfigMap(client, clusterInst); err != nil {
 			return err
 		}

--- a/mexos/misc.go
+++ b/mexos/misc.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -36,40 +37,34 @@ func CopyFile(src string, dst string) error {
 	return nil
 }
 
-func SeedDockerSecret(client pc.PlatformClient, inst *edgeproto.ClusterInst, singleNode bool) error {
-	log.DebugLog(log.DebugLevelMexos, "seed docker secret", "singleNode", singleNode)
+func SeedDockerSecret(client pc.PlatformClient, inst *edgeproto.ClusterInst, app *edgeproto.App, vaultAddr string) error {
+	log.DebugLog(log.DebugLevelMexos, "seed docker secret")
 
-	if singleNode {
-		cmd := fmt.Sprintf("docker login %s -u %s -p %s", GetCloudletDockerRegistry(), "mobiledgex", GetCloudletDockerPass())
-		//TODO allow different docker registry as specified in the manifest
-		out, err := client.Output(cmd)
-		if err != nil {
-			return fmt.Errorf("can't docker login on rootlb to %s, %s, %v", GetCloudletDockerRegistry(), out, err)
-		}
-		return nil
-	}
-	_, masteraddr, err := GetMasterNameAndIP(inst)
+	auth, err := cloudcommon.GetRegistryAuth(app.ImagePath, vaultAddr)
 	if err != nil {
 		return err
 	}
-	var out string
-	cmd := fmt.Sprintf("echo %s > .docker-pass", GetCloudletDockerPass())
-	out, err = client.Output(cmd)
+	if auth.AuthType != cloudcommon.BasicAuth {
+		return fmt.Errorf("auth type for %s is not basic auth type", auth.Hostname)
+	}
+
+	// XXX: not sure writing password to file buys us anything if the
+	// echo command is recorded in some history.
+	cmd := fmt.Sprintf("echo %s > .docker-pass", auth.Password)
+	out, err := client.Output(cmd)
 	if err != nil {
 		return fmt.Errorf("can't store docker password, %s, %v", out, err)
 	}
 	log.DebugLog(log.DebugLevelMexos, "stored docker password")
-	cmd = fmt.Sprintf("scp -o %s -o %s -i id_rsa_mex .docker-pass %s:", sshOpts[0], sshOpts[1], masteraddr)
+	defer func() {
+		cmd := fmt.Sprintf("rm .docker-pass")
+		client.Output(cmd)
+	}()
+
+	cmd = fmt.Sprintf("cat .docker-pass | docker login -u %s --password-stdin %s ", auth.Username, auth.Hostname)
 	out, err = client.Output(cmd)
 	if err != nil {
-		return fmt.Errorf("can't copy docker password to k8s-master, %s, %v", out, err)
-	}
-	log.DebugLog(log.DebugLevelMexos, "copied over docker password")
-	cmd = fmt.Sprintf("ssh -o %s -o %s -i id_rsa_mex %s 'cat .docker-pass| docker login -u mobiledgex --password-stdin %s'", sshOpts[0], sshOpts[1], masteraddr, GetCloudletDockerRegistry())
-	//TODO allow different docker registry as specified in the manifest
-	out, err = client.Output(cmd)
-	if err != nil {
-		return fmt.Errorf("can't docker login on k8s-master to %s, %s, %v", GetCloudletDockerRegistry(), out, err)
+		return fmt.Errorf("can't docker login on rootlb to %s, %s, %v", auth.Hostname, out, err)
 	}
 	log.DebugLog(log.DebugLevelMexos, "docker login ok")
 	return nil


### PR DESCRIPTION
Infra portion of customizable registry. It is no longer assumed that the image is in docker.mobiledgex.net and that secrets come from env vars (which were coming from Vault, but only for docker.mobiledge.net). Instead, we pull secrets from Vault based on their registry hostname, so as long as the secrets exist in Vault, it can be any registry, mobiledgex or customer-owned.

Because of this, secrets in kubernetes cannot be populated during CreateClusterInst, because they are based on the App ImagePath. So secrets are now populated during CreateAppInst. Also cleaned up a bit of the docker secret which isn't needed for kubernetes.