### PR TITLE
Orange secgrp bug

### DIFF
--- a/mexos/oscli.go
+++ b/mexos/oscli.go
@@ -855,7 +855,7 @@ func GetSecurityGroupIDForProject(ctx context.Context, grpname string, projectID
 			}
 			if g.Project == "" {
 				// This is an openstack bug in some environments in which it may not show the project ids when listing the group
-				// all we can do is hope for no conflcts in this case
+				// all we can do is hope for no conflicts in this case
 				log.SpanLog(ctx, log.DebugLevelMexos, "Warning: no project id returned for security group", "group", grpname)
 				return g.ID, nil
 			}


### PR DESCRIPTION
While working with the latest Orange Spain deployment I came across the following OpenStack bug in their environment:

When listing security groups, the project id is null, even though all groups have a project.   This caused the new security group code to fail.

I have checked several other environments and not seen this problem, it seems specific to Orange's setup.

As a workaround, if the group name matches but project id is blank, return it as a match.   