### PR TITLE
EDGECLOUD-1373: Cloudlet stuck in delete prepare state when phyicalname is invalid

### DIFF
--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -357,11 +357,14 @@ func (s *Platform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 func (s *Platform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelMexos, "Deleting cloudlet", "cloudletName", cloudlet.Key.Name)
 
+	updateCallback(edgeproto.UpdateTask, "Deleting cloudlet")
+
 	// Soure OpenRC file to access openstack API endpoint
-	updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Sourcing platform variables for %s cloudlet", cloudlet.PhysicalName))
 	err := mexos.InitOpenstackProps(ctx, cloudlet.Key.OperatorKey.Name, cloudlet.PhysicalName, pfConfig.VaultAddr)
 	if err != nil {
-		return err
+		// ignore this error, as no creation would've happened on infra, so nothing to delete
+		log.SpanLog(ctx, log.DebugLevelMexos, "failed to source platform variables", "cloudletName", cloudlet.Key.Name, "err", err)
+		return nil
 	}
 
 	platform_vm_name := getPlatformVMName(cloudlet)


### PR DESCRIPTION
* If physicalname is invalid, then CreateCloudlet will fail. Because this is happening on infra side, we undo the creation by deleting the cloudlet. In deletion, we source platform variables using physicalname (which is invalid). And hence, deletion also fails. 
* Have added code to ignore this failure, because if init fails, creation itself will fail and hence there is nothing to delete
* Also, changed the message from `Sourcing platform ....` to `Deleting cloudlet` as it is repetitive when deletion happens as part of undo process during CreateCloudlet .
* Do review corresponding changes in [ec-repo](https://github.com/mobiledgex/edge-cloud/pull/696) as well.

Thanks!