### PR TITLE
EC-796 autogen'd AliasArgs for new endport

### DIFF
--- a/mc/mcctl/ormctl/app_inst.mc2.go
+++ b/mc/mcctl/ormctl/app_inst.mc2.go
@@ -139,6 +139,7 @@ var AppInstAliasArgs = []string{
 	"mappedports.publicport=appinst.mappedports.publicport",
 	"mappedports.pathprefix=appinst.mappedports.pathprefix",
 	"mappedports.fqdnprefix=appinst.mappedports.fqdnprefix",
+	"mappedports.endport=appinst.mappedports.endport",
 	"flavor.name=appinst.flavor.name",
 	"state=appinst.state",
 	"errors=appinst.errors",


### PR DESCRIPTION
A single auto gen'ed mod, from the addition of end_port to the AppPort. See Edge-Cloud PR 599 for details.