### PR TITLE
EC-1175: CreateCloudlet fails as Shepherd and CRM containers are started with same name

### DIFF
--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -67,6 +67,7 @@ func startPlatformService(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.Plat
 	cmd := []string{
 		"sudo docker run",
 		"-d",
+		"--network host",
 		"-v /tmp:/tmp",
 		"--restart=unless-stopped",
 		"--name", container_name,


### PR DESCRIPTION
* Container creation was failing because Shepherd and CRM were using same name. Changed the code to use service name as container name
* Shepherd was unable to connect to CRM's notifySrvAddr. Fixed it by using host network mode for the container.

Thanks. 