### PR TITLE
EDGECLOUD-1269 mc email templates are text

### DIFF
--- a/mc/orm/emails.go
+++ b/mc/orm/emails.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"html/template"
 	"net/smtp"
+	"text/template"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"


### PR DESCRIPTION
MC email templates was using the "html/template" package instead of the "text/template" package, causing inline text such as "mextester04+5@gmail.com" to be converted to `mextester04&#43;5@gmail.com.` Using the text template package avoids html character escaping.