### PR TITLE
EDGECLOUD-1525 audit log show commands if failed

### DIFF
--- a/e2e-tests/data/mc_admin_data.yml
+++ b/e2e-tests/data/mc_admin_data.yml
@@ -2,10 +2,6 @@ controllers:
 - region: local
   address: "127.0.0.1:55001"
   influxdb: "http://127.0.0.1:8086"
-- region: usa
-  address: "usa.mc.mobiledgex.com:55001"
-- region: germany
-  address: "germany.mc.mobiledgex.com:55001"
 
 orgs:
 - name: enterprise

--- a/e2e-tests/data/mc_cloudlets_flavors.yml
+++ b/e2e-tests/data/mc_cloudlets_flavors.yml
@@ -2,10 +2,6 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
-- region: usa
-  address: usa.mc.mobiledgex.com:55001
-- region: germany
-  address: germany.mc.mobiledgex.com:55001
 regiondata:
 - region: local
   appdata:

--- a/e2e-tests/data/mc_flavors.yml
+++ b/e2e-tests/data/mc_flavors.yml
@@ -2,10 +2,6 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
-- region: usa
-  address: usa.mc.mobiledgex.com:55001
-- region: germany
-  address: germany.mc.mobiledgex.com:55001
 regiondata:
 - region: local
   appdata:

--- a/e2e-tests/data/mc_showaudit_admin.yml
+++ b/e2e-tests/data/mc_showaudit_admin.yml
@@ -65,26 +65,26 @@
   username: mexadmin
   clientip: 127.0.0.1
   status: 200
-  starttime: "2019-09-26T15:31:34.97016-07:00"
-  duration: 1.497ms
-  request: '{"Region":"germany","Address":"germany.mc.mobiledgex.com:55001","InfluxDB":"","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
-  response: '{"message":"Controller deregistered"}'
-  traceid: 330ebf735516f800
-- operationname: /api/v1/auth/controller/delete
-  username: mexadmin
-  clientip: 127.0.0.1
-  status: 200
-  starttime: "2019-09-26T15:31:34.96522-07:00"
-  duration: 1.492ms
-  request: '{"Region":"usa","Address":"usa.mc.mobiledgex.com:55001","InfluxDB":"","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
-  response: '{"message":"Controller deregistered"}'
-  traceid: 4b6e24c72c5334cd
-- operationname: /api/v1/auth/controller/delete
-  username: mexadmin
-  clientip: 127.0.0.1
-  status: 200
   starttime: "2019-09-26T15:31:34.960139-07:00"
   duration: 1.48ms
   request: '{"Region":"local","Address":"127.0.0.1:55001","InfluxDB":"http://127.0.0.1:8086","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
   response: '{"message":"Controller deregistered"}'
   traceid: 2a2c6480666aff04
+- operationname: /api/v1/auth/role/removeuser
+  username: mexadmin
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2019-11-05T17:06:33.239904-08:00"
+  duration: 586µs
+  request: '{"org":"enterprise","username":"user3","role":"DeveloperManager"}'
+  response: '{"message":"Role removed from user"}'
+  traceid: 1c1aff34d0d8f0a9
+- operationname: /api/v1/auth/org/delete
+  username: mexadmin
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2019-11-05T17:06:33.229084-08:00"
+  duration: 7.6ms
+  request: '{"Name":"enterprise","Type":"developer","Address":"enterprise headquarters","Phone":"123-123-1234","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
+  response: '{"message":"Organization deleted"}'
+  traceid: 384d9326d52eefe9

--- a/e2e-tests/data/mc_showaudit_all.yml
+++ b/e2e-tests/data/mc_showaudit_all.yml
@@ -85,6 +85,6 @@
   status: 200
   starttime: "2019-09-26T15:30:00.278638-07:00"
   duration: 1.413ms
-  request: '{"Region":"germany","Address":"germany.mc.mobiledgex.com:55001","InfluxDB":"","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
+  request: '{"Region":"local","Address":"127.0.0.1:55001","InfluxDB":"http://127.0.0.1:8086","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
   response: '{"message":"Controller deregistered"}'
   traceid: 7e61d350f6c309c3

--- a/e2e-tests/data/mc_user1_data_show.yml
+++ b/e2e-tests/data/mc_user1_data_show.yml
@@ -2,10 +2,6 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
-- region: usa
-  address: usa.mc.mobiledgex.com:55001
-- region: germany
-  address: germany.mc.mobiledgex.com:55001
 orgs:
 - name: tmus
   type: operator

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -2,10 +2,6 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
-- region: usa
-  address: usa.mc.mobiledgex.com:55001
-- region: germany
-  address: germany.mc.mobiledgex.com:55001
 orgs:
 - name: AcmeAppCo
   type: developer

--- a/e2e-tests/data/mc_user3_data_show.yml
+++ b/e2e-tests/data/mc_user3_data_show.yml
@@ -4,14 +4,6 @@ controllers:
   influxdb: http://127.0.0.1:8086
   createdat: 2019-09-26T14:54:12.019247-07:00
   updatedat: 2019-09-26T14:54:12.019247-07:00
-- region: usa
-  address: usa.mc.mobiledgex.com:55001
-  createdat: 2019-09-26T14:54:12.021051-07:00
-  updatedat: 2019-09-26T14:54:12.021051-07:00
-- region: germany
-  address: germany.mc.mobiledgex.com:55001
-  createdat: 2019-09-26T14:54:12.022424-07:00
-  updatedat: 2019-09-26T14:54:12.022424-07:00
 orgs:
 - name: enterprise
   type: developer

--- a/e2e-tests/data/mc_user3_empty_show.yml
+++ b/e2e-tests/data/mc_user3_empty_show.yml
@@ -4,14 +4,6 @@ controllers:
   influxdb: http://127.0.0.1:8086
   createdat: 2019-09-26T15:12:31.962691-07:00
   updatedat: 2019-09-26T15:12:31.962691-07:00
-- region: usa
-  address: usa.mc.mobiledgex.com:55001
-  createdat: 2019-09-26T15:12:31.964426-07:00
-  updatedat: 2019-09-26T15:12:31.964426-07:00
-- region: germany
-  address: germany.mc.mobiledgex.com:55001
-  createdat: 2019-09-26T15:12:31.965676-07:00
-  updatedat: 2019-09-26T15:12:31.965676-07:00
 orgs:
 - name: enterprise
   type: developer


### PR DESCRIPTION
Fixes code to log show commands if they failed. There were two issues,
1. nexterr is actually nil even on failure, what happens is the status in the result body is set to something besides 200 (ok).
2. The "IgnoreLvl" wasn't allowing logs to accumulate on the span (see https://github.com/mobiledgex/edge-cloud/pull/700 for accompanying fix).

I removed the dummy controllers in the e2e test data because they always caused errors and I don't think we really need to test multiple objects for the controller API in e2e tests. With them there and this new feature, there were a lot of show failures ending up in the audit logs.