### PR TITLE
EDGECLOUD-1326 Flavor details and properties parse

### DIFF
--- a/mc/orm/auditlog.go
+++ b/mc/orm/auditlog.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -13,12 +12,12 @@ import (
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/tls"
 )
 
 var AuditId uint64
-var jwtRegex = regexp.MustCompile(`"(.*?)"`) // scrub jwt tokens from responses before logging, find all quoted strings.
 
 func logger(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) (nexterr error) {
@@ -125,7 +124,7 @@ func logger(next echo.HandlerFunc) echo.HandlerFunc {
 			// for all responses, if it has a jwt token
 			// remove it before logging
 			if strings.Contains(string(resBody), "token") {
-				ms := jwtRegex.FindAllStringSubmatch(string(resBody), -1)
+				ms := cloudcommon.QuotedStringRegex.FindAllStringSubmatch(string(resBody), -1)
 				if ms != nil {
 					ss := make([]string, len(ms))
 					for i, m := range ms {

--- a/mexos/oscli.go
+++ b/mexos/oscli.go
@@ -111,6 +111,26 @@ func ListNetworks(ctx context.Context) ([]OSNetwork, error) {
 	return networks, nil
 }
 
+//ShowFlavor returns the details of a given flavor.
+// If the flavor has any properties set, these are returned as well
+func ShowFlavor(ctx context.Context, flavor string) (details string, properties string, err error) {
+
+	out, err := TimedOpenStackCommand(ctx, "openstack", "flavor", "show", flavor, "-f", "json")
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelMexos, "flavor show failed", "out", out)
+		fmt.Printf("Timed Op return error %d\n", err)
+		return "", "", err
+	}
+	s := strings.Index(string(out), "properties")
+	s += len("properties") + 2
+	ms := cloudcommon.QuotedStringRegex.FindAllString(string(out[s:]), -1)
+	ss := make([]string, len(ms))
+	for i, m := range ms {
+		ss[i] = m[1 : len(m)-1]
+	}
+	return string(out), ss[0], err
+}
+
 //ListFlavors lists flavors known to the platform.   The ones matching the flavorMatchPattern are returned
 func ListFlavors(ctx context.Context) ([]OSFlavor, error) {
 	flavorMatchPattern := GetCloudletFlavorMatchPattern()
@@ -630,7 +650,7 @@ func OSGetLimits(ctx context.Context, info *edgeproto.CloudletInfo) error {
 		}
 	}
 
-	finfo, err := GetFlavorInfo(ctx, )
+	finfo, err := GetFlavorInfo(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use new common QuotedStringRegex expression for both auditlog and new ShowFlavor() which returns flavor details and if exists, any properties set on the flavor.