### PR TITLE
EDGECLOUD-1618 MC LDAP listener TLS support

### DIFF
--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -260,7 +260,13 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	ldapServer.BindFunc("", handler)
 	ldapServer.SearchFunc("", handler)
 	go func() {
-		if err := ldapServer.ListenAndServe(config.LDAPAddr); err != nil {
+		var err error
+		if config.TlsCertFile != "" {
+			err = ldapServer.ListenAndServeTLS(config.LDAPAddr, config.TlsCertFile, config.TlsKeyFile)
+		} else {
+			err = ldapServer.ListenAndServe(config.LDAPAddr)
+		}
+		if err != nil {
 			server.Stop()
 			log.FatalLog("LDAP Server Failed", "err", err)
 		}

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -81,7 +81,7 @@ func TestServer(t *testing.T) {
 	policies, status, err := showRolePerms(mcClient, uri, token)
 	require.Nil(t, err, "show role perms err")
 	require.Equal(t, http.StatusOK, status, "show role perms status")
-	require.Equal(t, 123, len(policies), "number of role perms")
+	require.Equal(t, 125, len(policies), "number of role perms")
 	roles, status, err := showRoles(mcClient, uri, token)
 	require.Nil(t, err, "show roles err")
 	require.Equal(t, http.StatusOK, status, "show roles status")


### PR DESCRIPTION
This adds TLS support for the LDAP listener port on MC if a cert is specified when running MC. Venky will need to configure TLS for gitlab/artifactory when deploying after this change.

Also fixed unit test from unrelated change to more roles.