### PR TITLE
EDGECLOUD-1527 mcctl crash on RunCommand

### DIFF
--- a/mc/mcctl/ormctl/execreq.go
+++ b/mc/mcctl/ormctl/execreq.go
@@ -49,10 +49,13 @@ func runExecRequest(c *cli.Command, args []string) error {
 	var clusterdeveloper string
 	for _, arg := range args {
 		parts := strings.Split(arg, "=")
+		if len(parts) != 2 {
+			continue
+		}
 		if parts[0] == "developer" {
 			developer = parts[1]
 		}
-		if parts[1] == "clusterdeveloper" {
+		if parts[0] == "clusterdeveloper" {
 			clusterdeveloper = parts[1]
 		}
 	}


### PR DESCRIPTION
Fix mcctl crashes when doing RunCommand with unknown appinst. Problem was array out of bounds access.