### PR TITLE
Fix build breakage caused by letsencrypt vault plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ mc/rbac.conf
 *.postgres
 ansible.auto.tfvars
 .terraform.init.done
+vault/letsencrypt-plugin/letsencrypt/version.go

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ build-internal:
 	fixmod -srcRepo ../edge-cloud
 	go install ./protoc-gen-mc2
 	make -f proto.make
+	make -C vault/letsencrypt-plugin letsencrypt/version.go
 	go build ./...
 	go build -buildmode=plugin -o ${GOPATH}/plugins/platforms.so plugin/*.go
 	go vet ./...

--- a/vault/letsencrypt-plugin/Makefile
+++ b/vault/letsencrypt-plugin/Makefile
@@ -11,8 +11,10 @@ build: $(VERSION_FILE)
 
 build-linux: build
 
-$(VERSION_FILE): $(VERSION_FILE).tmpl
-	sed -e 's/{{VERSION}}/$(VERSION)/' -e 's/{{GITCOMMIT}}/$(GITCOMMIT)/' $< >$@
+$(VERSION_FILE): FORCE
+	sed -e 's/{{VERSION}}/$(VERSION)/' -e 's/{{GITCOMMIT}}/$(GITCOMMIT)/' $@.tmpl >$@
 
-clean:
+clean: FORCE
 	$(RM) $(VERSION_FILE)
+
+FORCE:


### PR DESCRIPTION
The vault plugin was designed to be built on-demand, but the top level
build will end up building it anyway.  This change fixes the build by
generating the version file for the plugin on every top-level build.