### PR TITLE
edgecloud-1267 fix nginx crashing

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -87,7 +87,6 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 					err = mexos.CreateAppDNS(ctx, client, names, getDnsAction)
 				} else {
 					updateCallback(edgeproto.UpdateTask, "Configuring Service: LB, Firewall Rules and DNS")
-					// err = mexos.AddProxySecurityRulesAndPatchDNS(ctx, client, names, appInst, getDnsAction, rootLBName, masterIP, true, nginx.WithDockerNetwork("host"))
 					err = mexos.AddProxySecurityRulesAndPatchDNS(ctx, client, names, appInst, getDnsAction, rootLBName, masterIP, true, nginx.WithDockerPublishPorts(), nginx.WithDockerNetwork(""))
 				}
 			}


### PR DESCRIPTION
any nginx instance created after the first one would be in a continual restart loop since they were all trying to lock onto rootlb's port 65121. Moved the docker containers that nginx runs on from the host network interface to a bridge network and only publish the ports that the appinst uses. This way all the nginx docker containers can serve metrics on port 65121 as we don't publish it. The only drawback is this increases network latency a little as now theres an extra hop through the iptables. On Bruce's face detection demo app this come out to be an extra 1-2ms. 

It is possible to have docker containers on multiple networks so it might also be possible to configure nginx to serve metrics through the bridge network like I have it now and do app stuff through the host network to get back the latency drop and get the best of both worlds. For now though this will allow shepherd to keep scraping metrics from nginx and only have to reserve one port for it