### PR TITLE
EDGECLOUD-523  Vault plugin frontend for letsencrypt certs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,12 +18,14 @@ require (
 	github.com/elazarl/goproxy/ext v0.0.0-20190410145444-c548f45dcf1d // indirect
 	github.com/fsouza/go-dockerclient v1.3.6
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-resty/resty/v2 v2.0.0
 	github.com/gogo/googleapis v1.0.0
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.1
 	github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42
 	github.com/gophercloud/gophercloud v0.0.0-20190330013820-4d3066f119fa
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5
+	github.com/hashicorp/vault v0.11.5
 	github.com/influxdata/influxdb v1.6.2
 	github.com/jaegertracing/jaeger v1.13.1
 	github.com/jarcoal/httpmock v1.0.4
@@ -49,6 +51,7 @@ require (
 	github.com/parnurzeal/gorequest v0.2.15
 	github.com/pelletier/go-toml v1.3.0
 	github.com/pion/webrtc/v2 v2.0.24
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.1
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spf13/cobra v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMo
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/SAP/go-hdb v0.14.1/go.mod h1:7fdQLVC2lER3urZLjZCm0AuMQfApof92n3aylBPEkMo=
+github.com/SermoDigital/jose v0.9.1 h1:atYaHPD3lPICcbK1owly3aPm0iaJGSGPi0WD4vLznv8=
 github.com/SermoDigital/jose v0.9.1/go.mod h1:ARgCUhI1MHQH+ONky/PAtmVHQrP5JlGY0F3poXOp/fA=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
@@ -31,6 +32,7 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
+github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf h1:eg0MeVzsP1G42dRafH3vf+al2vQIJU0YHX+1Tw87oco=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -118,6 +120,8 @@ github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-resty/resty/v2 v2.0.0 h1:9Nq/U+V4xsoDnDa/iTrABDWUCuk3Ne92XFHPe6dKWUc=
+github.com/go-resty/resty/v2 v2.0.0/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -206,11 +210,14 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
+github.com/hashicorp/go-hclog v0.8.0 h1:z3ollgGRg8RjfJH6UVBaG54R70GFd++QOkvnJH3VSBY=
 github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-memdb v1.0.0/go.mod h1:I6dKdmYhZqU0RJSheVEWgTNWdVQH5QvTgIUQ0t/t32M=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-plugin v1.0.0 h1:/gQ1sNR8/LHpoxKRQq4PmLBuacfZb4tC93e9B30o/7c=
 github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.0 h1:aVN0FYnPwAgZI/hVzqwfMiM86ttcHTlQKbBVeVmXPIs=
 github.com/hashicorp/go-retryablehttp v0.5.0/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
@@ -219,15 +226,19 @@ github.com/hashicorp/go-rootcerts v0.0.0-20160503143440-6bb64b370b90/go.mod h1:o
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/vault v0.11.5 h1:6G3922BuHAxy3icIgSTJiv6GQCqFgdmXBvn3L9bNrZA=
 github.com/hashicorp/vault v0.11.5/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/vault-plugin-secrets-kv v0.0.0-20190404212640-4807e6564154/go.mod h1:VJHHT2SC1tAPrfENQeBhLlb5FbZoKZM+oC/ROmEftz0=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
@@ -307,6 +318,7 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
@@ -340,6 +352,7 @@ github.com/nmcclain/asn1-ber v0.0.0-20170104154839-2661553a0484 h1:D9EvfGQvlkKaD
 github.com/nmcclain/asn1-ber v0.0.0-20170104154839-2661553a0484/go.mod h1:O1EljZ+oHprtxDDPHiMWVo/5dBT6PlvWX5PSwj80aBA=
 github.com/nmcclain/ldap v0.0.0-20160601145537-6e14e8271933 h1:0Fd8aTYHbLx4Wx2aT048Z8KT93VgzY9XmCV6DjHFDPw=
 github.com/nmcclain/ldap v0.0.0-20160601145537-6e14e8271933/go.mod h1:YtrVB1/v9Td9SyjXpjYVmbdKgj9B0nPTBsdGUxy0i8U=
+github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/vault/letsencrypt-plugin/Makefile
+++ b/vault/letsencrypt-plugin/Makefile
@@ -1,0 +1,18 @@
+VERSION		= 1.0
+GITCOMMIT	= $(shell git describe --always --dirty=+)
+VERSION_FILE	= letsencrypt/version.go
+
+COMPILE_ENV	=
+
+build-linux: COMPILE_ENV = CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+
+build: $(VERSION_FILE)
+	$(COMPILE_ENV) go build .
+
+build-linux: build
+
+$(VERSION_FILE): $(VERSION_FILE).tmpl
+	sed -e 's/{{VERSION}}/$(VERSION)/' -e 's/{{GITCOMMIT}}/$(GITCOMMIT)/' $< >$@
+
+clean:
+	$(RM) $(VERSION_FILE)

--- a/vault/letsencrypt-plugin/docker/Dockerfile
+++ b/vault/letsencrypt-plugin/docker/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:2.6
+
+RUN apt-get update -qq && apt-get install -y \
+	build-essential \
+	cron \
+	python3-acme \
+	python3-certbot \
+	python3-mock \
+	python3-openssl \
+	python3-pkg-resources \
+	python3-pyparsing \
+	python3-zope.interface \
+	python3-certbot-nginx \
+	python3-certbot-dns-cloudflare \
+	supervisor
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+COPY supervisord.conf /etc
+COPY run.sh $APP_HOME
+COPY crontab /etc/crontab
+
+COPY Gemfile Gemfile.lock $APP_HOME/
+RUN bundle install
+
+COPY app.rb $APP_HOME
+
+CMD [ "./run.sh" ]

--- a/vault/letsencrypt-plugin/docker/Gemfile
+++ b/vault/letsencrypt-plugin/docker/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'

--- a/vault/letsencrypt-plugin/docker/Gemfile.lock
+++ b/vault/letsencrypt-plugin/docker/Gemfile.lock
@@ -1,0 +1,22 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mustermann (1.0.3)
+    rack (2.0.7)
+    rack-protection (2.0.5)
+      rack
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    tilt (2.0.9)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sinatra
+
+BUNDLED WITH
+   1.17.2

--- a/vault/letsencrypt-plugin/docker/Makefile
+++ b/vault/letsencrypt-plugin/docker/Makefile
@@ -1,0 +1,11 @@
+TAG ?= $(shell date +'%Y-%m-%d')
+
+IMAGE = mobiledgex/certgen
+REGISTRY = registry.mobiledgex.net:5000
+
+build:
+	docker build -t $(IMAGE):$(TAG) .
+	docker tag $(IMAGE):$(TAG) $(REGISTRY)/$(IMAGE):$(TAG)
+
+publish: build
+	docker push $(REGISTRY)/$(IMAGE):$(TAG)

--- a/vault/letsencrypt-plugin/docker/app.rb
+++ b/vault/letsencrypt-plugin/docker/app.rb
@@ -1,0 +1,52 @@
+require 'bundler/setup'
+
+require 'json'
+require 'openssl'
+require 'sinatra'
+
+VALID_DOMAIN = ENV["DOMAIN"] || "mobiledgex.net"
+OPS_EMAIL = ENV["OPS_EMAIL"] || "mobiledgex.ops@mobiledgex.com"
+PRODUCTION = ENV["LETSENCRYPT_ENV"] == "production" ? true : false
+LETSENCRYPT_DIR = "/etc/letsencrypt/live"
+
+certbot = [
+  "certbot", "certonly",
+  "--non-interactive", "--agree-tos", "-m", OPS_EMAIL,
+  "--dns-cloudflare", "--dns-cloudflare-credentials", "/etc/cloudflare.ini"
+]
+certbot << "--test-cert" unless PRODUCTION
+
+get "/cert/:domain" do
+  content_type :json
+
+  domain = params[:domain]
+  if not domain.end_with? VALID_DOMAIN
+    status 401
+    body "Invalid domain: #{domain}"
+    return
+  end
+
+  certdir = File.join(LETSENCRYPT_DIR, domain)
+  if not Dir.exist? certdir
+    certbot_run = certbot + [ "-d", domain ]
+    ok = system(*certbot_run)
+    if not ok
+      status 401
+      body "Failed to generate cert: status = #{$?.exitstatus}"
+      return
+    end
+  end
+
+  cert = File.read File.join(certdir, "fullchain.pem")
+  key = File.read File.join(certdir, "privkey.pem")
+
+  x509 = OpenSSL::X509::Certificate.new cert
+  ttl = (x509.not_after - Time.now).to_i
+
+  cert = {
+    :cert => cert,
+    :key  => key,
+    :ttl  => ttl,
+  }
+  cert.to_json
+end

--- a/vault/letsencrypt-plugin/docker/crontab
+++ b/vault/letsencrypt-plugin/docker/crontab
@@ -1,0 +1,1 @@
+9 4,16 * * * root certbot renew >/proc/1/fd/1 2>/proc/1/fd/2

--- a/vault/letsencrypt-plugin/docker/run.sh
+++ b/vault/letsencrypt-plugin/docker/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+if [ -z "$CF_USER" -o -z "$CF_APIKEY" ]; then
+	echo "ERROR: Cloudflare credentials not provided" >&2
+	exit 2
+fi
+cat >/etc/cloudflare.ini <<EOT
+dns_cloudflare_email = $CF_USER
+dns_cloudflare_api_key = $CF_APIKEY
+EOT
+chmod 400 /etc/cloudflare.ini
+exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/vault/letsencrypt-plugin/docker/supervisord.conf
+++ b/vault/letsencrypt-plugin/docker/supervisord.conf
@@ -1,0 +1,20 @@
+[supervisord]
+nodaemon=true
+
+[program:cron]
+command=/usr/sbin/cron -f
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes=0
+priority=600
+
+[program:certgen]
+command=/usr/local/bin/bundle exec ruby /app/app.rb
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes=0
+priority=900

--- a/vault/letsencrypt-plugin/letsencrypt/backend.go
+++ b/vault/letsencrypt-plugin/letsencrypt/backend.go
@@ -1,0 +1,79 @@
+package letsencrypt
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+	"github.com/pkg/errors"
+)
+
+type tls struct {
+	Cert string `json:"cert"`
+	Key string `json:"key"`
+	Ttl int `json:"ttl"`
+}
+
+// Factory creates a new usable instance of this secrets engine.
+func Factory(ctx context.Context, c *logical.BackendConfig) (logical.Backend, error) {
+	b := Backend(c)
+	if err := b.Setup(ctx, c); err != nil {
+		return nil, errors.Wrap(err, "failed to create factory")
+	}
+	return b, nil
+}
+
+// backend is the actual backend.
+type backend struct {
+	*framework.Backend
+}
+
+// Backend creates a new backend.
+func Backend(c *logical.BackendConfig) *backend {
+	var b backend
+
+	b.Backend = &framework.Backend{
+		BackendType: logical.TypeLogical,
+		Help: `
+
+The letsencrypt secrets acts as a front-end for generating and retrieving certbot
+certificates.
+
+		`,
+		Paths: []*framework.Path{
+			&framework.Path{
+				Pattern:      "info",
+				HelpSynopsis: "Display information about this plugin",
+				HelpDescription: `
+
+Displays information about the plugin, such as the plugin version and git commit.
+
+`,
+				Callbacks: map[logical.Operation]framework.OperationFunc{
+					logical.ReadOperation: b.pathInfo,
+				},
+			},
+
+			&framework.Path{
+				Pattern:      "cert/" + framework.GenericNameRegex("domain"),
+				HelpSynopsis: "Retrieve a letsencrypt cert",
+				HelpDescription: `
+
+Return the letsencrypt cert for the given domain, generating it if it is not present.
+
+`,
+				Fields: map[string]*framework.FieldSchema{
+					"domain": {
+						Type:		framework.TypeString,
+						Description:	"Domain for the cert",
+					},
+				},
+				Callbacks: map[logical.Operation]framework.OperationFunc{
+					logical.ReadOperation: b.pathCert,
+				},
+			},
+		},
+	}
+
+	return &b
+}

--- a/vault/letsencrypt-plugin/letsencrypt/path_cert.go
+++ b/vault/letsencrypt-plugin/letsencrypt/path_cert.go
@@ -1,0 +1,37 @@
+package letsencrypt
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+	"github.com/go-resty/resty/v2"
+)
+
+func (b *backend) pathCert(_ context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	var t tls
+
+	domain := d.Get("domain").(string)
+
+	client := resty.New()
+	resp, err := client.R().
+			SetResult(&t).
+			Get("http://127.0.0.1:4567/cert/" + domain)
+	if err != nil {
+		b.Logger().Error(err.Error())
+		return logical.ErrorResponse(err.Error()), logical.ErrInvalidRequest
+	}
+	if resp.IsError() || t.Cert == "" || t.Key == "" {
+		b.Logger().Warn(resp.String())
+		return logical.ErrorResponse("Failed to retrieve cert: " + resp.String()),
+			logical.ErrInvalidRequest
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"cert":  t.Cert,
+			"key": t.Key,
+			"ttl": t.Ttl,
+		},
+	}, nil
+}

