### PR TITLE
EDGECLOUD-1191  Normalize App name for metrics api in the backend

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -12,6 +12,7 @@ import (
 	influxdb "github.com/influxdata/influxdb/client/v2"
 	"github.com/labstack/echo"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/log"
 	"google.golang.org/grpc/status"
@@ -95,7 +96,7 @@ func AppInstMetricsQuery(obj *ormapi.RegionAppInstMetrics, selectorStr string) s
 	arg := influxQueryArgs{
 		Selector:     selectorStr,
 		Measurement:  "appinst-" + obj.Selector,
-		AppInstName:  obj.AppInst.AppKey.Name,
+		AppInstName:  k8smgmt.NormalizeName(obj.AppInst.AppKey.Name),
 		CloudletName: obj.AppInst.ClusterInstKey.CloudletKey.Name,
 		ClusterName:  obj.AppInst.ClusterInstKey.ClusterKey.Name,
 		OperatorName: obj.AppInst.ClusterInstKey.CloudletKey.OperatorKey.Name,


### PR DESCRIPTION
```
LSHVARTS-MAC:yaml_merge levshvarts$ http --verify=false --auth-type=jwt --auth=$SUPERPASS POST https://127.0.0.1:9900/api/v1/auth/metrics/app <<< '{"region":"local","appinst":{"app_key":{"developer_key":{"name":"MobiledgeX"},"name":"mobiledgexsdkdemo","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"AppCluster"},"cloudlet_key":{"operator_key":{"name":""}}}},"selector":"cpu","last":1}'
{
    "data": [
        {
            "Messages": null,
            "Series": [
                {
                    "columns": [
                        "time",
                        "app",
                        "cloudlet",
                        "cluster",
                        "cpu",
                        "dev",
                        "operator"
                    ],
                    "name": "appinst-cpu",
                    "values": [
                        [
                            "2019-08-23T22:46:59.673000097Z",
                            "mobiledgexsdkdemo-deployment-978589486-ckl7z",
                            "localtest",
                            "AppCluster",
                            0,
                            "MobiledgeX",
                            "mexdev"
                        ]
                    ]
                }
            ]
        }
    ]
}

LSHVARTS-MAC:yaml_merge levshvarts$ http --verify=false --auth-type=jwt --auth=$SUPERPASS POST https://127.0.0.1:9900/api/v1/auth/metrics/app <<< '{"region":"local","appinst":{"app_key":{"developer_key":{"name":"MobiledgeX"},"name":"MobiledgeX SDK Demo","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"AppCluster"},"cloudlet_key":{"operator_key":{"name":""}}}},"selector":"cpu","last":1}'
{
    "data": [
        {
            "Messages": null,
            "Series": [
                {
                    "columns": [
                        "time",
                        "app",
                        "cloudlet",
                        "cluster",
                        "cpu",
                        "dev",
                        "operator"
                    ],
                    "name": "appinst-cpu",
                    "values": [
                        [
                            "2019-08-23T22:47:31.651000022Z",
                            "mobiledgexsdkdemo-deployment-978589486-ckl7z",
                            "localtest",
                            "AppCluster",
                            0,
                            "MobiledgeX",
                            "mexdev"
                        ]
                    ]
                }
            ]
        }
    ]
}```