### PR TITLE
EDGECLOUD-1094 viewers should not be able to upload gitlab images

### DIFF
--- a/e2e-tests/data/mc_user2_data.yml
+++ b/e2e-tests/data/mc_user2_data.yml
@@ -127,21 +127,3 @@ regiondata:
       liveness: LivenessStatic
       flavor:
         name: x1.small
-    - key:
-        appkey:
-          developerkey:
-            name: Samsung
-          name: SamsungEnablingLayer
-          version: "1.0"
-        clusterinstkey:
-          clusterkey:
-            name: default
-          cloudletkey:
-            operatorkey:
-              name: developer
-            name: default
-          developer: Samsung
-      liveness: LivenessStatic
-      uri: default.samsungenablement.samsung.com
-      flavor:
-        name: x1.small

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -317,28 +317,6 @@ regiondata:
     - key:
         appkey:
           developerkey:
-            name: Samsung
-          name: SamsungEnablingLayer
-          version: "1.0"
-        clusterinstkey:
-          clusterkey:
-            name: default
-          cloudletkey:
-            operatorkey:
-              name: developer
-            name: default
-          developer: Samsung
-      uri: default.samsungenablement.samsung.com
-      liveness: LivenessStatic
-      mappedports:
-      - proto: LProtoTcp
-        internalport: 64000
-      flavor:
-        name: x1.small
-      state: Ready
-    - key:
-        appkey:
-          developerkey:
             name: AcmeAppCo
           name: someapplication1
           version: "1.0"

--- a/mc/orm/gitlab.go
+++ b/mc/orm/gitlab.go
@@ -54,6 +54,7 @@ func gitlabCreateLDAPUser(ctx context.Context, user *ormapi.User) {
 	// generate long random password for LDAP users, effectively disabling it
 	pw := string(util.RandAscii(128))
 	_true := true
+	_false := false
 	opts := gitlab.CreateUserOptions{
 		Email:            &user.Email,
 		Name:             &user.Name,
@@ -62,6 +63,7 @@ func gitlabCreateLDAPUser(ctx context.Context, user *ormapi.User) {
 		Provider:         &LDAPProvider,
 		Password:         &pw,
 		SkipConfirmation: &_true,
+		CanCreateGroup:   &_false,
 	}
 	_, _, err := gitlabClient.Users.CreateUser(&opts)
 	if err != nil {
@@ -156,7 +158,7 @@ func gitlabAddGroupMember(ctx context.Context, role *ormapi.Role) {
 	if enforcer.Enforce(role.Username, role.Org, ResourceUsers, ActionManage) {
 		access = gitlab.AccessLevel(gitlab.OwnerPermissions)
 	} else {
-		access = gitlab.AccessLevel(gitlab.MaintainerPermissions)
+		access = gitlab.AccessLevel(gitlab.ReporterPermissions)
 	}
 	opts := gitlab.AddGroupMemberOptions{
 		UserID:      &user.ID,


### PR DESCRIPTION
Fix gitlab viewer role so they can't upload images. Also make it so users (any user) cannot create new groups. That should be the domain of admins only. 

Also includes fix for infra e2e tests from changes for official fqdn.

Note there are still problems here where a user could set the image path (if they somehow knew it) to that of a different organization's image. The CRM pulls with admin privileges, so it's possible for one org to create an app using another org's image by specifying it in the imagepath (or in the kubernetes manifest/docker compose file). I'm not sure what the solution is for that, but we'll need something eventually.
