### PR TITLE
cleanup of cluster-svc args

### DIFF
--- a/e2e-tests/setups/local_dind.yml
+++ b/e2e-tests/setups/local_dind.yml
@@ -96,7 +96,6 @@ clustersvcs:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
   promports: "tcp:9090"
-  influxdb: "http://host.docker.internal:8086"
   interval: "5s"
   hostname: "127.0.0.1"
 


### PR DESCRIPTION
quick fix for local_dind that I forgot to make when i integrated shepherd, cluster svc no longer needs the influxdb address as prometheus doesn't use it.