### PR TITLE
CRM-GW ansible

### DIFF
--- a/ansible/pan-net
+++ b/ansible/pan-net
@@ -1,0 +1,6 @@
+[all:vars]
+controller_hostname=mexdemo.ctrl.mobiledgex.net
+controller_notify_port=37001
+
+[crmgws]
+pan-gw

--- a/ansible/playbooks/crm_gw.yml
+++ b/ansible/playbooks/crm_gw.yml
@@ -1,0 +1,69 @@
+- name: deploy CRM GW 
+  user: ubuntu
+  gather_facts: no
+  become: yes
+  hosts: crmgws
+  vars:
+     nginx_dir: /home/ubuntu/crm-gw/nginx  
+     nginx_log_dir: /var/log/nginx/
+     tinyproxy_log_dir: /var/log/tinyproxy/
+ 
+  tasks:
+    - name: check variables
+      debug: 
+        msg: verify controller_hostname and controller_notify_port set
+      failed_when:
+       - controller_hostname is not defined
+       - controller_notify_port is not defined
+
+    - name: Install python3-pip
+      package:
+        name: python3-pip
+        state: present
+        update_cache: yes
+
+    - name: Pip install docker
+      pip:
+        name: docker
+
+    - name: Create nginx dirs
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ nginx_dir }}"
+        - "{{ nginx_log_dir }}"
+    
+    - name: Create tinyproxy log dir
+      file:
+        path: "{{ tinyproxy_log_dir }}"
+        state: directory
+        mode: '777'
+
+    - name: install nginx config
+      template: 
+        src: templates/crm-gw-nginx-config.j2
+        dest: "{{ nginx_dir}}/nginx.conf"
+       
+    - name: startup nginx
+      docker_container:
+        image: nginx
+        name: crm-gw-nginx
+        network_mode: host
+        restart_policy: unless-stopped   
+        state: started
+        volumes:
+         - "{{ nginx_dir }}/nginx.conf:/etc/nginx/nginx.conf"
+         - "{{ nginx_log_dir }}:{{ nginx_log_dir }}"
+
+    - name: startup tinyproxy
+      docker_container:
+        image: travix/tinyproxy
+        name: tinyproxy
+        ports:
+         - "443:8888"
+        restart_policy: unless-stopped
+        state: started
+        volumes:
+         - "{{ tinyproxy_log_dir }}:{{ tinyproxy_log_dir }}"
+

--- a/ansible/playbooks/templates/crm-gw-nginx-config.j2
+++ b/ansible/playbooks/templates/crm-gw-nginx-config.j2
@@ -1,0 +1,14 @@
+user nginx;
+worker_processes  1;
+
+events {
+   worker_connections 1024;
+}
+
+stream {
+        server {
+              error_log  /var/log/nginx/nginx-gw.log debug;
+              listen {{ controller_notify_port }};
+              proxy_pass {{ controller_hostname }}:{{ controller_notify_port }};
+        }
+}


### PR DESCRIPTION
Ansible playbooks for the new CRM-GW implementation in which the CRM is within the secure network and the CRM-GW just proxies the requests

I tried to make traefik work for GRPC streaming but even though they recently implemented a TCP endpoint, it seems to check the TLS certs and that fails.  So for now sticking with the nginx streaming for GRPC

For the forward proxy, neither nginx nor traefik seems to work.   I was previously using squid which as pointed out is sort of old and clunky.   A simple alternative is tinyproxy which seems to work fine.  Our forward proxy requirements are not very complicated anyway.      