### PR TITLE
EDGECLOUD-1472: Multiple Orgs with same App name for VM deployments might fail

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -157,9 +157,10 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		if err != nil {
 			return fmt.Errorf("unable to find closest flavor for app: %v", err)
 		}
+		objName := cloudcommon.GetAppFQN(&app.Key)
 		vmp, err := mexos.GetVMParams(ctx,
 			mexos.UserVMDeployment,
-			app.Key.Name,
+			objName,
 			vmspec.FlavorName,
 			vmspec.ExternalVolumeSize,
 			imageName,
@@ -173,12 +174,12 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 			return fmt.Errorf("unable to get vm params: %v", err)
 		}
 		updateCallback(edgeproto.UpdateTask, "Deploying VM")
-		log.SpanLog(ctx, log.DebugLevelMexos, "Deploying VM", "stackName", app.Key.Name, "vmspec", vmspec)
-		err = mexos.CreateHeatStackFromTemplate(ctx, vmp, app.Key.Name, mexos.VmTemplate, updateCallback)
+		log.SpanLog(ctx, log.DebugLevelMexos, "Deploying VM", "stackName", objName, "vmspec", vmspec)
+		err = mexos.CreateHeatStackFromTemplate(ctx, vmp, objName, mexos.VmTemplate, updateCallback)
 		if err != nil {
 			return err
 		}
-		external_ip, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), app.Key.Name)
+		external_ip, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), objName)
 		if err != nil {
 			return err
 		}
@@ -188,7 +189,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 				return err
 			}
 			log.SpanLog(ctx, log.DebugLevelMexos, "DNS A record activated",
-				"name", app.Key.Name,
+				"name", objName,
 				"fqdn", fqdn,
 				"IP", external_ip)
 		}
@@ -291,8 +292,9 @@ func (s *Platform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		}
 
 	case cloudcommon.AppDeploymentTypeVM:
-		log.SpanLog(ctx, log.DebugLevelMexos, "Deleting VM", "stackName", app.Key.Name)
-		err := mexos.HeatDeleteStack(ctx, app.Key.Name)
+		objName := cloudcommon.GetAppFQN(&app.Key)
+		log.SpanLog(ctx, log.DebugLevelMexos, "Deleting VM", "stackName", objName)
+		err := mexos.HeatDeleteStack(ctx, objName)
 		if err != nil {
 			return fmt.Errorf("DeleteVMAppInst error: %v", err)
 		}
@@ -394,7 +396,8 @@ func (s *Platform) GetContainerCommand(ctx context.Context, clusterInst *edgepro
 func (s *Platform) GetConsoleUrl(ctx context.Context, app *edgeproto.App) (string, error) {
 	switch deployment := app.Deployment; deployment {
 	case cloudcommon.AppDeploymentTypeVM:
-		consoleUrl, err := mexos.OSGetConsoleUrl(ctx, app.Key.Name)
+		objName := cloudcommon.GetAppFQN(&app.Key)
+		consoleUrl, err := mexos.OSGetConsoleUrl(ctx, objName)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
This fixes following issues:
* EDGECLOUD-1472: Multiple Orgs with same App name for VM deployments might fail
  * AppName & StackName will have dev.appname.vers
* EDGECLOUD-1517: Periods (".") should not be allowed in app names for VM-based (QCOW) apps
  * For this, i have added DNSSanitize code
* For existing deployments, we'll need to modify names manually
* Please corresponding changes in [EC repo](https://github.com/mobiledgex/edge-cloud/pull/690) as well

Thanks!