### PR TITLE
Handle natted IPs

### DIFF
--- a/mexos/dns.go
+++ b/mexos/dns.go
@@ -92,10 +92,11 @@ func CreateAppDNS(ctx context.Context, client pc.PlatformClient, kubeNames *k8sm
 			}
 		}
 		if action.AddDNS && useDns {
+			mappedAddr := GetMappedExternalIP(action.ExternalIP)
 			fqdn := cloudcommon.ServiceFQDN(sn, fqdnBase)
 
-			if err := cloudflare.CreateOrUpdateDNSRecord(ctx, GetCloudletDNSZone(), fqdn, "A", action.ExternalIP, 1, false); err != nil {
-				return fmt.Errorf("can't create DNS record for %s,%s, %v", fqdn, action.ExternalIP, err)
+			if err := cloudflare.CreateOrUpdateDNSRecord(ctx, GetCloudletDNSZone(), fqdn, "A", mappedAddr, 1, false); err != nil {
+				return fmt.Errorf("can't create DNS record for %s,%s, %v", fqdn, mappedAddr, err)
 			}
 			log.SpanLog(ctx, log.DebugLevelMexos, "registered DNS name, may still need to wait for propagation", "name", fqdn, "externalIP", action.ExternalIP)
 		}

--- a/mexos/fqdn.go
+++ b/mexos/fqdn.go
@@ -62,8 +62,10 @@ func uri2fqdn(uri string) string {
 
 //ActivateFQDNA updates and ensures Fqdn is registered properly
 func ActivateFQDNA(ctx context.Context, fqdn, addr string) error {
+
+	mappedAddr := GetMappedExternalIP(addr)
 	if err := cloudflare.InitAPI(GetCloudletCFUser(), GetCloudletCFKey()); err != nil {
 		return fmt.Errorf("cannot init cloudflare api, %v", err)
 	}
-	return cloudflare.CreateOrUpdateDNSRecord(ctx, GetCloudletDNSZone(), fqdn, "A", addr, 1, false)
+	return cloudflare.CreateOrUpdateDNSRecord(ctx, GetCloudletDNSZone(), fqdn, "A", mappedAddr, 1, false)
 }


### PR DESCRIPTION
EDGECLOUD-1262

Some PoC environments have "external" IPs which are not really external.  They are External from an OpenStack standpoint, but to actually reach stuff it's not uncommon for there to be some NAT via some other IPs.  When this happens we always end up manually changing the DNS entries.

This PR is to allow the CRM to be configured with the IP mappings so it can create DNS entries with the IPs which the test mobiles will use. 