### PR TITLE
EDGECLOUD-1306 ldap block user if locked or email unverified

### DIFF
--- a/mc/orm/ldap.go
+++ b/mc/orm/ldap.go
@@ -51,6 +51,9 @@ func (s *ldapHandler) Bind(bindDN, bindSimplePw string, conn net.Conn) (ldap.LDA
 		}
 		// don't log "user", as it contains password hash
 		log.SpanLog(ctx, log.DebugLevelApi, "pw check", "user", lookup)
+		if !user.EmailVerified || user.Locked {
+			return ldap.LDAPResultInvalidCredentials, nil
+		}
 		matches, err := PasswordMatches(bindSimplePw, user.Passhash, user.Salt, user.Iter)
 		if err != nil || !matches {
 			time.Sleep(BadAuthDelay)


### PR DESCRIPTION
Fail to authenticate LDAP user if account is blocked or email is not verified, to match MC behavior.