### PR TITLE
Fix shepherd crash on krakow site

### DIFF
--- a/shepherd/cloudlet-worker.go
+++ b/shepherd/cloudlet-worker.go
@@ -45,6 +45,11 @@ func MarshalCloudletMetrics(data *shepherd_common.CloudletMetrics) []*edgeproto.
 	cMetric := edgeproto.Metric{}
 	nMetric := edgeproto.Metric{}
 
+	// bail out if we get no metrics
+	if data == nil {
+		return nil
+	}
+
 	// If the timestamp for any given metric is null, don't send anything
 	if data.ComputeTS != nil {
 		cMetric.Name = "cloudlet-utilization"

--- a/shepherd/cloudlet-worker_test.go
+++ b/shepherd/cloudlet-worker_test.go
@@ -39,6 +39,8 @@ func TestCloudletStats(t *testing.T) {
 		Name:        "testcloudlet",
 	}
 
+	// Test null handling
+	assert.Nil(t, MarshalCloudletMetrics(nil))
 	testCloudletData.ComputeTS, err = types.TimestampProto(time.Now())
 	assert.Nil(t, err, "Couldn't get current timestamp")
 	testCloudletData.NetworkTS = testCloudletData.ComputeTS

--- a/shepherd/cluster-worker.go
+++ b/shepherd/cluster-worker.go
@@ -94,7 +94,7 @@ func (p *ClusterWorker) RunNotify() {
 					p.send(ctx, metric)
 				}
 			}
-			clusterMetrics := MarshalClusterMetrics(clusterStats, p.clusterInstKey)
+			clusterMetrics := MarshalClusterMetrics(p.clusterInstKey, clusterStats)
 			for _, metric := range clusterMetrics {
 				p.send(ctx, metric)
 			}
@@ -120,9 +120,14 @@ func newMetric(clusterInstKey edgeproto.ClusterInstKey, name string, key *shephe
 	return &metric
 }
 
-func MarshalClusterMetrics(cm *shepherd_common.ClusterMetrics, key edgeproto.ClusterInstKey) []*edgeproto.Metric {
+func MarshalClusterMetrics(key edgeproto.ClusterInstKey, cm *shepherd_common.ClusterMetrics) []*edgeproto.Metric {
 	var metrics []*edgeproto.Metric
 	var metric *edgeproto.Metric
+
+	// bail out if we get no metrics
+	if cm == nil {
+		return nil
+	}
 
 	//nil timestamps mean the curl request failed. So do not write the metric in
 	if cm.CpuTS != nil {
@@ -183,6 +188,11 @@ func MarshalClusterMetrics(cm *shepherd_common.ClusterMetrics, key edgeproto.Clu
 func MarshalAppMetrics(key *shepherd_common.MetricAppInstKey, stat *shepherd_common.AppMetrics) []*edgeproto.Metric {
 	var metrics []*edgeproto.Metric
 	var metric *edgeproto.Metric
+
+	// bail out if we get no metrics
+	if stat == nil {
+		return nil
+	}
 
 	if stat.CpuTS != nil {
 		metric = newMetric(key.ClusterInstKey, "appinst-cpu", key, stat.CpuTS)

--- a/shepherd/prom-stats_test.go
+++ b/shepherd/prom-stats_test.go
@@ -265,6 +265,10 @@ func TestPromStats(t *testing.T) {
 
 	// Check callback is called
 	assert.Equal(t, int(0), testMetricSent)
-	testPromStats.send(ctx, MarshalClusterMetrics(clusterMetrics, testPromStats.clusterInstKey)[0])
+	testPromStats.send(ctx, MarshalClusterMetrics(testPromStats.clusterInstKey, clusterMetrics)[0])
 	assert.Equal(t, int(1), testMetricSent)
+
+	// Check null handling for Marshal functions
+	assert.Nil(t, MarshalClusterMetrics(testPromStats.clusterInstKey, nil), "Nil metrics should marshal into a nil")
+	assert.Nil(t, MarshalAppMetrics(&testAppKey, nil), "Nil metrics should marshal into a nil")
 }

--- a/shepherd/shepherd.go
+++ b/shepherd/shepherd.go
@@ -28,7 +28,6 @@ var platformName = flag.String("platform", "", "Platform type of Cloudlet")
 var vaultAddr = flag.String("vaultAddr", "", "Address to vault")
 var physicalName = flag.String("physicalName", "", "Physical infrastructure cloudlet name, defaults to cloudlet name in cloudletKey")
 var cloudletKeyStr = flag.String("cloudletKey", "", "Json or Yaml formatted cloudletKey for the cloudlet in which this CRM is instantiated; e.g. '{\"operator_key\":{\"name\":\"TMUS\"},\"name\":\"tmocloud1\"}'")
-var region = flag.String("region", "local", "region name")
 var name = flag.String("name", "shepherd", "Unique name to identify a process")
 
 var defaultPrometheusPort = int32(9090)


### PR DESCRIPTION
Fixed unchecked null- pointer crashes and added unit-tests for them.
Also removed unused "region" cmdline argument, and swapped around arguments in MarshalClusterMetrics() for consistency