### PR TITLE
Restart nginx after cert renewal (follow-up)

### DIFF
--- a/ansible/roles/web/files/nginx_reload_hook
+++ b/ansible/roles/web/files/nginx_reload_hook
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl reload nginx

--- a/ansible/roles/web/files/nginx_restart_hook
+++ b/ansible/roles/web/files/nginx_restart_hook
@@ -1,2 +1,0 @@
-#!/bin/bash
-systemctl restart nginx

--- a/ansible/roles/web/tasks/certs.yml
+++ b/ansible/roles/web/tasks/certs.yml
@@ -33,8 +33,8 @@
 
 - name: Install nginx post-renewal hook
   copy:
-    src: nginx_restart_hook
-    dest: "{{ letsencrypt_renewal_hooks_dir }}/post/nginx_restart_hook"
+    src: nginx_reload_hook
+    dest: "{{ letsencrypt_renewal_hooks_dir }}/post/nginx_reload_hook"
     owner: root
     group: root
     mode: 0755


### PR DESCRIPTION
Use reload instead of restart to avoid disrupting existing connections