### PR TITLE
EDGECLOUD-1206 update fields for edgectl/mcctl

### DIFF
--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -126,7 +126,22 @@ var UpdateAppCmd = &cli.Command{
 	Comments:     addRegionComment(AppComments),
 	ReqData:      &ormapi.RegionApp{},
 	ReplyData:    &edgeproto.Result{},
-	Run:          runRest("/auth/ctrl/UpdateApp"),
+	Run: runRest("/auth/ctrl/UpdateApp",
+		withSetFieldsFunc(setUpdateAppFields),
+	),
+}
+
+func setUpdateAppFields(in map[string]interface{}) {
+	// get map for edgeproto object in region struct
+	obj := in[strings.ToLower("App")]
+	if obj == nil {
+		return
+	}
+	objmap, ok := obj.(map[string]interface{})
+	if !ok {
+		return
+	}
+	objmap["fields"] = cli.GetSpecifiedFields(objmap, &edgeproto.App{}, cli.JsonNamespace)
 }
 
 var ShowAppCmd = &cli.Command{
@@ -141,6 +156,7 @@ var ShowAppCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowApp"),
 	StreamOut:    true,
 }
+
 var AppApiCmds = []*cli.Command{
 	CreateAppCmd,
 	DeleteAppCmd,

--- a/mc/mcctl/ormctl/app_inst.mc2.go
+++ b/mc/mcctl/ormctl/app_inst.mc2.go
@@ -52,17 +52,32 @@ var DeleteAppInstCmd = &cli.Command{
 }
 
 var UpdateAppInstCmd = &cli.Command{
-	Use:                  "UpdateAppInst",
-	RequiredArgs:         strings.Join(append([]string{"region"}, AppInstRequiredArgs...), " "),
-	OptionalArgs:         strings.Join(AppInstOptionalArgs, " "),
-	AliasArgs:            strings.Join(AppInstAliasArgs, " "),
-	SpecialArgs:          &AppInstSpecialArgs,
-	Comments:             addRegionComment(AppInstComments),
-	ReqData:              &ormapi.RegionAppInst{},
-	ReplyData:            &edgeproto.Result{},
-	Run:                  runRest("/auth/ctrl/UpdateAppInst"),
+	Use:          "UpdateAppInst",
+	RequiredArgs: strings.Join(append([]string{"region"}, AppInstRequiredArgs...), " "),
+	OptionalArgs: strings.Join(AppInstOptionalArgs, " "),
+	AliasArgs:    strings.Join(AppInstAliasArgs, " "),
+	SpecialArgs:  &AppInstSpecialArgs,
+	Comments:     addRegionComment(AppInstComments),
+	ReqData:      &ormapi.RegionAppInst{},
+	ReplyData:    &edgeproto.Result{},
+	Run: runRest("/auth/ctrl/UpdateAppInst",
+		withSetFieldsFunc(setUpdateAppInstFields),
+	),
 	StreamOut:            true,
 	StreamOutIncremental: true,
+}
+
+func setUpdateAppInstFields(in map[string]interface{}) {
+	// get map for edgeproto object in region struct
+	obj := in[strings.ToLower("AppInst")]
+	if obj == nil {
+		return
+	}
+	objmap, ok := obj.(map[string]interface{})
+	if !ok {
+		return
+	}
+	objmap["fields"] = cli.GetSpecifiedFields(objmap, &edgeproto.AppInst{}, cli.JsonNamespace)
 }
 
 var ShowAppInstCmd = &cli.Command{
@@ -77,6 +92,7 @@ var ShowAppInstCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowAppInst"),
 	StreamOut:    true,
 }
+
 var AppInstApiCmds = []*cli.Command{
 	CreateAppInstCmd,
 	DeleteAppInstCmd,

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -51,17 +51,32 @@ var DeleteCloudletCmd = &cli.Command{
 }
 
 var UpdateCloudletCmd = &cli.Command{
-	Use:                  "UpdateCloudlet",
-	RequiredArgs:         strings.Join(append([]string{"region"}, CloudletRequiredArgs...), " "),
-	OptionalArgs:         strings.Join(CloudletOptionalArgs, " "),
-	AliasArgs:            strings.Join(CloudletAliasArgs, " "),
-	SpecialArgs:          &CloudletSpecialArgs,
-	Comments:             addRegionComment(CloudletComments),
-	ReqData:              &ormapi.RegionCloudlet{},
-	ReplyData:            &edgeproto.Result{},
-	Run:                  runRest("/auth/ctrl/UpdateCloudlet"),
+	Use:          "UpdateCloudlet",
+	RequiredArgs: strings.Join(append([]string{"region"}, CloudletRequiredArgs...), " "),
+	OptionalArgs: strings.Join(CloudletOptionalArgs, " "),
+	AliasArgs:    strings.Join(CloudletAliasArgs, " "),
+	SpecialArgs:  &CloudletSpecialArgs,
+	Comments:     addRegionComment(CloudletComments),
+	ReqData:      &ormapi.RegionCloudlet{},
+	ReplyData:    &edgeproto.Result{},
+	Run: runRest("/auth/ctrl/UpdateCloudlet",
+		withSetFieldsFunc(setUpdateCloudletFields),
+	),
 	StreamOut:            true,
 	StreamOutIncremental: true,
+}
+
+func setUpdateCloudletFields(in map[string]interface{}) {
+	// get map for edgeproto object in region struct
+	obj := in[strings.ToLower("Cloudlet")]
+	if obj == nil {
+		return
+	}
+	objmap, ok := obj.(map[string]interface{})
+	if !ok {
+		return
+	}
+	objmap["fields"] = cli.GetSpecifiedFields(objmap, &edgeproto.Cloudlet{}, cli.JsonNamespace)
 }
 
 var ShowCloudletCmd = &cli.Command{
@@ -76,6 +91,7 @@ var ShowCloudletCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowCloudlet"),
 	StreamOut:    true,
 }
+
 var CloudletApiCmds = []*cli.Command{
 	CreateCloudletCmd,
 	DeleteCloudletCmd,
@@ -95,6 +111,7 @@ var ShowCloudletInfoCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowCloudletInfo"),
 	StreamOut:    true,
 }
+
 var CloudletInfoApiCmds = []*cli.Command{
 	ShowCloudletInfoCmd,
 }

--- a/mc/mcctl/ormctl/cloudletpool.mc2.go
+++ b/mc/mcctl/ormctl/cloudletpool.mc2.go
@@ -57,6 +57,7 @@ var ShowCloudletPoolCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowCloudletPool"),
 	StreamOut:    true,
 }
+
 var CloudletPoolApiCmds = []*cli.Command{
 	CreateCloudletPoolCmd,
 	DeleteCloudletPoolCmd,
@@ -138,6 +139,7 @@ var ShowCloudletsForPoolListCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowCloudletsForPoolList"),
 	StreamOut:    true,
 }
+
 var CloudletPoolMemberApiCmds = []*cli.Command{
 	CreateCloudletPoolMemberCmd,
 	DeleteCloudletPoolMemberCmd,

--- a/mc/mcctl/ormctl/clusterinst.mc2.go
+++ b/mc/mcctl/ormctl/clusterinst.mc2.go
@@ -50,17 +50,32 @@ var DeleteClusterInstCmd = &cli.Command{
 }
 
 var UpdateClusterInstCmd = &cli.Command{
-	Use:                  "UpdateClusterInst",
-	RequiredArgs:         strings.Join(append([]string{"region"}, ClusterInstRequiredArgs...), " "),
-	OptionalArgs:         strings.Join(ClusterInstOptionalArgs, " "),
-	AliasArgs:            strings.Join(ClusterInstAliasArgs, " "),
-	SpecialArgs:          &ClusterInstSpecialArgs,
-	Comments:             addRegionComment(ClusterInstComments),
-	ReqData:              &ormapi.RegionClusterInst{},
-	ReplyData:            &edgeproto.Result{},
-	Run:                  runRest("/auth/ctrl/UpdateClusterInst"),
+	Use:          "UpdateClusterInst",
+	RequiredArgs: strings.Join(append([]string{"region"}, ClusterInstRequiredArgs...), " "),
+	OptionalArgs: strings.Join(ClusterInstOptionalArgs, " "),
+	AliasArgs:    strings.Join(ClusterInstAliasArgs, " "),
+	SpecialArgs:  &ClusterInstSpecialArgs,
+	Comments:     addRegionComment(ClusterInstComments),
+	ReqData:      &ormapi.RegionClusterInst{},
+	ReplyData:    &edgeproto.Result{},
+	Run: runRest("/auth/ctrl/UpdateClusterInst",
+		withSetFieldsFunc(setUpdateClusterInstFields),
+	),
 	StreamOut:            true,
 	StreamOutIncremental: true,
+}
+
+func setUpdateClusterInstFields(in map[string]interface{}) {
+	// get map for edgeproto object in region struct
+	obj := in[strings.ToLower("ClusterInst")]
+	if obj == nil {
+		return
+	}
+	objmap, ok := obj.(map[string]interface{})
+	if !ok {
+		return
+	}
+	objmap["fields"] = cli.GetSpecifiedFields(objmap, &edgeproto.ClusterInst{}, cli.JsonNamespace)
 }
 
 var ShowClusterInstCmd = &cli.Command{
@@ -75,6 +90,7 @@ var ShowClusterInstCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowClusterInst"),
 	StreamOut:    true,
 }
+
 var ClusterInstApiCmds = []*cli.Command{
 	CreateClusterInstCmd,
 	DeleteClusterInstCmd,

--- a/mc/mcctl/ormctl/exec.mc2.go
+++ b/mc/mcctl/ormctl/exec.mc2.go
@@ -32,6 +32,7 @@ var RunCommandCmd = &cli.Command{
 	ReplyData:    &edgeproto.ExecRequest{},
 	Run:          runRest("/auth/ctrl/RunCommand"),
 }
+
 var ExecApiCmds = []*cli.Command{
 	RunCommandCmd,
 }

--- a/mc/mcctl/ormctl/flavor.mc2.go
+++ b/mc/mcctl/ormctl/flavor.mc2.go
@@ -54,7 +54,22 @@ var UpdateFlavorCmd = &cli.Command{
 	Comments:     addRegionComment(FlavorComments),
 	ReqData:      &ormapi.RegionFlavor{},
 	ReplyData:    &edgeproto.Result{},
-	Run:          runRest("/auth/ctrl/UpdateFlavor"),
+	Run: runRest("/auth/ctrl/UpdateFlavor",
+		withSetFieldsFunc(setUpdateFlavorFields),
+	),
+}
+
+func setUpdateFlavorFields(in map[string]interface{}) {
+	// get map for edgeproto object in region struct
+	obj := in[strings.ToLower("Flavor")]
+	if obj == nil {
+		return
+	}
+	objmap, ok := obj.(map[string]interface{})
+	if !ok {
+		return
+	}
+	objmap["fields"] = cli.GetSpecifiedFields(objmap, &edgeproto.Flavor{}, cli.JsonNamespace)
 }
 
 var ShowFlavorCmd = &cli.Command{
@@ -69,6 +84,7 @@ var ShowFlavorCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowFlavor"),
 	StreamOut:    true,
 }
+
 var FlavorApiCmds = []*cli.Command{
 	CreateFlavorCmd,
 	DeleteFlavorCmd,

--- a/mc/mcctl/ormctl/node.mc2.go
+++ b/mc/mcctl/ormctl/node.mc2.go
@@ -33,6 +33,7 @@ var ShowNodeCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowNode"),
 	StreamOut:    true,
 }
+
 var NodeApiCmds = []*cli.Command{
 	ShowNodeCmd,
 }

--- a/mc/mcctl/ormctl/refs.mc2.go
+++ b/mc/mcctl/ormctl/refs.mc2.go
@@ -33,6 +33,7 @@ var ShowCloudletRefsCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowCloudletRefs"),
 	StreamOut:    true,
 }
+
 var CloudletRefsApiCmds = []*cli.Command{
 	ShowCloudletRefsCmd,
 }
@@ -49,6 +50,7 @@ var ShowClusterRefsCmd = &cli.Command{
 	Run:          runRest("/auth/ctrl/ShowClusterRefs"),
 	StreamOut:    true,
 }
+
 var ClusterRefsApiCmds = []*cli.Command{
 	ShowClusterRefsCmd,
 }


### PR DESCRIPTION
Changes the auto-generated mcctl code for controller Update APIs to set the "fields" field for specified args. Leverages changes in the cli input library from https://github.com/mobiledgex/edge-cloud/pull/652.
