### PR TITLE
speed up slow unit tests

### DIFF
--- a/mc/orm/artifactory.go
+++ b/mc/orm/artifactory.go
@@ -30,6 +30,9 @@ func getArtifactoryRepoName(orgName string) string {
 }
 
 func artifactoryClient(ctx context.Context) (*artifactory.Artifactory, error) {
+	if serverConfig.ArtifactoryAddr == "" {
+		return nil, fmt.Errorf("no artifactory addr specified")
+	}
 	if rtfAuth == nil {
 		auth, err := cloudcommon.GetRegistryAuth(serverConfig.ArtifactoryAddr, serverConfig.VaultAddr)
 		if err != nil {

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -23,6 +23,8 @@ var Fail = false
 
 func TestController(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelApi)
+	log.InitTracer("")
+	defer log.FinishTracer()
 	addr := "127.0.0.1:9999"
 	uri := "http://" + addr + "/api/v1"
 

--- a/mc/orm/emails.go
+++ b/mc/orm/emails.go
@@ -99,6 +99,9 @@ Subject: {{.Subject}}
 `
 
 func sendNotify(ctx context.Context, to, subject, message string) error {
+	if serverConfig.SkipVerifyEmail {
+		return nil
+	}
 	noreply, err := getNoreply(ctx)
 	if err != nil {
 		return err
@@ -286,6 +289,9 @@ MobiledgeX Team
 `
 
 func sendAddedEmail(ctx context.Context, admin, name, email, org, role string) error {
+	if serverConfig.SkipVerifyEmail {
+		return nil
+	}
 	noreply, err := getNoreply(ctx)
 	if err != nil {
 		return err

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -60,7 +60,10 @@ func connectInfluxDB(ctx context.Context, region string) (influxdb.Client, error
 	if err != nil {
 		return nil, err
 	}
-	creds := cloudcommon.GetInfluxDataAuth(serverConfig.VaultAddr, region)
+	creds, err := cloudcommon.GetInfluxDataAuth(serverConfig.VaultAddr, region)
+	if err != nil {
+		return nil, fmt.Errorf("get influxDB auth failed, %v", err)
+	}
 	if creds == nil {
 		// defeault to empty auth
 		creds = &cloudcommon.InfluxCreds{}

--- a/mc/orm/userauth.go
+++ b/mc/orm/userauth.go
@@ -29,9 +29,9 @@ var PasshashSaltBytes = 8
 
 var Jwks vault.JWKS
 
-func InitVault(addr, roleID, secretID string) {
+func InitVault(addr, roleID, secretID string, updateDone chan struct{}) {
 	Jwks.Init(addr, "", "mcorm", roleID, secretID)
-	Jwks.GoUpdate()
+	Jwks.GoUpdate(updateDone)
 }
 
 func ValidPassword(pw string) error {


### PR DESCRIPTION
Infra unit tests had gotten really slow, like 6 minutes. These changes removes many of the things causing unnecessary delays, primarily network connect attempts to artifactory/vault/send-email that are expected to fail in unit tests. It gets them back down to ~20 sec.

I also hit an issue that the JWT key was not gotten from Vault in time for the login API call (race condition) so I added another wait chan in server.go. This required a change to the func in edge-proto.