### PR TITLE
Bump up Gitlab version

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1,3 +1,3 @@
-gitlab_version: 11.10.4-ee.0
+gitlab_version: 12.3.5-ee.0
 gitlab_force_reconfigure: false
 gitlab_slack_notify_image_version: 2019-07-26


### PR DESCRIPTION
This is just for any new Gitlab installations.  The actual upgrade from 11.x to 12.3.5 was done manually in the main, stage, and dev environments.