### PR TITLE
updates to image pull secrets per review

### DIFF
--- a/crm-platforms/azure/azure-appinst.go
+++ b/crm-platforms/azure/azure-appinst.go
@@ -31,7 +31,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 	}
 	updateCallback(edgeproto.UpdateTask, "Creating Registry Secret")
 
-	err = mexos.CreateDockerRegistrySecret(ctx, client, clusterInst, app, s.config.VaultAddr)
+	err = mexos.CreateDockerRegistrySecret(ctx, client, clusterInst, app, s.config.VaultAddr, names)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/gcp/gcp-appinst.go
+++ b/crm-platforms/gcp/gcp-appinst.go
@@ -27,7 +27,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 	if err != nil {
 		return err
 	}
-	err = mexos.CreateDockerRegistrySecret(ctx, client, clusterInst, app, s.config.VaultAddr)
+	err = mexos.CreateDockerRegistrySecret(ctx, client, clusterInst, app, s.config.VaultAddr, names)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/mexdind/mexdind-appinst.go
+++ b/crm-platforms/mexdind/mexdind-appinst.go
@@ -24,7 +24,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 	if err != nil {
 		return err
 	}
-	err = mexos.CreateDockerRegistrySecret(ctx, client, clusterInst, app, s.config.VaultAddr)
+	err = mexos.CreateDockerRegistrySecret(ctx, client, clusterInst, app, s.config.VaultAddr, names)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -40,7 +40,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 			return err
 		}
 		updateCallback(edgeproto.UpdateTask, "Setting up registry secret")
-		err = mexos.CreateDockerRegistrySecret(ctx, client, clusterInst, app, s.config.VaultAddr)
+		err = mexos.CreateDockerRegistrySecret(ctx, client, clusterInst, app, s.config.VaultAddr, names)
 		if err != nil {
 			return err
 		}

--- a/mexos/kubectl.go
+++ b/mexos/kubectl.go
@@ -16,7 +16,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func CreateDockerRegistrySecret(ctx context.Context, client pc.PlatformClient, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, vaultAddr string) error {
+func CreateDockerRegistrySecret(ctx context.Context, client pc.PlatformClient, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, vaultAddr string, names *k8smgmt.KubeNames) error {
 	var out string
 	log.SpanLog(ctx, log.DebugLevelMexos, "creating docker registry secret in kubernetes cluster")
 	auth, err := cloudcommon.GetRegistryAuth(ctx, app.ImagePath, vaultAddr)
@@ -54,6 +54,7 @@ func CreateDockerRegistrySecret(ctx context.Context, client pc.PlatformClient, c
 			log.SpanLog(ctx, log.DebugLevelMexos, "warning, docker registry secret already exists.")
 		}
 	}
+	names.ImagePullSecret = secretName
 	log.SpanLog(ctx, log.DebugLevelMexos, "ok, created registry secret", "out", out)
 	return nil
 }


### PR DESCRIPTION
Infra changes per comments to edge-cloud/pull/682:

When creating a docker registry secret, add the secret name to the kubenames.  This is used in the edge-cloud PR in MergeEnvVars