### PR TITLE
EDGECLOUD-1581: unable to create VM app instances

### DIFF
--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -425,6 +425,9 @@ func waitForStack(ctx context.Context, stackname string, action string, updateCa
 
 func WithPublicKey(authPublicKey string) VMParamsOp {
 	return func(vmp *VMParams) error {
+		if authPublicKey == "" {
+			return nil
+		}
 		convKey, err := util.ConvertPEMtoOpenSSH(authPublicKey)
 		if err != nil {
 			return err


### PR DESCRIPTION
No conversion should take place if authpublickey is empty