### PR TITLE
EDGECLOUD-1574 - use force option for ifdown

### DIFF
--- a/mexos/lb.go
+++ b/mexos/lb.go
@@ -308,9 +308,9 @@ func configureInternalInterfaceAndExternalForwarding(ctx context.Context, client
 		if err != nil {
 			return fmt.Errorf("unable to write interface config file: %s -- %v", filename, err)
 		}
-		// now bring the new internal interface up
-		log.SpanLog(ctx, log.DebugLevelMexos, "bringing up interface", "internalIfname", internalIfname)
-		cmd = fmt.Sprintf("sudo ifdown %s;sudo ifup %s", internalIfname, internalIfname)
+		// now bring the new internal interface up.
+		cmd = fmt.Sprintf("sudo ifdown --force %s;sudo ifup %s", internalIfname, internalIfname)
+		log.SpanLog(ctx, log.DebugLevelMexos, "bringing up interface", "internalIfname", internalIfname, "cmd", cmd)
 		out, err = client.Output(cmd)
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelMexos, "unable to run ifup", "out", out, "err", err)


### PR DESCRIPTION
EDGECLOUD-1574: the new cluster rootlb interfaces failed to come up in an automation test environment because of a state inconsistency.  

The ifup/ifdown commands rely on the /run/network/ifstate to know the state.  

Somehow in the test environment here the ifstate file was mismatched with the real state, probably due to deletion of the cluster stack outside of CRM.  To deal with this possibility, use the --force option when doing the ifdown to force the interface to be deconfigured so it can be reconfigured. 