### PR TITLE
EDGECLOUD-1325: Production mc not populating orgs/users to Artifactory

### DIFF
--- a/mc/orm/appstore_sync_test.go
+++ b/mc/orm/appstore_sync_test.go
@@ -182,6 +182,7 @@ func TestAppStoreApi(t *testing.T) {
 		rtf.verify(t, v, MCObj)
 		gm.verify(t, v, MCObj)
 	}
+	rtf.verifyCount(t, MCObj)
 
 	// Create users & orgs which are not present in MC
 	for _, v := range extraEntries {

--- a/mc/orm/artifactory.go
+++ b/mc/orm/artifactory.go
@@ -402,6 +402,9 @@ func artifactoryCreateRepoPerms(ctx context.Context, orgName, orgType string) er
 		if role == nil {
 			continue
 		}
+		if role.Org != orgName {
+			continue
+		}
 		userName := strings.ToLower(role.Username)
 		if role.Role == RoleDeveloperManager {
 			userPerms[userName] = []string{"w", "d", "r", "m"}

--- a/mc/orm/artifactory_test.go
+++ b/mc/orm/artifactory_test.go
@@ -378,6 +378,17 @@ func (s *ArtifactoryMock) verify(t *testing.T, v entry, objType string) {
 	}
 }
 
+func (s *ArtifactoryMock) verifyCount(t *testing.T, objType string) {
+	if objType != MCObj {
+		return
+	}
+	for _, v := range s.permStore {
+		require.Equal(t, 3, len(*v.Principals.Users), "permission target has right number of users")
+		require.Equal(t, 1, len(*v.Principals.Groups), "permission target has right number of groups")
+		require.Equal(t, 1, len(*v.Repositories), "permission target has right number of repos")
+	}
+}
+
 func (s *ArtifactoryMock) verifyEmpty(t *testing.T) {
 	require.Equal(t, 0, len(s.userStore), "deleted all artifactory users")
 	require.Equal(t, 0, len(s.groupStore), "deleted all artifactory groups")


### PR DESCRIPTION
* This issue was seen in production MC
* Permission targets were not getting created because all the users were getting added to the group
* Fixed it by adding only org users
* Added test case to test the same