### PR TITLE
EDGECLOUD-1386 Artifactory repository contents are getting deleted

### DIFF
--- a/ansible/main/group_vars/all
+++ b/ansible/main/group_vars/all
@@ -1,2 +1,3 @@
+mc_artifactory_address: https://artifactory.mobiledgex.net/artifactory
 jaeger_hostname: jaeger.mobiledgex.net
 jaeger_endpoint: "https://{{ jaeger_hostname }}:14268/api/traces"

--- a/ansible/qa
+++ b/ansible/qa
@@ -5,6 +5,7 @@ gitlab_vm_hostname=gitlab-{{ deploy_environ }}.mobiledgex.net
 gitlab_email_enabled=false
 gitlab_slack_notifications=false
 gitlab_docker_hostname="docker-{{ deploy_environ }}.mobiledgex.net"
+mc_artifactory_address=https://artifactory-qa.mobiledgex.net/artifactory
 mc_vm_hostname=mc-{{ deploy_environ}}.mobiledgex.net
 mc_ldap_hostname=automationmc.mobiledgex.net
 console_vm_hostname=console-qa.mobiledgex.net

--- a/ansible/roles/mc/tasks/main.yml
+++ b/ansible/roles/mc/tasks/main.yml
@@ -19,8 +19,6 @@
       - "{{ vault_address }}"
       - "-gitlabAddr"
       - "https://{{ gitlab_vm_hostname }}"
-      - "-artifactoryAddr"
-      - "{{ artifactory_address }}"
       - "-ldapAddr"
       - "0.0.0.0:{{ mc_ldap_port }}"
       - "-jaegerAddr"
@@ -33,6 +31,11 @@
       - "/root/tls/mex-server.crt"
       - "-d"
       - "api"
+
+- name: Add artifactory address
+  set_fact:
+    mc_args: "{{ mc_args + [ '-artifactoryAddr', mc_artifactory_address ] }}"
+  when: mc_artifactory_address is defined
 
 - name: Compute MC name
   set_fact:


### PR DESCRIPTION
Point instances explicitly to their Artifactory instances instead of
defaulting to the main artifactory instance.