### PR TITLE
fix openstack version

### DIFF
--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -34,8 +34,8 @@ RUN apt-get update && apt-get install -y \
 	azure-cli \
 	google-cloud-sdk \
 	kubectl 
-RUN pip install python-heatclient
-RUN pip install python-openstackclient
+RUN pip install python-heatclient==1.18.0
+RUN pip install python-openstackclient==3.18.0
 RUN pip install gnocchiclient
 
 COPY edge-cloud-base-image.root/_ssh /root/.ssh


### PR DESCRIPTION
EDGECLOUD-1457

When the edge-cloud-base-image was rebuilt recently, it pulled a new, developer-branch version of the openstack client.  This is not compatible with the current OpenStack versions we are interworking with.

Freeze the openstack cli versions to fix this.