### PR TITLE
Empty netspec for CreateCloudlet

### DIFF
--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -472,8 +472,8 @@ func GetVMParams(ctx context.Context, depType DeploymentType, serverName, flavor
 	ni, err := ParseNetSpec(ctx, GetCloudletNetworkScheme())
 	if err != nil {
 		// The netspec should always be present but is not set when running OpenStack from the controller.
-		// for now, tolerate this as it will work with default settings but not anywhere that requires a non-default
-		// netspec.  TODO This meeds a general fix
+		// For now, tolerate this as it will work with default settings but not anywhere that requires a non-default
+		// netspec.  TODO This meeds a general fix to allow CreateCloudlet to work with floating IPs.
 		log.SpanLog(ctx, log.DebugLevelMexos, "WARNING, empty netspec")
 	}
 	if depType != UserVMDeployment {


### PR DESCRIPTION
EDGECLOUD-1579

I broke CreateCloudlet  in TDG as I did not adequately test after my last set of review changes.

When doing CreateCloudlet, the controller creates a VM but it has no netspec info.   After my latest changes, this will fail.   

This is a quick change to revert this behavior and unblock the test team.   This is still broken in any cloudlet that requires floating IPs, so eventually this should be reverted and become and error again when the Controller based deploy can populate the cloudlet netspec.
