### PR TITLE
fix additional cases when stack deleted

### DIFF
--- a/mexos/cluster.go
+++ b/mexos/cluster.go
@@ -204,7 +204,11 @@ func DeleteCluster(ctx context.Context, rootLBName string, clusterInst *edgeprot
 	dedicatedRootLB := clusterInst.IpAccess == edgeproto.IpAccess_IP_ACCESS_DEDICATED
 	client, err := GetSSHClient(ctx, rootLBName, GetCloudletExternalNetwork(), SSHUser)
 	if err != nil {
-		return err
+		if strings.Contains(err.Error(), "No server with a name or ID") {
+			log.SpanLog(ctx, log.DebugLevelMexos, "Dedicated RootLB is gone, allow stack delete to proceed")
+		} else {
+			return err
+		}
 	}
 	err = HeatDeleteCluster(ctx, client, clusterInst, rootLBName, dedicatedRootLB)
 	if err != nil {

--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -525,8 +525,9 @@ func CreateHeatStackFromTemplate(ctx context.Context, templateData interface{}, 
 func HeatDeleteCluster(ctx context.Context, client pc.PlatformClient, clusterInst *edgeproto.ClusterInst, rootLBName string, dedicatedRootLB bool) error {
 	cp, err := getClusterParams(ctx, clusterInst, rootLBName, dedicatedRootLB, heatDelete)
 	if err == nil {
-		// no need to detach the port from the dedicated RootLB because the VM is going away with the stack
-		if cp.RootLBPortName != "" && !dedicatedRootLB {
+		// no need to detach the port from the dedicated RootLB because the VM is going away with the stack.  A nil client can be passed here in
+		// some rare cases because the server was somehow deleted
+		if cp.RootLBPortName != "" && !dedicatedRootLB && client != nil {
 			err = DetachAndDisableRootLBInterface(ctx, client, rootLBName, cp.RootLBPortName, cp.GatewayIP)
 			if err != nil {
 				log.SpanLog(ctx, log.DebugLevelMexos, "unable to detach rootLB interface, proceed with stack deletion", "err", err)


### PR DESCRIPTION
Fix additional cases for EDGECLOUD-1340:
- in the appisnt dedicated case, check for the existence of the rootLB before deletion by calling GetServerDetails.  This will add a couple seconds to delete time, but prevents long hangs and possible failures if the server is gone
- fix additional case of clusterinst delete which I introduced with the no-router changes