--- a/vault/letsencrypt-plugin/letsencrypt/path_info.go
+++ b/vault/letsencrypt-plugin/letsencrypt/path_info.go
@@ -1,0 +1,17 @@
+package letsencrypt
+
+import (
+	"context"
+
+	"github.com/hashicorp/vault/logical"
+	"github.com/hashicorp/vault/logical/framework"
+)
+
+func (b *backend) pathInfo(_ context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"version": Version,
+			"commit":  GitCommit,
+		},
+	}, nil
+}

--- a/vault/letsencrypt-plugin/letsencrypt/version.go.tmpl
+++ b/vault/letsencrypt-plugin/letsencrypt/version.go.tmpl
@@ -1,0 +1,6 @@
+package letsencrypt
+
+const (
+	Version		= "{{VERSION}}"
+	GitCommit	= "{{GITCOMMIT}}"
+)

--- a/vault/letsencrypt-plugin/main.go
+++ b/vault/letsencrypt-plugin/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/hashicorp/vault/helper/pluginutil"
+	"github.com/hashicorp/vault/logical/plugin"
+	"github.com/mobiledgex/edge-cloud-infra/vault/letsencrypt-plugin/letsencrypt"
+)
+
+func main() {
+	apiClientMeta := &pluginutil.APIClientMeta{}
+	flags := apiClientMeta.FlagSet()
+	flags.Parse(os.Args[1:])
+
+	tlsConfig := apiClientMeta.GetTLSConfig()
+	tlsProviderFunc := pluginutil.VaultPluginTLSProvider(tlsConfig)
+
+	if err := plugin.Serve(&plugin.ServeOpts{
+		BackendFactoryFunc: letsencrypt.Factory,
+		TLSProviderFunc:    tlsProviderFunc,
+	}); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
The vault plugin queries a local docker service which generates, caches, and auto-renews letsencrypt certs.

Certs can be retrieved by doing this (or the equivalent using the vault REST API):
`vault kv get certs/cert/foo.mobiledgex.net`