### PR TITLE
EDGECLOUD-590 log tracing from mc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	google.golang.org/grpc v1.21.0
 	gopkg.in/ldap.v3 v3.0.3
 	gopkg.in/yaml.v2 v2.2.2
+	grpc.go4.org v0.0.0-20170609214715-11d0a25b4919
 	//	k8s.io/api v0.0.0-20190327184913-92d2ee7fc726
 	k8s.io/api v0.0.0-20190222213804-5cb15d344471
 	k8s.io/apimachinery v0.0.0-20190402064448-91ffda0f6be2

--- a/go.sum
+++ b/go.sum
@@ -668,6 +668,7 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+grpc.go4.org v0.0.0-20170609214715-11d0a25b4919 h1:tmXTu+dfa+d9Evp8NpJdgOy6+rt8/x4yG7qPBrtNfLY=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/mc/mc.go
+++ b/mc/mc.go
@@ -32,6 +32,9 @@ var sigChan chan os.Signal
 func main() {
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
+	log.InitTracer()
+	defer log.FinishTracer()
+
 	sigChan = make(chan os.Signal, 1)
 
 	config := orm.ServerConfig{

--- a/mc/orm/alldata_test.go
+++ b/mc/orm/alldata_test.go
@@ -19,6 +19,8 @@ import (
 
 func TestAllData(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelApi)
+	log.InitTracer()
+	defer log.FinishTracer()
 	addr := "127.0.0.1:9999"
 	uri := "http://" + addr + "/api/v1"
 

--- a/mc/orm/echo_context.go
+++ b/mc/orm/echo_context.go
@@ -1,0 +1,28 @@
+package orm
+
+import (
+	"context"
+
+	"github.com/labstack/echo"
+)
+
+type EchoContext struct {
+	echo.Context
+	ctx context.Context
+}
+
+func NewEchoContext(c echo.Context, ctx context.Context) *EchoContext {
+	ec := EchoContext{
+		Context: c,
+		ctx:     ctx,
+	}
+	return &ec
+}
+
+func GetContext(c echo.Context) context.Context {
+	ec, ok := c.(*EchoContext)
+	if !ok {
+		panic("auditlog.go logger func should have wrapped echo.Context with EchoContext")
+	}
+	return ec.ctx
+}

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -331,8 +331,8 @@ func waitServerOnline(addr string) error {
 func dumpTables() {
 	users := []ormapi.User{}
 	orgs := []ormapi.Organization{}
-	db.Find(&users)
-	db.Find(&orgs)
+	database.Find(&users)
+	database.Find(&orgs)
 	for _, user := range users {
 		fmt.Printf("%v\n", user)
 	}

--- a/mc/orm/userauth.go
+++ b/mc/orm/userauth.go
@@ -98,24 +98,27 @@ func GenerateCookie(user *ormapi.User) (string, error) {
 
 func getClaims(c echo.Context) (*UserClaims, error) {
 	user := c.Get("user")
+	ctx := GetContext(c)
 	if user == nil {
-		log.DebugLog(log.DebugLevelApi, "get claims: no user")
+		log.SpanLog(ctx, log.DebugLevelApi, "get claims: no user")
 		return nil, echo.ErrUnauthorized
 	}
 	token, ok := user.(*jwt.Token)
 	if !ok {
-		log.DebugLog(log.DebugLevelApi, "get claims: no token")
+		log.SpanLog(ctx, log.DebugLevelApi, "get claims: no token")
 		return nil, echo.ErrUnauthorized
 	}
 	claims, ok := token.Claims.(*UserClaims)
 	if !ok {
-		log.DebugLog(log.DebugLevelApi, "get claims: bad claims type")
+		log.SpanLog(ctx, log.DebugLevelApi, "get claims: bad claims type")
 		return nil, echo.ErrUnauthorized
 	}
 	if claims.Username == "" {
-		log.DebugLog(log.DebugLevelApi, "get claims: bad claims content")
+		log.SpanLog(ctx, log.DebugLevelApi, "get claims: bad claims content")
 		return nil, echo.ErrUnauthorized
 	}
+	span := log.SpanFromContext(ctx)
+	span.SetTag("username", claims.Username)
 	return claims, nil
 }
 


### PR DESCRIPTION
More changes for trace logging.
- Add span logging for MC audit logs
- Forwards span log to Controller APIs as grpc metadata (code is in edge-cloud repo, but look at ctrl.go where it adds interceptors to grpc.Dial command). So in Jaeger UI trace contains spans from MC -> Controller
- Converts many DebugLog calls to SpanLog calls (have to pass ctx around everywhere)
- To pass span context to echo handler functions, wrapped echo.Context in EchoContext (see echo_context.go)

Still needed:
- MC API (command) to show audit logs from Jaeger, filtered by Org/User.
- convert more DebugLog calls to SpanLog calls (more so in edge-cloud)