### PR TITLE
EDGECLOUD-1326: create new detailed osflavor type, use json unmarshal

### DIFF
--- a/mexos/openstack.go
+++ b/mexos/openstack.go
@@ -140,6 +140,19 @@ type OSFlavor struct {
 	RAM, Ephemeral, VCPUs, Disk int
 }
 
+type OSFlavorDetail struct {
+	Name       string `json:"name"`
+	ID         string `json:"id"`
+	RAM        int    `json:"ram"`
+	Ephemeral  int    `json:"OS-FLV-EXT-DATA:ephemeral"`
+	VCPUs      int    `json:"vcpus"`
+	Disk       int    `json:"disk"`
+	Disabled   bool   `json:"OS-FLV-DISABLED:disabled"`
+	Public     bool   `json:"os-flavor-access:is_public"`
+	Properties string `json:"properties"`
+	// TBD: access_project_ids : is this flavor available to only certain projects?
+}
+
 type OSSubnet struct {
 	Name, ID, Network, Subnet string
 }

--- a/mexos/oscli.go
+++ b/mexos/oscli.go
@@ -112,23 +112,23 @@ func ListNetworks(ctx context.Context) ([]OSNetwork, error) {
 }
 
 //ShowFlavor returns the details of a given flavor.
-// If the flavor has any properties set, these are returned as well
-func ShowFlavor(ctx context.Context, flavor string) (details string, properties string, err error) {
+func ShowFlavor(ctx context.Context, flavor string) (details OSFlavorDetail, err error) {
 
+	var flav OSFlavorDetail
 	out, err := TimedOpenStackCommand(ctx, "openstack", "flavor", "show", flavor, "-f", "json")
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelMexos, "flavor show failed", "out", out)
 		fmt.Printf("Timed Op return error %d\n", err)
-		return "", "", err
+		return flav, err
 	}
-	s := strings.Index(string(out), "properties")
-	s += len("properties") + 2
-	ms := cloudcommon.QuotedStringRegex.FindAllString(string(out[s:]), -1)
-	ss := make([]string, len(ms))
-	for i, m := range ms {
-		ss[i] = m[1 : len(m)-1]
+
+	err = json.Unmarshal(out, &flav)
+	if err != nil {
+		fmt.Printf("unmar failed: %d\n", err)
+		return flav, err
 	}
-	return string(out), ss[0], err
+	return flav, nil
+
 }
 
 //ListFlavors lists flavors known to the platform.   The ones matching the flavorMatchPattern are returned


### PR DESCRIPTION
Revist 'openstack flavor show $favor -f json' use Unmarshal like everything else. Use separate detailed flavor type.