### PR TITLE
fix tests

### DIFF
--- a/e2e-tests/e2e-setup/e2e-setup.go
+++ b/e2e-tests/e2e-setup/e2e-setup.go
@@ -151,7 +151,7 @@ func StartProcesses(processName string, outputDir string) bool {
 	}
 	for _, p := range Deployment.Shepherds {
 		opts = append(opts, process.WithRolesFile(rolesfile))
-		opts = append(opts, process.WithDebug("metrics"))
+		opts = append(opts, process.WithDebug("api,metrics"))
 		if !setupmex.StartLocal(processName, outputDir, p, opts...) {
 			return false
 		}

--- a/e2e-tests/int-process/process_local.go
+++ b/e2e-tests/int-process/process_local.go
@@ -291,11 +291,20 @@ func SetupVault(p *process.Vault, opts ...process.StartOp) (*VaultRoles, error) 
 		return nil, err
 	}
 
+	// run regional setup script
+	region := "local"
+	setup = gopath + "/src/github.com/mobiledgex/edge-cloud-infra/vault/setup-region.sh " + region
+	out = p.Run("/bin/sh", setup, &err)
+	if err != nil {
+		fmt.Println(out)
+		return nil, err
+	}
+
 	// get roleIDs and secretIDs
 	roles := VaultRoles{}
 	p.GetAppRole("", "mcorm", &roles.MCRoleID, &roles.MCSecretID, &err)
 	p.GetAppRole("", "rotator", &roles.RotatorRoleID, &roles.RotatorSecretID, &err)
-	p.GetAppRole("", "shepherd", &roles.ShepherdRoleID, &roles.ShepherdSecretID, &err)
+	p.GetAppRole(region, "shepherd", &roles.ShepherdRoleID, &roles.ShepherdSecretID, &err)
 	p.PutSecret("", "mcorm", mcormSecret+"-old", &err)
 	p.PutSecret("", "mcorm", mcormSecret, &err)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -382,7 +382,7 @@ replace github.com/pion/webrtc/v2 => github.com/pion/webrtc/v2 v2.0.7
 
 replace golang.org/x/text => golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
 
-replace github.com/uber/prototool => github.com/uber/prototool v1.8.0
+replace github.com/uber/prototool => github.com/uber/prototool v1.8.1
 
 replace github.com/pseudomuto/protoc-gen-doc => github.com/pseudomuto/protoc-gen-doc v1.3.0
 

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/uber/prototool v1.7.0/go.mod h1:0o3beySzHomA5oaVIGTR9z5lkPtjy4mbFuDpqIaNyT4=
 github.com/uber/prototool v1.8.0/go.mod h1:E+xJFE/vf87XeqHbKM4uGQMrJ7NyKQb0+G7NtqHBgYs=
+github.com/uber/prototool v1.8.1/go.mod h1:E+xJFE/vf87XeqHbKM4uGQMrJ7NyKQb0+G7NtqHBgYs=
 github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/vault/setup-region.sh
+++ b/vault/setup-region.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# exit immediately on failure (enable approle will fail if already enabled)
+set -e
+
+# Set up the profiles for the edge-cloud approles.
+# This assumes a global Vault for all regions, so paths in the Vault
+# are region-specific.
+# This script should be run for each new region that we bring online.
+
+# You may need to set the following env vars before running:
+# VAULT_ADDR=http://127.0.0.1:8200
+# VAULT_TOKEN=<my auth token>
+
+# Region should be set to the correct region name
+# REGION=local
+REGION=$1
+
+if [ -z "$REGION" ]; then
+    echo "Usage: setup-region.sh <region>"
+    exit 1
+fi
+echo "Setting up Vault region $REGION"
+
+# enable approle auth if not already enabled
+auths=$(vault auth list)
+case "$auths" in
+    *_"approle"_*) ;;
+    *) vault auth enable approle
+esac
+
+# shepherd approle
+# This has access to all influxdb accounts
+cat >/tmp/shepherd-pol.hcl <<EOF
+path "auth/approle/login" {
+  capabilities = [ "create", "read" ]
+}
+
+path "secret/data/$REGION/accounts/influxdb" {
+  capabilities = [ "read" ]
+}
+EOF
+vault policy write $REGION.shepherd /tmp/shepherd-pol.hcl
+rm /tmp/shepherd-pol.hcl
+vault write auth/approle/role/$REGION.shepherd period="720h" policies="$REGION.shepherd"
+# get shepherd app roleID and generate secretID
+vault read auth/approle/role/$REGION.shepherd/role-id
+vault write -f auth/approle/role/$REGION.shepherd/secret-id
+
+# generate secret string:
+# openssl rand -base64 128

--- a/vault/setup.sh
+++ b/vault/setup.sh
@@ -89,21 +89,3 @@ vault write auth/approle/role/mexenv period="720h" policies="mexenv"
 # get mexenv app roleID and generate secretID
 vault read auth/approle/role/mexenv/role-id
 vault write -f auth/approle/role/mexenv/secret-id
-
-# shepherd approle
-# This has access to all influxdb accounts
-cat >/tmp/shepherd-pol.hcl <<EOF
-path "auth/approle/login" {
-  capabilities = [ "create", "read" ]
-}
-
-path "secret/data/+/accounts/influxdb" {
-  capabilities = [ "read" ]
-}
-EOF
-vault policy write shepherd /tmp/shepherd-pol.hcl
-rm /tmp/shepherd-pol.hcl
-vault write auth/approle/role/shepherd period="720h" policies="shepherd"
-# get shepherd app roleID and generate secretID
-vault read auth/approle/role/shepherd/role-id
-vault write -f auth/approle/role/shepherd/secret-id


### PR DESCRIPTION
Shepherd was failing to start in e2e tests because of invalid vault perms. Added a regional script to set up shepherd access in vault based on region.