### PR TITLE
influx measurement changes

### DIFF
--- a/shepherd/prom-stats_test.go
+++ b/shepherd/prom-stats_test.go
@@ -232,6 +232,6 @@ func TestPromStats(t *testing.T) {
 	// Check callback is called
 	ts, _ := types.TimestampProto(time.Now())
 	assert.Equal(t, int(0), testMetricSent)
-	testPromStats.send(ClusterStatToMetric(ts, testPromStats.clusterStat, testAppKey.operator, testAppKey.cloudlet, testAppKey.cluster))
+	testPromStats.send(ClusterStatToMetrics(ts, testPromStats)[0])
 	assert.Equal(t, int(1), testMetricSent)
 }

--- a/shepherd/shepherd.go
+++ b/shepherd/shepherd.go
@@ -137,8 +137,8 @@ func main() {
 	// get influxDB credentials from vault
 	influxAuth := cloudcommon.GetInfluxDataAuth(*vaultAddr, *region)
 	if influxAuth == nil {
-		// defeault to default user/pass
-		influxAuth = &cloudcommon.InfluxCreds{}
+		// default to default user/pass
+		influxAuth = &cloudcommon.InfluxCreds{User: "root", Pass: "root"}
 	}
 	influxQ = influxq.NewInfluxQ(InfluxDBName, influxAuth.User, influxAuth.Pass)
 	err = influxQ.Start(*influxdb, "")


### PR DESCRIPTION
Split up and organized the metrics being written into influx. Breaking up metrics to be separate measurements into influx allows for it to be much easier to add new ones in the future.