### PR TITLE
EC-1304: Disallow username to be same as orgname and vice-versa

### DIFF
--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -59,6 +59,9 @@ func CreateOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.Organizat
 	if org.Phone == "" {
 		return fmt.Errorf("Phone number not specified")
 	}
+	if strings.ToLower(claims.Username) == strings.ToLower(org.Name) {
+		return fmt.Errorf("org name cannot be same as existing user name")
+	}
 	org.AdminUsername = claims.Username
 	db := loggedDB(ctx)
 	err = db.Create(&org).Error

--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -248,6 +248,9 @@ func AddUserRoleObj(ctx context.Context, claims *UserClaims, role *ormapi.Role) 
 	if role.Role == "" {
 		return fmt.Errorf("Role not specified")
 	}
+	if strings.ToLower(role.Username) == strings.ToLower(role.Org) {
+		return fmt.Errorf("org name cannot be same as existing user name")
+	}
 	if role.Org != "" {
 		span := log.SpanFromContext(ctx)
 		span.SetTag("org", role.Org)

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -99,6 +99,10 @@ func TestServer(t *testing.T) {
 		Address: "123 X Way",
 		Phone:   "123-123-1234",
 	}
+	orgX := org1
+	orgX.Name = user1.Name
+	_, err = mcClient.CreateOrg(uri, tokenMisterX, &orgX)
+	require.NotNil(t, err, "create org with same name as user (case-insensitive)")
 	status, err = mcClient.CreateOrg(uri, tokenMisterX, &org1)
 	require.Nil(t, err, "create org")
 	require.Equal(t, http.StatusOK, status, "create org status")
@@ -264,6 +268,14 @@ func TestServer(t *testing.T) {
 	// add users to org with different roles, make sure they can see users
 	testAddUserRole(t, mcClient, uri, tokenMisterX, org1.Name, "DeveloperContributor", user3.Name, Success)
 	testAddUserRole(t, mcClient, uri, tokenMisterX, org1.Name, "DeveloperViewer", user4.Name, Success)
+	// add user with same name as org
+	roleArgX := ormapi.Role{
+		Username: org1.Name,
+		Org:      org1.Name,
+		Role:     "DeveloperViewer",
+	}
+	_, err = mcClient.AddUserRole(uri, tokenMisterX, &roleArgX)
+	require.NotNil(t, err, "user name with same name as org (case-insensitive)")
 	// check that they can see all users in org
 	users, status, err = mcClient.ShowUser(uri, token3, &org1)
 	require.Nil(t, err)


### PR DESCRIPTION
* Gitlab shares same namespace for users & groups
* Added code to disallow username to be same as orgname as per Jon's comment in the bug.