### PR TITLE
Remove region option from deployment script

### DIFF
--- a/ansible/roles/shepherd/tasks/main.yml
+++ b/ansible/roles/shepherd/tasks/main.yml
@@ -55,8 +55,6 @@
       - "{{ vault_vm_hostname }}:{{ vault_port }}"
       - "--cloudletKey"
       - "{\\\"operator_key\\\":{\\\"name\\\":\\\"{{ item.operator_key | mandatory }}\\\"},\\\"name\\\":\\\"{{ item.cloudlet_name }}\\\"}"
-      - "--region"
-      - "{{ item.controller_region }}"
       - "-d"
       - "api,notify,mexos,metrics"
 


### PR DESCRIPTION
I removed "region" cmdline option from shepherd, but forgot to fix up deployment scripts. This change fixes the deployment scripts