### PR TITLE
Wildcard cert for DMEs

### DIFF
--- a/ansible/roles/dme/tasks/main.yml
+++ b/ansible/roles/dme/tasks/main.yml
@@ -11,21 +11,12 @@
 - set_fact:
     cert_name: "{{ dme_dns | replace('.', '-') }}"
     cert_secret_name: "{{ dme_dns | replace('.', '-') }}-global-tls"
-    fqdn_list: [ "{{ dme_dns }}.{{ cloudflare_zone }}" ]
 
-- name: Set global DME aliases
-  set_fact:
-    fqdn_list: "{{ dme_aliases }}"
-  when: dme_aliases|length > 0
-
-- set_fact:
-    cert_id: "{{ fqdn_list | join(',') }}"
-
-- name: "Get DME cert from vault for domain(s): {{ fqdn_list }}"
+- name: "Get wildcard DME cert from vault"
   set_fact:
     vault_lookup: "{{ lookup('vault', cert_path) }}"
   vars:
-    cert_path: "certs/cert/{{ cert_id }}:dmecert"
+    cert_path: "certs/cert/_.dme.{{ cloudflare_zone }}:dmecert"
 
 - name: "Generate DME tls secret: {{ cert_secret_name }}"
   k8s:

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -3,5 +3,5 @@ vault_version: 1.1.2
 vault_checksum: sha256:e927fd4daac11f6c7b8b3f1f53f2017516e29e99585dc975b657acdeac43500b
 vault_letsencrypt_plugin: "{{ artifactory_address }}/binaries/vault-letsencrypt-plugin/1.1/letsencrypt-plugin"
 vault_letsencrypt_plugin_sha256sum: e111a2db44059d0e460178ec25eaab72c7b44667d5a0f89fcae18d37ad86155d
-certgen_image_version: 2019-09-08
+certgen_image_version: 2019-11-01
 additional_vault_domains: ''

--- a/ansible/roles/vault/tasks/main.yml
+++ b/ansible/roles/vault/tasks/main.yml
@@ -174,18 +174,22 @@
 
 - set_fact:
     le_env: "{{ letsencrypt_env | default('staging') }}"
+  tags: certgen
 
 - name: Lookup up NS1 apikey in vault
   set_fact:
     vault_lookup: "{{ lookup('vault', vault_ns1_apikey_path) }}"
+  tags: certgen
 
 - set_fact:
     ns1_apikey: "{{ vault_lookup.ns1.data.apikey }}"
+  tags: certgen
 
 - name: Load cloudflare creds
   import_role:
     name: load-vault-creds
     tasks_from: cloudflare
+  tags: certgen
 
 - name: "Deploy certgen service ({{ le_env }})"
   docker_container:
@@ -203,6 +207,7 @@
       CF_USER: "{{ cloudflare_account_email }}"
       CF_APIKEY: "{{ cloudflare_account_api_token }}"
       NS1_APIKEY: "{{ ns1_apikey }}"
+  tags: certgen
 
 - name: Set default cert ACLs
   acl:
@@ -272,6 +277,8 @@
 
 - debug:
     msg: "Vault needs to be initialized"
-  when: not result.json.initialized
+  when:
+    - not ansible_check_mode
+    - not result.json.initialized
   changed_when: true
   notify: Vault initialization prompt

--- a/vault/letsencrypt-plugin/docker/app.rb
+++ b/vault/letsencrypt-plugin/docker/app.rb
@@ -54,14 +54,17 @@ get "/cert/:domain" do
     end
   end
 
-  domain_list = domains.join(',')
+  domain_id = domains.join(',')
 
-  certdir = File.join(LETSENCRYPT_DIR, domain_list)
+  # Replace wildcard requests starting with an '_.' with '*'
+  domain_list = domains.map{|d| d.sub(/^_\./, '*.')}
+
+  certdir = File.join(LETSENCRYPT_DIR, domain_id)
   if not Dir.exist? certdir
     certbot_run = certbot \
                     + dns_provider_args[dns_provider] \
-                    + [ "--cert-name", domain_list ] \
-                    + domains.map{|d| [ "-d", d ]}.flatten
+                    + [ "--cert-name", domain_id ] \
+                    + domain_list.map{|d| [ "-d", d ]}.flatten
     ok = system(*certbot_run)
     if not ok
       status 401


### PR DESCRIPTION
With the MCC-MNC DME aliases, we can't have DME certs for specific FQDNs as the list of aliases can change without the actual DME being redeployed.  This change switches DMEs to use a common wildcard `*.dme.mobiledgex.net` cert.

`ansible/roles/dme/tasks/main.yml`
  - Get rid of specific certs for each DME and instead use a common wildcard cert for all DMEs

`ansible/roles/vault/tasks/main.yml`
  - Some ansible tweaks to allow selective deployment

`vault/letsencrypt-plugin/docker/app.rb`
  - Vault plugin backend to generate wildcard certs
