### PR TITLE
wait for delete

### DIFF
--- a/crm-platforms/azure/azure-appinst.go
+++ b/crm-platforms/azure/azure-appinst.go
@@ -35,7 +35,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	case cloudcommon.AppDeploymentTypeKubernetes:
 		err = k8smgmt.CreateAppInst(client, names, app, appInst)
 		if err == nil {
-			err = k8smgmt.WaitForAppInst(client, names, app)
+			err = k8smgmt.WaitForAppInst(client, names, app, k8smgmt.WaitRunning)
 		}
 	default:
 		err = fmt.Errorf("unsupported deployment type %s", deployment)
@@ -88,11 +88,7 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 		return err
 	}
 
-	err = mexos.DeleteAppDNS(client, names)
-	if err != nil {
-		return err
-	}
-	return nil
+	return mexos.DeleteAppDNS(client, names)
 }
 
 func (s *Platform) SetupKconf(clusterInst *edgeproto.ClusterInst) error {

--- a/crm-platforms/gcp/gcp-appinst.go
+++ b/crm-platforms/gcp/gcp-appinst.go
@@ -35,7 +35,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	case cloudcommon.AppDeploymentTypeKubernetes:
 		err = k8smgmt.CreateAppInst(client, names, app, appInst)
 		if err == nil {
-			err = k8smgmt.WaitForAppInst(client, names, app)
+			err = k8smgmt.WaitForAppInst(client, names, app, k8smgmt.WaitRunning)
 		}
 	default:
 		err = fmt.Errorf("unsupported deployment type %s", deployment)
@@ -87,11 +87,7 @@ func (s *Platform) DeleteAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 		return err
 	}
 
-	err = mexos.DeleteAppDNS(client, names)
-	if err != nil {
-		return err
-	}
-	return nil
+	return mexos.DeleteAppDNS(client, names)
 }
 
 func SetupKconf(clusterInst *edgeproto.ClusterInst) error {

--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -55,7 +55,7 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 		// wait for the appinst in parallel with other tasks
 		go func() {
 			if deployment == cloudcommon.AppDeploymentTypeKubernetes {
-				waitErr := k8smgmt.WaitForAppInst(client, names, app)
+				waitErr := k8smgmt.WaitForAppInst(client, names, app, k8smgmt.WaitRunning)
 				if waitErr == nil {
 					appWaitChan <- ""
 				} else {


### PR DESCRIPTION
EDGECLOUD-877

See the edge-cloud portion for details.  This part is just to deal with the signature change for waitForAppinst.  As noted in the edge-cloud push, the wait for delete is done in a common place, unlike the wait for create