### PR TITLE
EDGECLOUD-919

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -382,7 +382,7 @@ replace github.com/pion/webrtc/v2 => github.com/pion/webrtc/v2 v2.0.7
 
 replace golang.org/x/text => golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
 
-replace github.com/uber/prototool => github.com/uber/prototool v1.8.0
+replace github.com/uber/prototool => github.com/uber/prototool v1.8.1
 
 replace github.com/pseudomuto/protoc-gen-doc => github.com/pseudomuto/protoc-gen-doc v1.3.0
 

--- a/go.sum
+++ b/go.sum
@@ -440,6 +440,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/uber/prototool v1.7.0/go.mod h1:0o3beySzHomA5oaVIGTR9z5lkPtjy4mbFuDpqIaNyT4=
 github.com/uber/prototool v1.8.0/go.mod h1:E+xJFE/vf87XeqHbKM4uGQMrJ7NyKQb0+G7NtqHBgYs=
+github.com/uber/prototool v1.8.1/go.mod h1:E+xJFE/vf87XeqHbKM4uGQMrJ7NyKQb0+G7NtqHBgYs=
 github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/mc/orm/gitlab.go
+++ b/mc/orm/gitlab.go
@@ -3,6 +3,7 @@ package orm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
@@ -96,13 +97,29 @@ func gitlabCreateGroup(org *ormapi.Organization) {
 		Path:       &name,
 		Visibility: gitlab.Visibility(gitlab.PrivateVisibility),
 	}
-	grp, _, err := gitlabClient.Groups.CreateGroup(&groupOpts)
+	// The "path" argument is used to access the group via a URL,
+	// and so is case-insensitive. If there is a case conflict,
+	// i.e. two orgs named "org1" and "Org1", modify the path so
+	// there is no conflict.
+	var err error
+	var grp *gitlab.Group
+	for ii := 0; ii < 20; ii++ {
+		log.DebugLog(log.DebugLevelApi, "gitlab create group", "data", groupOpts)
+		grp, _, err = gitlabClient.Groups.CreateGroup(&groupOpts)
+		if err != nil && strings.Contains(err.Error(), "path=>[\"has already been taken\"]") {
+			path := *groupOpts.Path + "_"
+			groupOpts.Path = &path
+			continue
+		}
+		break
+	}
 	if err != nil {
 		log.DebugLog(log.DebugLevelApi, "gitlab create group",
 			"org", org, "name", name, "err", err)
 		gitlabSync.NeedsSync()
 		return
 	}
+
 	attr := gitlab.CustomAttribute{
 		Key:   "createdby",
 		Value: GitlabMCTag,


### PR DESCRIPTION
Gitlab paths are urls so are case-insensitive, leading to conflicts between org names that are case sensitive. We don't really care about the paths, so tweak the path until there's no conflict.