### PR TITLE
fix floating ip support with routerless cloudlets

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -75,7 +75,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		var rootLBIPaddr string
 		_, masterIP, err := mexos.GetMasterNameAndIP(ctx, clusterInst)
 		if err == nil {
-			rootLBIPaddr, err = mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), rootLBName)
+			rootLBIPaddr, err = mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), rootLBName, mexos.ExternalIPType)
 			if err == nil {
 				getDnsAction := func(svc v1.Service) (*mexos.DnsSvcAction, error) {
 					action := mexos.DnsSvcAction{}
@@ -184,7 +184,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		if err != nil {
 			return err
 		}
-		external_ip, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), objName)
+		external_ip, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), objName, mexos.ExternalIPType)
 		if err != nil {
 			return err
 		}
@@ -209,7 +209,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		if err != nil {
 			return err
 		}
-		rootLBIPaddr, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), rootLBName)
+		rootLBIPaddr, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), rootLBName, mexos.ExternalIPType)
 		if err != nil {
 			return err
 		}

--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -335,7 +335,7 @@ func (s *Platform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 	}
 	updateCallback(edgeproto.UpdateTask, "Successfully Deployed Platform VM")
 
-	external_ip, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), platform_vm_name)
+	external_ip, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), platform_vm_name, mexos.ExternalIPType)
 	if err != nil {
 		return err
 	}

--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -167,7 +167,7 @@ var vmTemplateResources = `
            fixed_ips: 
             - subnet_id: {{.SubnetName}}
            security_groups:
-            - {{$.RootLBParams.ApplicationSecurityGroup}}
+            - { get_resource: vm_security_group }
    floatingip:
        type: OS::Neutron::FloatingIPAssociation
        properties:

--- a/mexos/lb.go
+++ b/mexos/lb.go
@@ -346,8 +346,7 @@ func AttachAndEnableRootLBInterface(ctx context.Context, client pc.PlatformClien
 	if err != nil {
 		return err
 	}
-
-	rootLbIp, err := GetServerIPAddr(ctx, GetCloudletExternalNetwork(), rootLBName)
+	rootLbIp, err := GetServerIPAddr(ctx, GetCloudletExternalNetwork(), rootLBName, InternalIPType)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelMexos, "fail to get RootLB IP address", "rootLBName", rootLBName)
 

--- a/mexos/rootlb.go
+++ b/mexos/rootlb.go
@@ -148,7 +148,7 @@ func SetupRootLB(ctx context.Context, rootLBName string, rootLBSpec *vmspec.VMCr
 		log.SpanLog(ctx, log.DebugLevelMexos, "timeout waiting for agent to run", "name", rootLB.Name)
 		return fmt.Errorf("Error waiting for rootLB %v", err)
 	}
-	extIP, err := GetServerIPAddr(ctx, GetCloudletExternalNetwork(), rootLBName)
+	extIP, err := GetServerIPAddr(ctx, GetCloudletExternalNetwork(), rootLBName, ExternalIPType)
 	if err != nil {
 		return fmt.Errorf("cannot get rootLB IP %sv", err)
 	}

--- a/mexos/ssh.go
+++ b/mexos/ssh.go
@@ -17,7 +17,7 @@ var SSHUser = "ubuntu"
 func CopySSHCredential(ctx context.Context, serverName, networkName, userName string) error {
 	//TODO multiple keys to be copied and added to authorized_keys if needed
 	log.SpanLog(ctx, log.DebugLevelMexos, "copying ssh credentials", "server", serverName, "network", networkName, "user", userName)
-	addr, err := GetServerIPAddr(ctx, networkName, serverName)
+	addr, err := GetServerIPAddr(ctx, networkName, serverName, ExternalIPType)
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func GetSSHClient(ctx context.Context, serverName, networkName, userName string)
 	auth := ssh.Auth{Keys: []string{PrivateSSHKey()}}
 	log.SpanLog(ctx, log.DebugLevelMexos, "GetSSHClient", "serverName", serverName)
 
-	addr, err := GetServerIPAddr(ctx, networkName, serverName)
+	addr, err := GetServerIPAddr(ctx, networkName, serverName, ExternalIPType)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix the following related to floating IP support:

- Fix problem when using Floating IPs in routerless clusters (EDGECLOUD-1576).  The problem is that the IP address is used to find the port on the rootLB.   The port is then used to find the MAC address which is used to configure the new interface.  In the case of floating IPs, there are 2 IP addresses on the port, we need the internal one to get the MAC.  A new param is added to  GetServerIPAddr to allow specification of internal vs external address 
- Fix security group in heat template when using floating IPs