### PR TITLE
EDGECLOUD-1582 disallow mobiledgex org name

### DIFF
--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud-infra/mc/rbac"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/log"
 )
 
@@ -62,6 +63,11 @@ func CreateOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.Organizat
 	}
 	if strings.ToLower(claims.Username) == strings.ToLower(org.Name) {
 		return fmt.Errorf("org name cannot be same as existing user name")
+	}
+	if strings.ToLower(org.Name) == strings.ToLower(cloudcommon.DeveloperMobiledgeX) {
+		if !authorized(ctx, claims.Username, "", ResourceUsers, ActionManage) {
+			return fmt.Errorf("Not authorized to create reserved org %s", org.Name)
+		}
 	}
 	db := loggedDB(ctx)
 	err = db.Create(&org).Error

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormclient"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/vault"
 	"github.com/stretchr/testify/require"
@@ -195,6 +196,20 @@ func TestServer(t *testing.T) {
 	tokenAdmin, err := mcClient.DoLogin(uri, admin.Name, admin.Passhash)
 	require.Nil(t, err, "login as admin")
 
+	orgMex := ormapi.Organization{
+		Type:    "developer",
+		Name:    cloudcommon.DeveloperMobiledgeX,
+		Address: "123",
+		Phone:   "123",
+	}
+	_, err = mcClient.CreateOrg(uri, tokenMisterX, &orgMex)
+	require.NotNil(t, err, "create reserved mobiledgex org")
+	status, err = mcClient.CreateOrg(uri, tokenAdmin, &orgMex)
+	require.Nil(t, err, "create reserved mobiledgex org")
+	require.Equal(t, http.StatusOK, status)
+	_, err = mcClient.DeleteOrg(uri, tokenMisterX, &orgMex)
+	require.NotNil(t, err, "delete reserved mobiledgex org")
+
 	// check org membership as mister x
 	orgs, status, err := mcClient.ShowOrg(uri, tokenMisterX)
 	require.Nil(t, err)
@@ -213,11 +228,11 @@ func TestServer(t *testing.T) {
 	orgs, status, err = mcClient.ShowOrg(uri, token)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	require.Equal(t, 2, len(orgs))
+	require.Equal(t, 3, len(orgs))
 	orgs, status, err = mcClient.ShowOrg(uri, tokenAdmin)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	require.Equal(t, 2, len(orgs))
+	require.Equal(t, 3, len(orgs))
 
 	// users should be able to update their own orgs
 	testUpdateOrg(t, mcClient, uri, tokenMisterX, org1.Name)
@@ -243,11 +258,11 @@ func TestServer(t *testing.T) {
 	roleAssignments, status, err = mcClient.ShowRoleAssignment(uri, token)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	require.Equal(t, 4, len(roleAssignments))
+	require.Equal(t, 5, len(roleAssignments))
 	roleAssignments, status, err = mcClient.ShowRoleAssignment(uri, tokenAdmin)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	require.Equal(t, 4, len(roleAssignments))
+	require.Equal(t, 5, len(roleAssignments))
 
 	// show org users as mister x
 	users, status, err = mcClient.ShowUser(uri, tokenMisterX, &org1)
@@ -341,6 +356,9 @@ func TestServer(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	status, err = mcClient.DeleteOrg(uri, tokenMisterY, &org2)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, status)
+	status, err = mcClient.DeleteOrg(uri, tokenAdmin, &orgMex)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	// delete users

--- a/mc/orm/validate.go
+++ b/mc/orm/validate.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/util"
 )
 
@@ -37,9 +36,6 @@ func ValidName(name string) error {
 	}
 	if strings.HasSuffix(name, "-cache") {
 		return fmt.Errorf("Name cannot end with '-cache'")
-	}
-	if strings.ToLower(name) == strings.ToLower(cloudcommon.DeveloperMobiledgeX) {
-		return fmt.Errorf("Name %s is reserved, please choose another", name)
 	}
 	return nil
 }

--- a/mc/orm/validate_test.go
+++ b/mc/orm/validate_test.go
@@ -3,7 +3,6 @@ package orm
 import (
 	"testing"
 
-	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,7 +41,4 @@ func TestValidName(t *testing.T) {
 
 	err = ValidName("username_123dev&test")
 	require.NotNil(t, err, "invalid user name")
-
-	err = ValidName(cloudcommon.DeveloperMobiledgeX)
-	require.NotNil(t, err, "invalid org name")
 }


### PR DESCRIPTION
Disallow user to create org with mobiledgex org name, as it is used internally for prometheus app.