### PR TITLE
Remove shared Artifactory creds

### DIFF
--- a/ansible/development/group_vars/all
+++ b/ansible/development/group_vars/all
@@ -1,3 +1,5 @@
+mc_artifactory_apikey: FAKE
+crm_artifactory_apikey: FAKE
 crm_instances:
 
 - cloudlet_name: "{{ deploy_target }}-bonn-cloudlet"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -17,8 +17,6 @@ mc_api_port: 9900
 mc_api_internal_port: 19900
 mc_ldap_port: 9389
 postgres_server: postgres.mobiledgex.net:5432
-mc_artifactory_apikey: AKCp5cckWfoFRPDGNyyFkm49XtZxrMxLKknawYrT6KTCra3uuiTZtqgLgvbvccTNEXrEQSoyF
-crm_artifactory_apikey: AKCp5cckWfoFRPDGNyyFkm49XtZxrMxLKknawYrT6KTCra3uuiTZtqgLgvbvccTNEXrEQSoyF
 influxdb_name: monitoring-influxdb
 etcd_cluster_name: mex-etcd-cluster
 locapi_user: mexserver

--- a/ansible/staging/group_vars/all
+++ b/ansible/staging/group_vars/all
@@ -1,3 +1,5 @@
+mc_artifactory_apikey: FAKE
+crm_artifactory_apikey: FAKE
 crm_instances:
 
   - cloudlet_name: "{{ deploy_target }}-bonn-cloudlet"


### PR DESCRIPTION
Artifactory instances will not be shared any more.  There are two real
Artifactory instances--main and QA.  Staging and development will use a
fake Artifactory API implementation which is not ready yet.  For the
moment, staging and development have been configured with fake API keys.