### PR TITLE
EDGECLOUD-907 DIND not starting for infra 

### DIFF
--- a/mexos/kubectl.go
+++ b/mexos/kubectl.go
@@ -20,7 +20,8 @@ func CreateDockerRegistrySecret(client pc.PlatformClient, clusterInst *edgeproto
 	log.DebugLog(log.DebugLevelMexos, "creating docker registry secret in kubernetes cluster")
 	auth, err := cloudcommon.GetRegistryAuth(app.ImagePath, vaultAddr)
 	if err != nil {
-		return err
+		log.DebugLog(log.DebugLevelMexos, "warning, cannot get docker registry secret from vault - assume public registry", "err", err)
+		return nil
 	}
 	if auth.AuthType != cloudcommon.BasicAuth {
 		return fmt.Errorf("auth type for %s is not basic auth type", auth.Hostname)


### PR DESCRIPTION
We currently bail our of the app creation when we cannot get secret from the vault for a registry where the app image resides. However the registry might be an open one accessible to everybody. To address this case I changed an error to a warning. 