### PR TITLE
EDGECLOUD-1563 audit log broken in 1.1.18

### DIFF
--- a/ansible/templates/internal/elasticsearch/docker-compose.yml.j2
+++ b/ansible/templates/internal/elasticsearch/docker-compose.yml.j2
@@ -10,7 +10,7 @@ services:
       - discovery.seed_hosts=es01,es02
       - cluster.initial_master_nodes=es01,es02
       - ELASTIC_PASSWORD={{ es_root_pass }}
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
       - xpack.license.self_generated.type=basic 
       - xpack.security.enabled=true
       - xpack.security.http.ssl.enabled=true
@@ -37,7 +37,7 @@ services:
       - discovery.seed_hosts=es01,es02
       - cluster.initial_master_nodes=es01,es02
       - ELASTIC_PASSWORD={{ es_root_pass }}
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
       - xpack.license.self_generated.type=basic
       - xpack.security.enabled=true
       - xpack.security.http.ssl.enabled=true


### PR DESCRIPTION
Elasticsearch needs a heap size bump