### PR TITLE
App role for Shepherd allowing access to InfluxDB creds

### DIFF
--- a/vault/setup.sh
+++ b/vault/setup.sh
@@ -89,3 +89,21 @@ vault write auth/approle/role/mexenv period="720h" policies="mexenv"
 # get mexenv app roleID and generate secretID
 vault read auth/approle/role/mexenv/role-id
 vault write -f auth/approle/role/mexenv/secret-id
+
+# shepherd approle
+# This has access to all influxdb accounts
+cat >/tmp/shepherd-pol.hcl <<EOF
+path "auth/approle/login" {
+  capabilities = [ "create", "read" ]
+}
+
+path "secret/data/+/accounts/influxdb" {
+  capabilities = [ "read" ]
+}
+EOF
+vault policy write shepherd /tmp/shepherd-pol.hcl
+rm /tmp/shepherd-pol.hcl
+vault write auth/approle/role/shepherd period="720h" policies="shepherd"
+# get shepherd app roleID and generate secretID
+vault read auth/approle/role/shepherd/role-id
+vault write -f auth/approle/role/shepherd/secret-id


### PR DESCRIPTION
Vault setup script changes to add an approle for shepherd.

Note that the `"secret/data/+/accounts/influxdb"` way of specifying a path (with the "+" wildcard) only works for the latest vault versions.  Our current main vault is of a much older version.  While creating this role manually there, I had to add two policies like this:

```
path "secret/data/US/accounts/influxdb" {
  capabilities = [ "read" ]
}

path "secret/data/EU/accounts/influxdb" {
  capabilities = [ "read" ]
}
```