### PR TITLE
Azure status updates

### DIFF
--- a/crm-platforms/azure/azure-appinst.go
+++ b/crm-platforms/azure/azure-appinst.go
@@ -12,10 +12,10 @@ import (
 )
 
 func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, flavor *edgeproto.Flavor, updateCallback edgeproto.CacheUpdateCallback) error {
-	var err error
-	// regenerate kconf if missing because CRM in container was restarted
 	updateCallback(edgeproto.UpdateTask, "Creating AppInst")
 
+	var err error
+	// regenerate kconf if missing because CRM in container was restarted
 	if err = s.SetupKconf(clusterInst); err != nil {
 		return fmt.Errorf("can't set up kconf, %s", err.Error())
 	}
@@ -49,7 +49,6 @@ func (s *Platform) CreateAppInst(clusterInst *edgeproto.ClusterInst, app *edgepr
 	if err != nil {
 		return err
 	}
-
 	updateCallback(edgeproto.UpdateTask, "Waiting for Load Balancer External IP")
 
 	// set up dns


### PR DESCRIPTION
For some demo appinst creations, we use Azure.  Currently there are no status callbacks for Azure app inst creation which makes for a less than ideal demo.  This PR just adds some.
