### PR TITLE
EC-796 app port range gen new AppInstAliasArgs[] entry endport

### DIFF
--- a/mc/mcctl/ormctl/app_inst.mc2.go
+++ b/mc/mcctl/ormctl/app_inst.mc2.go
@@ -140,6 +140,7 @@ var AppInstAliasArgs = []string{
 	"mappedports.publicport=appinst.mappedports.publicport",
 	"mappedports.pathprefix=appinst.mappedports.pathprefix",
 	"mappedports.fqdnprefix=appinst.mappedports.fqdnprefix",
+	"mappedports.endport=appinst.mappedports.endport",
 	"flavor.name=appinst.flavor.name",
 	"state=appinst.state",
 	"errors=appinst.errors",


### PR DESCRIPTION
Only a single auto gen'ed file in infra. See PR #582 in edge-cloud for details.