### PR TITLE
EDGECLOUD-1223 nginx metrics cleanup

### DIFF
--- a/shepherd/nginx-stats.go
+++ b/shepherd/nginx-stats.go
@@ -184,6 +184,7 @@ func parseNginxResp(resp string, metrics *NginxMetrics) error {
 }
 
 func MarshallNginxMetric(scrapePoint NginxScrapePoint, data *NginxMetrics) *edgeproto.Metric {
+	RemoveShepherdMetrics(data)
 	metric := edgeproto.Metric{}
 	metric.Name = "appinst-nginx"
 	metric.Timestamp = *data.Ts
@@ -196,9 +197,11 @@ func MarshallNginxMetric(scrapePoint NginxScrapePoint, data *NginxMetrics) *edge
 	metric.AddIntVal("active", data.ActiveConn)
 	metric.AddIntVal("accepts", data.Accepts)
 	metric.AddIntVal("handled", data.HandledConn)
-	metric.AddIntVal("requests", data.Requests)
-	metric.AddIntVal("reading", data.Reading)
-	metric.AddIntVal("writing", data.Writing)
-	metric.AddIntVal("waiting", data.Waiting)
 	return &metric
+}
+
+func RemoveShepherdMetrics(data *NginxMetrics) {
+	data.ActiveConn = data.ActiveConn - 1
+	data.Accepts = data.Accepts - data.Requests
+	data.HandledConn = data.HandledConn - data.Requests
 }

--- a/shepherd/shepherd.go
+++ b/shepherd/shepherd.go
@@ -153,7 +153,7 @@ func main() {
 	if err != nil {
 		log.FatalLog("Failed to get platform", "platformName", platformName, "err", err)
 	}
-	pf.Init(ctx, &cloudletKey, *physicalName, *vaultAddr)
+	err = pf.Init(ctx, &cloudletKey, *physicalName, *vaultAddr)
 	if err != nil {
 		log.FatalLog("Failed to initialize platform", "platformName", platformName, "err", err)
 	}

--- a/shepherd/shepherd_platform/shepherd_openstack/shepherd_openstack.go
+++ b/shepherd/shepherd_platform/shepherd_openstack/shepherd_openstack.go
@@ -47,7 +47,7 @@ func (s *Platform) GetPlatformClient(ctx context.Context, clusterInst *edgeproto
 	if clusterInst != nil && clusterInst.IpAccess == edgeproto.IpAccess_IP_ACCESS_DEDICATED {
 		rootLb := cloudcommon.GetDedicatedLBFQDN(&clusterInst.Key.CloudletKey, &clusterInst.Key.ClusterKey)
 		pc, err := s.pf.GetPlatformClientRootLB(ctx, rootLb)
-		return pc, err //this is not ok, pc will go away when the func returns
+		return pc, err
 	} else {
 		return s.SharedClient, nil
 	}


### PR DESCRIPTION
Changed up nginx metrics a bit. No longer reports reading, writing, waiting, or requests since I think those only get logged if you're using nginx as an actual server and not a reverse proxy. So now there are just accepted connections, handled connections, and active connections. Also shepherd will now remove metrics generated by itself before sending the metrics to controller to write into influx. Thus the metrics created by shepherd will no longer be present as it is confusing to users for it to be there.