### PR TITLE
EU controller/cluster has been removed from mexdemo

### DIFF
--- a/terraform/mexplat/mexdemo/output.tf
+++ b/terraform/mexplat/mexdemo/output.tf
@@ -6,14 +6,6 @@ output "k8s_cluster_name" {
   value = "${var.cluster_name}"
 }
 
-output "eu_kube_config" {
-  value = "${module.k8s_eu.kube_config}"
-}
-
-output "eu_k8s_cluster_name" {
-  value = "${var.eu_cluster_name}"
-}
-
 output "k8s_clusters" {
   value = [
     {
@@ -21,10 +13,5 @@ output "k8s_clusters" {
       "kube_config" = "${module.k8s.kube_config}"
       "region" = "US"
     },
-    {
-      "name" = "${var.eu_cluster_name}"
-      "kube_config" = "${module.k8s_eu.kube_config}"
-      "region" = "EU"
-    }
   ]
 }


### PR DESCRIPTION
Looks like the EU cluster (which was hosting nothing) has been removed from mexdemo.