### PR TITLE
EDGECLOUD-1222 curl preinstalled on nginx container

### DIFF
--- a/shepherd/nginx-stats.go
+++ b/shepherd/nginx-stats.go
@@ -125,17 +125,6 @@ func QueryNginx(scrapePoint NginxScrapePoint) (*NginxMetrics, error) {
 		request = fmt.Sprintf("curl http://127.0.0.1:%d/nginx_metrics", nginxUnitTestPort)
 	}
 	resp, err := scrapePoint.Client.Output(request)
-	// if this is the first time, or the container got restarted, install curl
-	if strings.Contains(resp, "executable file not found") {
-		log.DebugLog(log.DebugLevelMexos, "Installing curl onto docker container ", "Container", container)
-		installer := fmt.Sprintf("docker exec %s apt-get update; docker exec %s apt-get --assume-yes install curl", container, container)
-		resp, err = scrapePoint.Client.Output(installer)
-		if err != nil {
-			return nil, fmt.Errorf("can't install curl on nginx container %s, %s, %v", *name, resp, err)
-		}
-		// now retry curling
-		resp, err = scrapePoint.Client.Output(request)
-	}
 	if err != nil {
 		log.DebugLog(log.DebugLevelMetrics, "Failed to run request", "request", request, "err", err.Error())
 		return nil, err


### PR DESCRIPTION
Now that we are using an nginx container with curl preinstalled, no need to have shepherd install curl when an error occurs while trying to curl nginx containers