### PR TITLE
EDGECLOUD-590 mc audit api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,12 +19,13 @@ require (
 	github.com/fsouza/go-dockerclient v1.3.6
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/googleapis v1.0.0
-	github.com/gogo/protobuf v1.2.0
+	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.1
 	github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42
 	github.com/gophercloud/gophercloud v0.0.0-20190330013820-4d3066f119fa
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5
 	github.com/influxdata/influxdb v1.6.2
+	github.com/jaegertracing/jaeger v1.13.1
 	github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 // indirect
 	github.com/jinzhu/gorm v1.9.1
 	github.com/json-iterator/go v1.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/gogo/protobuf v1.0.0 h1:2jyBKDKU/8v3v2xVR2PtiWQviFUyiaGk2rpfyFT8rTM=
 github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
+github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
@@ -235,6 +237,8 @@ github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.6.2 h1:Cvl0/3n7/T6RkCefitJtEHWKJznmOA+9tT8gVx3vVS0=
 github.com/influxdata/influxdb v1.6.2/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
+github.com/jaegertracing/jaeger v1.13.1 h1:vvub5of4Bc2yze5q+qvqjipO3UkeDPr1YUJfNFw4y2s=
+github.com/jaegertracing/jaeger v1.13.1/go.mod h1:LUWPSnzNPGRubM8pk0inANGitpiMOOxihXx0+53llXI=
 github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 h1:EFT6MH3igZK/dIVqgGbTqWVvkZ7wJ5iGN03SVtvvdd8=
 github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25/go.mod h1:sWkGw/wsaHtRsT9zGQ/WyJCotGWG/Anow/9hsAcBWRw=
 github.com/jefferai/jsonx v1.0.0/go.mod h1:OGmqmi2tTeI/PS+qQfBDToLHHJIy/RMp24fPo8vFvoQ=
@@ -261,6 +265,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/keybase/go-crypto v0.0.0-20190403132359-d65b6b94177f/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
+github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=

--- a/mc/mc.go
+++ b/mc/mc.go
@@ -24,6 +24,7 @@ var localVault = flag.Bool("localVault", false, "Run local Vault")
 var ldapAddr = flag.String("ldapAddr", "127.0.0.1:9389", "LDAP listener address")
 var gitlabAddr = flag.String("gitlabAddr", "http://127.0.0.1:80", "Gitlab server address")
 var artifactoryAddr = flag.String("artifactoryAddr", "http://127.0.0.1:80", "Artifactory server address")
+var jaegerAddr = flag.String("jaegerAddr", "127.0.0.1:16686", "Jaeger server address")
 var pingInterval = flag.Duration("pingInterval", 20*time.Second, "SQL database ping keep-alive interval")
 var skipVerifyEmail = flag.Bool("skipVerifyEmail", false, "skip email verification, for testing only")
 
@@ -52,6 +53,7 @@ func main() {
 		ClientCert:      *clientCert,
 		PingInterval:    *pingInterval,
 		SkipVerifyEmail: *skipVerifyEmail,
+		JaegerAddr:      *jaegerAddr,
 	}
 	server, err := orm.RunServer(&config)
 	if err != nil {

--- a/mc/mcctl/mcctl.go
+++ b/mc/mcctl/mcctl.go
@@ -25,6 +25,7 @@ func main() {
 	regionCmds.AddCommand(ormctl.GetRunCommandCmd())
 	rootCmd.AddCommand(regionCmds)
 	rootCmd.AddCommand(ormctl.GetConfigCommand())
+	rootCmd.AddCommand(ormctl.GetAuditCommand())
 
 	rootCmd.PersistentFlags().StringVar(&ormctl.Addr, "addr", "http://127.0.0.1:9900", "MC address")
 	rootCmd.PersistentFlags().StringVar(&ormctl.Token, "token", "", "JWT token")

--- a/mc/mcctl/ormctl/audit.go
+++ b/mc/mcctl/ormctl/audit.go
@@ -1,0 +1,24 @@
+package ormctl
+
+import (
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/spf13/cobra"
+)
+
+func GetAuditCommand() *cobra.Command {
+	cmds := []*Command{&Command{
+		Use:          "showself",
+		OptionalArgs: "limit",
+		ReqData:      &ormapi.AuditQuery{},
+		ReplyData:    &[]ormapi.AuditResponse{},
+		Path:         "/auth/audit/showself",
+	}, &Command{
+		Use:          "showorg",
+		RequiredArgs: "org",
+		OptionalArgs: "limit",
+		ReqData:      &ormapi.AuditQuery{},
+		ReplyData:    &[]ormapi.AuditResponse{},
+		Path:         "/auth/audit/showorg",
+	}}
+	return genGroup("audit", "show audit logs", cmds)
+}

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -235,7 +235,7 @@ var PlatformConfigOptionalArgs = []string{
 	"crmroleid",
 	"crmsecretid",
 	"platformtag",
-	"influxaddr",
+	"testmode",
 }
 var PlatformConfigAliasArgs = []string{
 	"registrypath=platformconfig.registrypath",
@@ -246,7 +246,7 @@ var PlatformConfigAliasArgs = []string{
 	"crmroleid=platformconfig.crmroleid",
 	"crmsecretid=platformconfig.crmsecretid",
 	"platformtag=platformconfig.platformtag",
-	"influxaddr=platformconfig.influxaddr",
+	"testmode=platformconfig.testmode",
 }
 var CloudletRequiredArgs = []string{
 	"operator",

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/util"
 )
 
@@ -26,6 +27,9 @@ func CreateOrg(c echo.Context) error {
 	if err := c.Bind(&org); err != nil {
 		return c.JSON(http.StatusBadRequest, Msg("Invalid POST data"))
 	}
+	span := log.SpanFromContext(ctx)
+	span.SetTag("org", org.Name)
+
 	err = CreateOrgObj(ctx, claims, &org)
 	return setReply(c, err, Msg("Organization created"))
 }
@@ -88,6 +92,9 @@ func DeleteOrg(c echo.Context) error {
 	if err := c.Bind(&org); err != nil {
 		return c.JSON(http.StatusBadRequest, Msg("Invalid POST data"))
 	}
+	span := log.SpanFromContext(ctx)
+	span.SetTag("org", org.Name)
+
 	err = DeleteOrgObj(ctx, claims, &org)
 	return setReply(c, err, Msg("Organization deleted"))
 }

--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -234,6 +234,10 @@ func AddUserRoleObj(ctx context.Context, claims *UserClaims, role *ormapi.Role) 
 	if role.Role == "" {
 		return fmt.Errorf("Role not specified")
 	}
+	if role.Org != "" {
+		span := log.SpanFromContext(ctx)
+		span.SetTag("org", role.Org)
+	}
 	// check that user/org/role exists
 	targetUser := ormapi.User{}
 	db := loggedDB(ctx)
@@ -322,6 +326,10 @@ func RemoveUserRoleObj(ctx context.Context, claims *UserClaims, role *ormapi.Rol
 	}
 	if role.Role == "" {
 		return fmt.Errorf("Role not specified")
+	}
+	if role.Org != "" {
+		span := log.SpanFromContext(ctx)
+		span.SetTag("org", role.Org)
 	}
 
 	// Special case: if policy does not exist, return success.

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -48,6 +48,7 @@ type ServerConfig struct {
 	ClientCert      string
 	PingInterval    time.Duration
 	SkipVerifyEmail bool
+	JaegerAddr      string
 }
 
 var DefaultDBUser = "mcuser"
@@ -222,6 +223,8 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	auth.POST("/config/show", ShowConfig)
 	auth.POST("/config/version", ShowVersion)
 	auth.POST("/restricted/user/update", RestrictedUserUpdate)
+	auth.POST("/audit/showself", ShowAuditSelf)
+	auth.POST("/audit/showorg", ShowAuditOrg)
 	addControllerApis(auth)
 	// Metrics api route use auth to serve a query to influxDB
 	auth.POST("/metrics/app", GetMetricsCommon)

--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -209,6 +209,9 @@ func VerifyEmail(c echo.Context) error {
 		// user got deleted in the meantime?
 		return nil
 	}
+	span := log.SpanFromContext(ctx)
+	span.SetTag("username", user.Name)
+
 	user.EmailVerified = true
 	if err := db.Model(&user).Updates(&user).Error; err != nil {
 		return setReply(c, dbErr(err), nil)
@@ -434,6 +437,9 @@ func PasswordReset(c echo.Context) error {
 			Internal: err,
 		}
 	}
+	ctx := GetContext(c)
+	span := log.SpanFromContext(ctx)
+	span.SetTag("username", claims.Username)
 	return setPassword(c, claims.Username, pw.Password)
 }
 

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -76,6 +76,25 @@ type CreateUser struct {
 	Verify EmailRequest `json:"verify"` // for verifying email
 }
 
+type AuditQuery struct {
+	Username string `json:"username"`
+	Org      string `form:"org" json:"org"`
+	Limit    int    `json:"limit"`
+}
+
+type AuditResponse struct {
+	OperationName string               `json:"operationname"`
+	Username      string               `json:"username"`
+	ClientIP      string               `json:"clientip"`
+	Status        int                  `json:"status"`
+	StartTime     TimeMicroseconds     `json:"starttime"`
+	Duration      DurationMicroseconds `json:"duration"`
+	Request       string               `json:"request"`
+	Response      string               `json:"response"`
+	Error         string               `json:"error"`
+	TraceID       string               `json:"traceid"`
+}
+
 // Email request is used for password reset and to resend welcome
 // verification email. It contains the information need to send
 // some kind of email to the user.

--- a/mc/ormapi/time.go
+++ b/mc/ormapi/time.go
@@ -1,0 +1,78 @@
+package ormapi
+
+import (
+	"strconv"
+	"time"
+)
+
+// microseconds since unix epoch
+type TimeMicroseconds uint64
+type DurationMicroseconds uint64
+
+const (
+	Second      int64 = 1
+	Millisecond       = 1000 * Second
+	Microsecond       = 1000 * Millisecond
+	Nanosecond        = 1000 * Microsecond
+)
+
+// It is intentional to not define custom marshalers for JSON.
+// This is so JSON data returned by MC to clients (UI, mcctl, etc)
+// remains in it's original form. It is up to the client to
+// transform the original data into a displayable format consumable
+// by the user. The backend should not do any such transformation.
+// If the client needs a JSON transformation, it will need to define
+// it's own struct type with custom marshalers.
+
+func (s *TimeMicroseconds) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	if err != nil {
+		return err
+	}
+	i, err := strconv.ParseUint(str, 10, 64)
+	if err == nil {
+		*s = TimeMicroseconds(i)
+		return nil
+	}
+	tt := time.Time{}
+	err = tt.UnmarshalText([]byte(str))
+	if err != nil {
+		return err
+	}
+	*s = TimeMicroseconds(tt.Second() * int(Microsecond))
+	*s = *s + TimeMicroseconds((tt.Nanosecond()%int(Nanosecond))/1000)
+	return nil
+}
+
+func (s TimeMicroseconds) MarshalYAML() (interface{}, error) {
+	sec := int64(s) / int64(Microsecond)
+	nsec := (int64(s) % int64(Microsecond)) * int64(1000)
+	tt := time.Unix(sec, nsec)
+	byt, err := tt.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return string(byt), nil
+}
+
+func (s *DurationMicroseconds) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	err := unmarshal(&str)
+	i, err := strconv.ParseUint(str, 10, 64)
+	if err == nil {
+		*s = DurationMicroseconds(i)
+		return nil
+	}
+	dur, err := time.ParseDuration(str)
+	if err != nil {
+		return err
+	}
+	*s = DurationMicroseconds(dur.Nanoseconds() / 1000)
+	return nil
+}
+
+func (s DurationMicroseconds) MarshalYAML() (interface{}, error) {
+	dur := time.Duration(s * 1000)
+	return dur.String(), nil
+}


### PR DESCRIPTION
This adds an MC API to query audit logs. It does this by connecting to Jaeger (via REST http call) and pulling "audit" spans. It then filters out sub-spans and fills in the info to show the user.

This API is for customers who want to see an audit log of the commands they issued, or that were issued against an Organization they manage. There are two apis, showself to see commands the current user ran, and showorg, to show commands run against a target org. Example output is below:

```
➜  mcctl audit showself
- operationname: /api/v1/auth/ctrl/CreateAppInst
  username: mexadmin
  clientip: 127.0.0.1
  status: 200
  starttime: "2019-08-01T14:01:15.42768-07:00"
  duration: 66.988ms
  request: '{"appinst":{"key":{"app_key":{"developer_key":{"name":"dev1"},"name":"myapp","version":"1.0.0"},"cluster_inst_key":{"cloudlet_key":{"name":"jon-berlin","operator_key":{"name":"TDG"}},"cluster_key":{"name":"jon-clust"}}}},"region":"local"}'
  response: |
    {"data":{"message":"Setting ClusterInst developer to match App developer"}}
    {"data":{"message":"Creating"}}
    {"data":{"message":"Ready"}}
    {"data":{"message":"Created successfully"}}
  traceid: 65c9286d05713eec
- operationname: /api/v1/auth/ctrl/CreateApp
  username: mexadmin
  clientip: 127.0.0.1
  status: 200
  starttime: "2019-08-01T14:01:08.371151-07:00"
  duration: 112.864ms
  request: '{"app":{"access_ports":"tcp:7777","default_flavor":{"name":"x1.medium"},"image_path":"docker.mobiledgex.net/mobiledgex/images/mobiledgexsdkdemo","image_type":1,"key":{"developer_key":{"name":"dev1"},"name":"myapp","version":"1.0.0"}},"region":"local"}'
  response: '{}'
  traceid: 7d4bbb70e96cf512
- operationname: /api/v1/auth/ctrl/DeleteApp
  username: mexadmin
  clientip: 127.0.0.1
  status: 200
  starttime: "2019-08-01T14:00:59.826424-07:00"
  duration: 9.281ms
  request: '{"app":{"key":{"developer_key":{"name":"dev1"},"name":"myapp","version":"1.0.0"}},"region":"local"}'
  response: '{}'
  traceid: 68d2c27694405ff9
- operationname: /api/v1/auth/ctrl/CreateApp
  username: mexadmin
  clientip: 127.0.0.1
  status: 400
  starttime: "2019-08-01T14:00:07.709926-07:00"
  duration: 451.763ms
  request: '{"app":{"access_ports":"tcp:7777","default_flavor":{"name":"x1.medium"},"image_path":"docker.mobiledgex.net/mobiledgex/images/mobiledgexsdkdemo","image_type":1,"key":{"developer_key":{"name":"dev1"},"name":"myapp","version":"1.0.0"}},"region":"local"}'
  response: '{"message":"Key already exists"}'
  traceid: 243ddcea15e710b4
```

Note the traceid is also displayed. The intent is that if a customer is having a problem doing something, they can provide us the traceid, and we can look up the associated full trace (all spans and logs) in the Jaeger UI. So standard customer support practice would be to ask for the audit log output of the command that failed, and then log that in the bug report.

I also disabled show command logging again, it was annoying and not useful.

Still TODO is e2e tests.