### PR TITLE
implement updateAppInst for azure and gcp

### DIFF
--- a/crm-platforms/gcp/gcp-appinst.go
+++ b/crm-platforms/gcp/gcp-appinst.go
@@ -113,7 +113,22 @@ func SetupKconf(clusterInst *edgeproto.ClusterInst) error {
 }
 
 func (s *Platform) UpdateAppInst(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, updateCallback edgeproto.CacheUpdateCallback) error {
-	return fmt.Errorf("Update not yet supported for GCP AppInst")
+	updateCallback(edgeproto.UpdateTask, "Updating GCP AppInst")
+	names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
+	if err != nil {
+		return err
+	}
+	client, err := s.GetPlatformClient(clusterInst)
+	if err != nil {
+		return err
+	}
+
+	err = k8smgmt.UpdateAppInst(client, names, app, appInst)
+	if err == nil {
+		updateCallback(edgeproto.UpdateTask, "Waiting for AppInst to Start")
+		err = k8smgmt.WaitForAppInst(client, names, app, k8smgmt.WaitRunning)
+	}
+	return err
 }
 
 func (s *Platform) GetAppInstRuntime(clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) (*edgeproto.AppInstRuntime, error) {


### PR DESCRIPTION
This is the last stage of appInst update from the platform side: support of Azure and GCP