### PR TITLE
EDGECLOUD-1362 UI: Console must not use non-standard ports

### DIFF
--- a/ansible/roles/console/tasks/main.yml
+++ b/ansible/roles/console/tasks/main.yml
@@ -21,3 +21,4 @@
       - "127.0.0.1:13030:3030"
     env:
       MC_URL: "https://{{mc_vm_hostname}}:{{mc_api_port}}"
+      REACT_APP_API_USE_SERVER_SUFFIX: "true"

--- a/ansible/templates/mexplat/console-nginx-config.j2
+++ b/ansible/templates/mexplat/console-nginx-config.j2
@@ -20,7 +20,7 @@ server {
 
 	location /server {
 		rewrite /server/(.*) /$1  break;
-		proxy_pass https://127.0.0.1:3030;
+		proxy_pass https://127.0.0.1:13030;
 		proxy_redirect     off;
 		proxy_set_header   Host $host;
 	}
@@ -38,22 +38,5 @@ server {
 
 	if ($scheme != "https") {
 		return 301 https://$host$request_uri;
-	}
-}
-
-server {
-	listen 3030 ssl;
-	listen [::]:3030 ssl ipv6only=on;
-
-        ssl_certificate {{ letsencrypt_root }}/{{ console_vm_hostname }}/fullchain.pem;
-        ssl_certificate_key {{ letsencrypt_root }}/{{ console_vm_hostname }}/privkey.pem;
-        ssl_session_cache shared:le_nginx_SSL:1m;
-        ssl_session_cache shared:le_nginx_SSL:1m;
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_prefer_server_ciphers on;
-        ssl_ciphers "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS";
-
-	location / {
-		proxy_pass https://127.0.0.1:13030;
 	}
 }


### PR DESCRIPTION
Make the console server share port 443 with the UI service instead of
listening on port 3030.

The changes to make the UI talk to the server on https://&lt;console-host&gt;/server instead of https://&lt;console-host&gt;:3030 is implemented in v1.0.9 of the console (in edge-cloud-ui) and activated by the environment variable REACT_APP_API_USE_SERVER_SUFFIX.