### PR TITLE
GCP login fix

### DIFF
--- a/crm-platforms/gcp/gcp-cluster.go
+++ b/crm-platforms/gcp/gcp-cluster.go
@@ -3,9 +3,7 @@ package gcp
 import (
 	"time"
 
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	sh "github.com/codeskyblue/go-sh"
@@ -14,19 +12,13 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
-	"github.com/mobiledgex/edge-cloud/vault"
 )
 
 // GCPLogin logs into google cloud
 func (s *Platform) GCPLogin() error {
 	log.DebugLog(log.DebugLevelMexos, "doing GcpLogin", "vault url", s.props.GcpAuthKeyUrl)
-	dat, err := vault.GetVaultData(s.props.GcpAuthKeyUrl)
-	if err != nil {
-		return err
-	}
-	databytes, err := json.Marshal(dat)
 	filename := "/tmp/auth_key.json"
-	err = ioutil.WriteFile(filename, databytes, 0644)
+	err := mexos.GetVaultDataToFile(s.props.GcpAuthKeyUrl, filename)
 	if err != nil {
 		return fmt.Errorf("unable to write auth file %s: %s", filename, err.Error())
 	}


### PR DESCRIPTION
EDGECLOUD-848

At some point pulling GCP login credentials from the vault got broken when the code that used to pull it into a struct with "data" got removed.  The "data" field is added automatically when pulling vault entries.
 
I'm fixing this by calling GetVaultDataToFile which accounts for the nested "data".    To make this work, I updated the GCP auth credentials in the vault to include an additional "data" tag because GetVaultDataToFile assumes there are 2 nested data tags: one for the actual vault entry, and one that the vault APIs add. 
