### PR TITLE
EDGECLOUD-1385 cache authz for role show to speed it up

### DIFF
--- a/mc/orm/authz_show.go
+++ b/mc/orm/authz_show.go
@@ -1,0 +1,31 @@
+package orm
+
+import "context"
+
+type AuthzShow struct {
+	allowedOrgs map[string]struct{}
+	allowAll    bool
+}
+
+func newShowAuthz(ctx context.Context, username, resource, action string) (*AuthzShow, error) {
+	orgs, err := enforcer.GetAuthorizedOrgs(ctx, username, resource, action)
+	if err != nil {
+		return nil, err
+	}
+	authz := AuthzShow{
+		allowedOrgs: orgs,
+	}
+	if _, found := orgs[""]; found {
+		// user is an admin.
+		authz.allowAll = true
+	}
+	return &authz, nil
+}
+
+func (s *AuthzShow) Ok(ctx context.Context, org string) bool {
+	if s.allowAll {
+		return true
+	}
+	_, found := s.allowedOrgs[org]
+	return found
+}

--- a/mc/orm/orgcloudletpools.go
+++ b/mc/orm/orgcloudletpools.go
@@ -185,9 +185,14 @@ func ShowOrgCloudletPoolObj(ctx context.Context, username string) ([]ormapi.OrgC
 	if err != nil {
 		return nil, dbErr(err)
 	}
+	authz, err := newShowAuthz(ctx, username, ResourceCloudletPools, ActionView)
+	if err != nil {
+		return nil, err
+	}
+
 	retops := []ormapi.OrgCloudletPool{}
 	for _, op := range ops {
-		if !authorized(ctx, username, op.Org, ResourceCloudletPools, ActionView) {
+		if !authz.Ok(ctx, op.Org) {
 			continue
 		}
 		retops = append(retops, op)

--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -417,12 +417,17 @@ func ShowUserRoleObj(ctx context.Context, username string) ([]ormapi.Role, error
 	if err != nil {
 		return nil, dbErr(err)
 	}
+	authz, err := newShowAuthz(ctx, username, ResourceUsers, ActionView)
+	if err != nil {
+		return nil, err
+	}
+
 	for ii, _ := range groupings {
 		role := parseRole(groupings[ii])
 		if role == nil {
 			continue
 		}
-		if !authorized(ctx, username, role.Org, ResourceUsers, ActionView) {
+		if !authz.Ok(ctx, role.Org) {
 			continue
 		}
 		roles = append(roles, *role)


### PR DESCRIPTION
This caches info from postgres for role show, so that postgres doesn't need to be queried for every single role.