### PR TITLE
EC-1192: Add parent span (controller) for Shepherd tracing

### DIFF
--- a/e2e-tests/int-process/process_defs.go
+++ b/e2e-tests/int-process/process_defs.go
@@ -34,4 +34,5 @@ type Shepherd struct {
 	CloudletKey    string
 	TLS            process.TLSCerts
 	cmd            *exec.Cmd
+	Span           string
 }

--- a/e2e-tests/int-process/process_local.go
+++ b/e2e-tests/int-process/process_local.go
@@ -238,6 +238,10 @@ func (p *Shepherd) GetArgs(opts ...process.StartOp) []string {
 		args = append(args, "--tls")
 		args = append(args, p.TLS.ServerCert)
 	}
+	if p.Span != "" {
+		args = append(args, "--span")
+		args = append(args, p.Span)
+	}
 	options := process.StartOptions{}
 	options.ApplyStartOptions(opts...)
 	if options.Debug != "" {

--- a/e2e-tests/int-process/services.go
+++ b/e2e-tests/int-process/services.go
@@ -24,6 +24,7 @@ func getShepherdProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformC
 	notifyAddr := ""
 	tlsCertFile := ""
 	vaultAddr := ""
+	span := ""
 	if pfConfig != nil {
 		// Same role-id/secret-id as CRM
 		envVars["VAULT_ROLE_ID"] = pfConfig.CrmRoleId
@@ -31,6 +32,7 @@ func getShepherdProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformC
 		notifyAddr = cloudlet.NotifySrvAddr
 		tlsCertFile = pfConfig.TlsCertFile
 		vaultAddr = pfConfig.VaultAddr
+		span = pfConfig.Span
 	}
 
 	opts = append(opts, process.WithDebug("api,mexos,notify,metrics"))
@@ -48,6 +50,7 @@ func getShepherdProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformC
 		},
 		VaultAddr:    vaultAddr,
 		PhysicalName: cloudlet.PhysicalName,
+		Span:         span,
 	}, opts, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/moul/http2curl v1.0.0 // indirect
 	github.com/nmcclain/asn1-ber v0.0.0-20170104154839-2661553a0484
 	github.com/nmcclain/ldap v0.0.0-20160601145537-6e14e8271933
+	github.com/opentracing/opentracing-go v1.1.0
 	github.com/parnurzeal/gorequest v0.2.15
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pion/webrtc/v2 v2.0.24

