### PR TITLE
Master-only clusters new fix

### DIFF
--- a/mexos/cluster.go
+++ b/mexos/cluster.go
@@ -227,7 +227,11 @@ func IsClusterReady(ctx context.Context, clusterInst *edgeproto.ClusterInst, mas
 	//                   node       state               role     age     version
 	nodeMatchPattern := "(\\S+)\\s+(Ready|NotReady)\\s+(\\S+)\\s+\\S+\\s+\\S+"
 	reg, err := regexp.Compile(nodeMatchPattern)
-
+	if err != nil {
+		// this is a bug if the regex does not compile
+		log.SpanLog(ctx, log.DebugLevelInfo, "failed to compile regex", "pattern", nodeMatchPattern)
+		return false, 0, fmt.Errorf("Internal Error compiling regex for k8s node")
+	}
 	masterString := ""
 	lines := strings.Split(out, "\n")
 	var readyCount uint32


### PR DESCRIPTION
This is a second attempt to fix EDGECLOUD-1109.  The original problem is the master node name is truncated to 63 characters.  The first fix just tried to do the same thing and truncate at 63 when running the taint remove command.  It worked most of the time but a new case was discovered by Andy:

If the master name ends in "-" after the truncation it still fails.  The reason is that k8s truncates it further to make sure it ends in alphanumeric.

This new fix parses the master node name directly from kubectl rather than trying to predict what type of manipulation k8s is going to do to it.   
