### PR TITLE
EDGECLOUD-1504 updates for AutoScalePolicy

### DIFF
--- a/mc/mcctl/cliwrapper/app_inst.mc2.go
+++ b/mc/mcctl/cliwrapper/app_inst.mc2.go
@@ -46,10 +46,22 @@ func (s *Client) DeleteAppInst(uri, token string, in *ormapi.RegionAppInst) ([]e
 	return outlist, st, err
 }
 
+func (s *Client) RefreshAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.Result, int, error) {
+	args := []string{"region", "RefreshAppInst"}
+	outlist := []edgeproto.Result{}
+	noconfig := strings.Split("CloudletLoc,Uri,MappedPorts,Liveness,Flavor,State,RuntimeInfo,AutoClusterIpAccess,Errors,CreatedAt,Status,Revision,Configs", ",")
+	ops := []runOp{
+		withIgnore(noconfig),
+		withStreamOutIncremental(),
+	}
+	st, err := s.runObjs(uri, token, args, in, &outlist, ops...)
+	return outlist, st, err
+}
+
 func (s *Client) UpdateAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.Result, int, error) {
 	args := []string{"region", "UpdateAppInst"}
 	outlist := []edgeproto.Result{}
-	noconfig := strings.Split("CloudletLoc,Uri,MappedPorts,Liveness,Flavor,State,RuntimeInfo,AutoClusterIpAccess,Errors,CreatedAt,Status,Revision", ",")
+	noconfig := strings.Split("CloudletLoc,Uri,MappedPorts,Liveness,Flavor,State,RuntimeInfo,AutoClusterIpAccess,Errors,CreatedAt,Status,Revision,UpdateMultiple", ",")
 	ops := []runOp{
 		withIgnore(noconfig),
 		withStreamOutIncremental(),

--- a/mc/mcctl/ormctl/app_inst.mc2.go
+++ b/mc/mcctl/ormctl/app_inst.mc2.go
@@ -51,6 +51,20 @@ var DeleteAppInstCmd = &cli.Command{
 	StreamOutIncremental: true,
 }
 
+var RefreshAppInstCmd = &cli.Command{
+	Use:                  "RefreshAppInst",
+	RequiredArgs:         strings.Join(append([]string{"region"}, RefreshAppInstRequiredArgs...), " "),
+	OptionalArgs:         strings.Join(RefreshAppInstOptionalArgs, " "),
+	AliasArgs:            strings.Join(AppInstAliasArgs, " "),
+	SpecialArgs:          &AppInstSpecialArgs,
+	Comments:             addRegionComment(AppInstComments),
+	ReqData:              &ormapi.RegionAppInst{},
+	ReplyData:            &edgeproto.Result{},
+	Run:                  runRest("/auth/ctrl/RefreshAppInst"),
+	StreamOut:            true,
+	StreamOutIncremental: true,
+}
+
 var UpdateAppInstCmd = &cli.Command{
 	Use:          "UpdateAppInst",
 	RequiredArgs: strings.Join(append([]string{"region"}, UpdateAppInstRequiredArgs...), " "),
@@ -96,6 +110,7 @@ var ShowAppInstCmd = &cli.Command{
 var AppInstApiCmds = []*cli.Command{
 	CreateAppInstCmd,
 	DeleteAppInstCmd,
+	RefreshAppInstCmd,
 	UpdateAppInstCmd,
 	ShowAppInstCmd,
 }
@@ -118,12 +133,12 @@ var CreateAppInstOptionalArgs = []string{
 	"configs.kind",
 	"configs.config",
 }
-var UpdateAppInstRequiredArgs = []string{
+var RefreshAppInstRequiredArgs = []string{
 	"developer",
 	"appname",
 	"appvers",
 }
-var UpdateAppInstOptionalArgs = []string{
+var RefreshAppInstOptionalArgs = []string{
 	"cluster",
 	"operator",
 	"cloudlet",
@@ -131,6 +146,19 @@ var UpdateAppInstOptionalArgs = []string{
 	"crmoverride",
 	"forceupdate",
 	"updatemultiple",
+}
+var UpdateAppInstRequiredArgs = []string{
+	"developer",
+	"appname",
+	"appvers",
+	"cluster",
+	"operator",
+	"cloudlet",
+}
+var UpdateAppInstOptionalArgs = []string{
+	"clusterdeveloper",
+	"crmoverride",
+	"forceupdate",
 	"configs.kind",
 	"configs.config",
 }

--- a/mc/ormclient/app_inst_client.go
+++ b/mc/ormclient/app_inst_client.go
@@ -39,6 +39,15 @@ func (s *Client) DeleteAppInst(uri, token string, in *ormapi.RegionAppInst) ([]e
 	return outlist, status, err
 }
 
+func (s *Client) RefreshAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.Result, int, error) {
+	out := edgeproto.Result{}
+	outlist := []edgeproto.Result{}
+	status, err := s.PostJsonStreamOut(uri+"/auth/ctrl/RefreshAppInst", token, in, &out, func() {
+		outlist = append(outlist, out)
+	})
+	return outlist, status, err
+}
+
 func (s *Client) UpdateAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.Result, int, error) {
 	out := edgeproto.Result{}
 	outlist := []edgeproto.Result{}
@@ -60,6 +69,7 @@ func (s *Client) ShowAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edg
 type AppInstApiClient interface {
 	CreateAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.Result, int, error)
 	DeleteAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.Result, int, error)
+	RefreshAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.Result, int, error)
 	UpdateAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.Result, int, error)
 	ShowAppInst(uri, token string, in *ormapi.RegionAppInst) ([]edgeproto.AppInst, int, error)
 }

--- a/plugin/common/cluster-svc-plugin.go
+++ b/plugin/common/cluster-svc-plugin.go
@@ -23,7 +23,7 @@ type ClusterSvc struct{}
 // The scale down alert files when any node is below the low cpu threshold,
 // and there are more than the min number of nodes.
 var MEXPrometheusAutoScaleT = `additionalPrometheusRules:
-- name: [[.AutoScalePolicy]]
+- name: autoscalepolicy
   groups:
   - name: autoscale.rules
     rules:


### PR DESCRIPTION
Corresponding infra changes for the edge-cloud PR. Mainly don't run Heat if we're just updating the AutoScalePolicy on the ClusterInst, and not changing the number of nodes.

I intend to add e2e tests later, as it will require a bit of work to be able to specify empty strings in the yaml that are preserved in the json sent to the update APIs.

Testing was done against the Frankfurt cloudlet.