### PR TITLE
EDGECLOUD-1029 controllers can talk to each other under kubernetes

### DIFF
--- a/e2e-tests/setups/local_multi.yml
+++ b/e2e-tests/setups/local_multi.yml
@@ -56,7 +56,7 @@ etcds:
 controllers:
 - name: ctrl1
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
-  apiaddr: "0.0.0.0:55001"
+  apiaddr: "127.0.0.1:55001"
   httpaddr: "0.0.0.0:36001"
   notifyaddr: "127.0.0.1:37001"
   tls:
@@ -68,7 +68,7 @@ controllers:
 
 - name: ctrl2
   etcdaddrs: "http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003"
-  apiaddr: "0.0.0.0:55002"
+  apiaddr: "127.0.0.1:55002"
   httpaddr: "0.0.0.0:36002"
   notifyaddr: "127.0.0.1:37002"
   tls:

--- a/mc/mcctl/cliwrapper/cloudlet.mc2.go
+++ b/mc/mcctl/cliwrapper/cloudlet.mc2.go
@@ -28,6 +28,7 @@ func (s *Client) CreateCloudlet(uri, token string, in *ormapi.RegionCloudlet) ([
 	noconfig := strings.Split("Location.HorizontalAccuracy,Location.VerticalAccuracy,Location.Course,Location.Speed,Location.Timestamp,TimeLimits,Status", ",")
 	ops := []runOp{
 		withIgnore(noconfig),
+		withStreamOutIncremental(),
 	}
 	st, err := s.runObjs(uri, token, args, in, &outlist, ops...)
 	return outlist, st, err
@@ -51,6 +52,7 @@ func (s *Client) UpdateCloudlet(uri, token string, in *ormapi.RegionCloudlet) ([
 	noconfig := strings.Split("Location.HorizontalAccuracy,Location.VerticalAccuracy,Location.Course,Location.Speed,Location.Timestamp,TimeLimits,Status", ",")
 	ops := []runOp{
 		withIgnore(noconfig),
+		withStreamOutIncremental(),
 	}
 	st, err := s.runObjs(uri, token, args, in, &outlist, ops...)
 	return outlist, st, err

--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -179,6 +179,7 @@ var AppOptionalArgs = []string{
 	"scalewithcluster",
 	"internalports",
 	"officialfqdn",
+	"md5sum",
 }
 var AppAliasArgs = []string{
 	"developer=app.key.developerkey.name",
@@ -203,4 +204,5 @@ var AppAliasArgs = []string{
 	"internalports=app.internalports",
 	"revision=app.revision",
 	"officialfqdn=app.officialfqdn",
+	"md5sum=app.md5sum",
 }

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -23,14 +23,15 @@ var _ = math.Inf
 // Auto-generated code: DO NOT EDIT
 
 var CreateCloudletCmd = &Command{
-	Use:          "CreateCloudlet",
-	RequiredArgs: strings.Join(append([]string{"region"}, CloudletRequiredArgs...), " "),
-	OptionalArgs: strings.Join(CloudletOptionalArgs, " "),
-	AliasArgs:    strings.Join(CloudletAliasArgs, " "),
-	ReqData:      &ormapi.RegionCloudlet{},
-	ReplyData:    &edgeproto.Result{},
-	Path:         "/auth/ctrl/CreateCloudlet",
-	StreamOut:    true,
+	Use:                  "CreateCloudlet",
+	RequiredArgs:         strings.Join(append([]string{"region"}, CloudletRequiredArgs...), " "),
+	OptionalArgs:         strings.Join(CloudletOptionalArgs, " "),
+	AliasArgs:            strings.Join(CloudletAliasArgs, " "),
+	ReqData:              &ormapi.RegionCloudlet{},
+	ReplyData:            &edgeproto.Result{},
+	Path:                 "/auth/ctrl/CreateCloudlet",
+	StreamOut:            true,
+	StreamOutIncremental: true,
 }
 
 var DeleteCloudletCmd = &Command{
@@ -46,14 +47,15 @@ var DeleteCloudletCmd = &Command{
 }
 
 var UpdateCloudletCmd = &Command{
-	Use:          "UpdateCloudlet",
-	RequiredArgs: strings.Join(append([]string{"region"}, CloudletRequiredArgs...), " "),
-	OptionalArgs: strings.Join(CloudletOptionalArgs, " "),
-	AliasArgs:    strings.Join(CloudletAliasArgs, " "),
-	ReqData:      &ormapi.RegionCloudlet{},
-	ReplyData:    &edgeproto.Result{},
-	Path:         "/auth/ctrl/UpdateCloudlet",
-	StreamOut:    true,
+	Use:                  "UpdateCloudlet",
+	RequiredArgs:         strings.Join(append([]string{"region"}, CloudletRequiredArgs...), " "),
+	OptionalArgs:         strings.Join(CloudletOptionalArgs, " "),
+	AliasArgs:            strings.Join(CloudletAliasArgs, " "),
+	ReqData:              &ormapi.RegionCloudlet{},
+	ReplyData:            &edgeproto.Result{},
+	Path:                 "/auth/ctrl/UpdateCloudlet",
+	StreamOut:            true,
+	StreamOutIncremental: true,
 }
 
 var ShowCloudletCmd = &Command{


### PR DESCRIPTION
See https://github.com/mobiledgex/edge-cloud/pull/577

To pull from a registry with a port specified, it must be included in the docker-server string. Also only works in kubernetes 1.14+.

Changes to auto-generated files appear to be from some other previous changeset.