### PR TITLE
fix cases where the deletion fails because the cluster was deleted manually

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -11,8 +11,8 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/nginx"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
-	"github.com/mobiledgex/edge-cloud/vmspec"
 	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/vmspec"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -240,15 +240,26 @@ func (s *Platform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		}
 		client, err := s.GetPlatformClient(ctx, clusterInst)
 		if err != nil {
+			if clusterInst.IpAccess == edgeproto.IpAccess_IP_ACCESS_DEDICATED &&
+				strings.Contains(err.Error(), "No server with a name or ID") {
+				// if this happens someone very likely deleted the dedicated cluster stack by hand.   If it happens
+				// on the shared RootLB then we have major problems
+				log.SpanLog(ctx, log.DebugLevelMexos, "Dedicated RootLB is gone, allow app deletion")
+				return nil
+			}
 			return err
 		}
+
 		names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
 		if err != nil {
 			return fmt.Errorf("get kube names failed: %s", err)
 		}
-
 		_, masterIP, err := mexos.GetMasterNameAndIP(ctx, clusterInst)
 		if err != nil {
+			if strings.Contains(err.Error(), mexos.ClusterNotFoundErr) {
+				log.SpanLog(ctx, log.DebugLevelMexos, "cluster is gone, allow app deletion")
+				return nil
+			}
 			return err
 		} // Clean up security rules and nginx proxy if app is external
 		if !app.InternalPorts {
@@ -260,11 +271,13 @@ func (s *Platform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 				log.SpanLog(ctx, log.DebugLevelMexos, "cannot clean up DNS entries", "name", names.AppName, "rootlb", rootLBName, "error", err)
 			}
 		}
+
 		if deployment == cloudcommon.AppDeploymentTypeKubernetes {
 			return k8smgmt.DeleteAppInst(client, names, app, appInst)
 		} else {
 			return k8smgmt.DeleteHelmAppInst(client, names, clusterInst)
 		}
+
 	case cloudcommon.AppDeploymentTypeVM:
 		log.SpanLog(ctx, log.DebugLevelMexos, "Deleting VM", "stackName", app.Key.Name)
 		err := mexos.HeatDeleteStack(ctx, app.Key.Name)
@@ -275,7 +288,13 @@ func (s *Platform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 	case cloudcommon.AppDeploymentTypeDocker:
 		client, err := s.GetPlatformClient(ctx, clusterInst)
 		if err != nil {
-			return err
+			if strings.Contains(err.Error(), "No server with a name or ID") {
+				// if the VM is gone then so is the app
+				log.SpanLog(ctx, log.DebugLevelMexos, "Docker VM is gone, allow app deletion")
+				return nil
+			} else {
+				return err
+			}
 		}
 		return dockermgmt.DeleteAppInst(ctx, client, app, appInst)
 	default:

--- a/mexos/ip.go
+++ b/mexos/ip.go
@@ -23,6 +23,8 @@ type NetSpecInfo struct {
 	RouterGatewayIP   string
 }
 
+const ClusterNotFoundErr string = "cluster not found"
+
 //ParseNetSpec decodes netspec string
 //TODO: IPv6
 func ParseNetSpec(ctx context.Context, netSpec string) (*NetSpecInfo, error) {
@@ -185,7 +187,7 @@ func GetMasterNameAndIP(ctx context.Context, clusterInst *edgeproto.ClusterInst)
 	nodeNameSuffix := k8smgmt.GetK8sNodeNameSuffix(&clusterInst.Key)
 	masterName, err := FindClusterMaster(ctx, nodeNameSuffix, srvs)
 	if err != nil {
-		return "", "", fmt.Errorf("can't find cluster with key %s, %v", nodeNameSuffix, err)
+		return "", "", fmt.Errorf("%s -- %s, %v", ClusterNotFoundErr, nodeNameSuffix, err)
 	}
 	masterIP, err := FindNodeIP(masterName, srvs)
 	return masterName, masterIP, err

--- a/mexos/oscli.go
+++ b/mexos/oscli.go
@@ -605,8 +605,12 @@ func deleteHeatStack(ctx context.Context, stackName string) error {
 			log.SpanLog(ctx, log.DebugLevelMexos, "stack not found")
 			return nil
 		}
-		log.InfoLog("stack deletion failed", "stackName", stackName, "out", string(out), "err", err)
-		return fmt.Errorf("stack deletion failed: %s -- %v", stackName, err)
+		log.SpanLog(ctx, log.DebugLevelMexos, "stack deletion failed", "stackName", stackName, "out", string(out), "err", err)
+		if strings.Contains(string(out), "Stack not found") {
+			log.SpanLog(ctx, log.DebugLevelMexos, "stack already deleted", "stackName", stackName)
+			return nil
+		}
+		return fmt.Errorf("stack deletion failed: %s, %s %v", stackName, out, err)
 	}
 	return nil
 }


### PR DESCRIPTION
EDGECLOUD-1346

There is an edge-cloud PR to fix the original issue noticed in Krakow when docker containers were deleted manually by the app developers.  This is similar but deals with cluster deletion cases:
- If the dedicated RootLB is gone, either docker or k8s case
- If the k8s cluster is gone
- when deleting heat stacks for whatever reason, if the stack is already gone