### PR TITLE
Use letsencrypt production certs in the dev setup

### DIFF
--- a/ansible/development/list
+++ b/ansible/development/list
@@ -18,7 +18,6 @@ console_vm_hostname=console-dev.mobiledgex.net
 gitlab_email_enabled=false
 gitlab_slack_notifications=false
 gitlab_docker_hostname="docker-{{ deploy_environ }}.mobiledgex.net"
-use_letsencrypt_staging=True
 azure_volume_storage_class=default
 influxdb_volume_size=1Gi
 vault_firewall_setup=no


### PR DESCRIPTION
The original reasoning was to avoid hitting letsencrypt rate limits by using staging certs in the dev setup.  But we almost never tear the setup down and rebuild it from scratch, and so we don't really hit letsencrypt often enough to trigger rate limits.