### PR TITLE
fix test due to missing cluster developer

### DIFF
--- a/e2e-tests/data/mc_user2_data.yml
+++ b/e2e-tests/data/mc_user2_data.yml
@@ -140,6 +140,7 @@ regiondata:
             operatorkey:
               name: developer
             name: default
+          developer: Samsung
       liveness: LivenessStatic
       uri: default.samsungenablement.samsung.com
       flavor:


### PR DESCRIPTION
Fix a broken e2e test in infra due to missing developer name in cluster.