### PR TITLE
Elasticsearch backend for main Jaeger

### DIFF
--- a/ansible/internal
+++ b/ansible/internal
@@ -12,6 +12,6 @@ influxdb.internal.mobiledgex.net
 vouch.mobiledgex.net
 
 [jaeger]
-jaeger.mobiledgex.net
+jaeger.mobiledgex.net		es_instance=main
 jaeger-dev.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443
 jaeger-qa.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443

--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -344,14 +344,17 @@
     - name: Look up CA cert in vault
       set_fact:
         vault_lookup: "{{ lookup('vault', vault_mex_ca_cert_path) }}"
+      tags: setup
     - set_fact:
         mex_ca_cert: "{{ vault_lookup.mex_ca.data.cert }}"
+      tags: setup
 
     - name: Copy CA cert
       copy:
         dest: "{{ mex_ca_cert_path }}"
         content: "{{ mex_ca_cert }}"
       become: yes
+      tags: setup
 
     - import_role:
         name: web

--- a/ansible/roles/jaeger/tasks/main.yml
+++ b/ansible/roles/jaeger/tasks/main.yml
@@ -1,10 +1,57 @@
 ---
-- name: Deploy jaeger
+- name: Deploy all-in-one jaeger
   docker_container:
     name: jaeger
     image: "{{ jaeger_image }}"
+    restart_policy: unless-stopped
     ports:
       - 127.0.0.1:24268:14268
       - 127.0.0.1:26686:16686
+  when:
+    - es_instance is not defined
 
+- name: Deploy jaeger components
+  block:
+    - name: Compute vault path for creds
+      set_fact:
+        vault_es_path: "secret/ansible/internal/accounts/elasticsearch/{{ es_instance }}"
 
+    - name: Look up elasticsearch credentials in vault
+      set_fact:
+        vault_lookup: "{{ lookup('vault', vault_es_path) }}"
+
+    - set_fact:
+        jaeger_es_url: "{{ vault_lookup.main.data.url }}"
+        jaeger_es_user: "{{ vault_lookup.main.data.user }}"
+        jaeger_es_pass: "{{ vault_lookup.main.data.pass }}"
+
+    - name: Deploy jaeger collector
+      docker_container:
+        name: jaeger-collector
+        image: "jaegertracing/jaeger-collector:{{ jaeger_version }}"
+        restart_policy: unless-stopped
+        ports:
+          - 127.0.0.1:24268:14268
+        env:
+          SPAN_STORAGE_TYPE: elasticsearch
+          ES_SERVER_URLS: "{{ jaeger_es_url }}"
+          ES_INDEX_PREFIX: "{{ es_index_prefix | default('main') }}"
+          ES_USERNAME: "{{ jaeger_es_user }}"
+          ES_PASSWORD: "{{ jaeger_es_pass }}"
+
+    - name: Deploy jaeger query
+      docker_container:
+        name: jaeger-query
+        image: "jaegertracing/jaeger-query:{{ jaeger_version }}"
+        restart_policy: unless-stopped
+        ports:
+          - 127.0.0.1:26686:16686
+        env:
+          SPAN_STORAGE_TYPE: elasticsearch
+          ES_SERVER_URLS: "{{ jaeger_es_url }}"
+          ES_INDEX_PREFIX: "{{ es_index_prefix | default('main') }}"
+          ES_USERNAME: "{{ jaeger_es_user }}"
+          ES_PASSWORD: "{{ jaeger_es_pass }}"
+
+  when:
+    - es_instance is defined


### PR DESCRIPTION
Also fixed as issue with missing restart_policy for jaeger containers.

Right now, the ElasticSearch backend is a (trial version) hosted ElasticSearch instance.  Set that up as a experiment, but given that our Elasticsearch needs are not that large, a single-node cluster hosted in GCP would be significantly cheaper.  Will set that up and switch the main jaeger to that soon.