### PR TITLE
EDGECLOUD-1083: MC/Artifactory User not being added to org in Artifactory

### DIFF
--- a/mc/orm/artifactory_sync.go
+++ b/mc/orm/artifactory_sync.go
@@ -142,7 +142,7 @@ func (s *AppStoreSync) syncGroupUsers(ctx context.Context) {
 		if _, ok := groupMembers[role.Username]; !ok {
 			groupMembers[role.Username] = map[string]*ormapi.Role{}
 		}
-		groupMembers[role.Username][role.Org] = role
+		groupMembers[role.Username][getArtifactoryName(role.Org)] = role
 	}
 
 	// Get Artifactory users


### PR DESCRIPTION
While checking for extra/missing user groups, prefix addition was not handled. Added the code to fix this.