### PR TITLE
EDGECLOUD-1243 mc api for nginx metrics

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -221,6 +221,8 @@ func parseAppSelectorString(selector string) (string, error) {
 	case "disk":
 		fallthrough
 	case "network":
+		fallthrough
+	case "nginx":
 		return "*", nil
 	}
 	return "", fmt.Errorf("Invalid selector in a request")


### PR DESCRIPTION
Added nginx stats for the mc api. The api is part of the metric/app api. To access the nginx stats just indicate "nginx" in the selector of the api, for example

`http --auth-type=jwt --auth=$WORKER1TOKEN POST 127.0.0.1:9900/api/v1/auth/metrics/app <<< '{"region":"local","appinst":{"app_key":{"developer_key":{"name":"MobiledgeX"},"name":"facedetectiondemo","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"AppCluster"},"cloudlet_key":{"operator_key":{"name":""}}}},"selector":"nginx","last":5}'`

Also, in order for this to work I had to normalize the app names that get written to influx for the "appinst-nginx" measurement. So now names like "Face Detection Demo" becomes "facedetectiondemo". I believe this needed to be done anyway as it was also a bug related Docker metrics