--- a/shepherd/cloudlet-worker.go
+++ b/shepherd/cloudlet-worker.go
@@ -27,7 +27,7 @@ func CloudletScraper() {
 			ctx := log.ContextWithSpan(context.Background(), span)
 			cloudletStats, err := pf.GetPlatformStats(ctx)
 			if err != nil {
-				log.DebugLog(log.DebugLevelMetrics, "Error retrieving platform metrics", "Platform", pf, "error", err.Error())
+				log.SpanLog(ctx, log.DebugLevelMetrics, "Error retrieving platform metrics", "Platform", pf, "error", err.Error())
 			} else {
 				metrics := MarshalCloudletMetrics(&cloudletStats)
 				for _, metric := range metrics {

--- a/shepherd/nginx-stats_test.go
+++ b/shepherd/nginx-stats_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -8,12 +9,17 @@ import (
 	"testing"
 
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
+	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/stretchr/testify/assert"
 )
 
 var testNginxData = "Active connections: 10\nserver accepts handled requests\n 101 202 303\nReading: 5 Writing: 4 Waiting: 3"
 
 func TestNginxStats(t *testing.T) {
+	log.InitTracer("")
+	defer log.FinishTracer()
+	ctx := log.StartTestSpan(context.Background())
+
 	testScrapePoint := NginxScrapePoint{
 		App:     "UnitTestApp",
 		Cluster: "UnitTestCluster",
@@ -27,7 +33,7 @@ func TestNginxStats(t *testing.T) {
 	nginxUnitTestPort, _ = strconv.ParseInt(strings.Split(fakeNginxTestServer.URL, ":")[2], 10, 32)
 	nginxUnitTest = true
 
-	testMetrics, err := QueryNginx(testScrapePoint)
+	testMetrics, err := QueryNginx(ctx, testScrapePoint)
 
 	assert.Nil(t, err, "Test Querying Nginx")
 	assert.Equal(t, uint64(10), testMetrics.ActiveConn)

--- a/shepherd/shepherd.go
+++ b/shepherd/shepherd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/notify"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 var debugLevels = flag.String("d", "", fmt.Sprintf("comma separated list of %v", log.DebugLevelStrings))
@@ -29,6 +30,7 @@ var vaultAddr = flag.String("vaultAddr", "", "Address to vault")
 var physicalName = flag.String("physicalName", "", "Physical infrastructure cloudlet name, defaults to cloudlet name in cloudletKey")
 var cloudletKeyStr = flag.String("cloudletKey", "", "Json or Yaml formatted cloudletKey for the cloudlet in which this CRM is instantiated; e.g. '{\"operator_key\":{\"name\":\"TMUS\"},\"name\":\"tmocloud1\"}'")
 var name = flag.String("name", "shepherd", "Unique name to identify a process")
+var parentSpan = flag.String("span", "", "Use parent span for logging")
 
 var defaultPrometheusPort = int32(9090)
 
@@ -143,7 +145,13 @@ func main() {
 	log.SetDebugLevelStrs(*debugLevels)
 	log.InitTracer(*tlsCertFile)
 	defer log.FinishTracer()
-	span := log.StartSpan(log.DebugLevelInfo, "main")
+
+	var span opentracing.Span
+	if *parentSpan != "" {
+		span = log.NewSpanFromString(log.DebugLevelInfo, *parentSpan, "main")
+	} else {
+		span = log.StartSpan(log.DebugLevelInfo, "main")
+	}
 	ctx := log.ContextWithSpan(context.Background(), span)
 
 	cloudcommon.ParseMyCloudletKey(false, cloudletKeyStr, &cloudletKey)


### PR DESCRIPTION
* Adds parent span to Shepherd service
* Modified some DebugLogs to SpanLog for Shepherd service

Tests:
```
❯ CreateCloudlet name=ashish-frankfurt operator=TDG location.latitude=32 location.longitude=-122 numdynamicips=1 platformtype=PlatformTypeMexdind physicalname=frankfurt
message: Creating Cloudlet
message: Starting CRMServer
message: Starting Shepherd
message: Gathering Cloudlet Info
message: Cloudlet created successfully
```
```
  501  7648  7591   controller --etcdUrls http://127.0.0.1:30001,http://127.0.0.1:30002,http://127.0.0.1:30003 --notifyAddr 127.0.0.1:37001 --apiAddr 127.0.0.1:55001 --httpAddr 0.0.0.0:36001 --tls /Users/ashishjain/go/src/github.com/mobiledgex/edge-cloud/tls/out/mex-server.crt -d etcd,api,notify -shortTimeouts --vaultAddr https://vault.mobiledgex.net --region EU --versionTag 2019-08-21
  501  7733  7648   crmserver --notifyAddrs 127.0.0.1:37001 --notifySrvAddr 127.0.0.1:51001 --cloudletKey {"operator_key":{"name":"TDG"},"name":"ashish-frankfurt"} --tls /Users/ashishjain/go/src/github.com/mobiledgex/edge-cloud/tls/out/mex-server.crt --platform PLATFORM_TYPE_MEXDIND --vaultAddr https://vault.mobiledgex.net --physicalName frankfurt --span {"uber-trace-id":"715ad54033abed24:715ad54033abed24:0:3"} -d api,mexos,notify,info
  501  7734  7648   shepherd --notifyAddrs 127.0.0.1:51001 --platform PLATFORM_TYPE_MEXDIND --vaultAddr https://vault.mobiledgex.net --physicalName frankfurt --cloudletKey {"operator_key":{"name":"TDG"},"name":"ashish-frankfurt"} --tls /Users/ashishjain/go/src/github.com/mobiledgex/edge-cloud/tls/out/mex-server.crt --span {"uber-trace-id":"715ad54033abed24:715ad54033abed24:0:3"} -d api,mexos,notify,metrics
```