### PR TITLE
EDGECLOUD-1569 Less confusing error message for invalid starttime/endtime

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -427,7 +427,7 @@ func checkForTimeError(errStr string) string {
 	// golang's reference time is "2006-01-02T15:04:05Z07:00" (123456 in the posix date command), which is confusing
 	refTime := "2006-01-02T15:04:05Z07:00"
 	if strings.Contains(errStr, refTime) {
-		return fmt.Sprintf("%s into RFC3339 format. Example: \"%s\"", strings.Split(errStr, " as")[0], refTime)
+		return fmt.Sprintf("%s into RFC3339 format failed. Example: \"%s\"", strings.Split(errStr, " as")[0], refTime)
 	}
 	return errStr
 }


### PR DESCRIPTION
If you enter an invalid starttime/endtime you get a confusing error message with something about the time: `2006-01-02T15:04:05Z07:00`.
A sample error looks like this:

`Invalid POST data: code=400, message=parsing time \"\"xxxx\"\" as \"\"2006-01-02T15:04:05Z07:00\"\": cannot parse \"xxxx\"\" as \"2006\"`  

The reason why this is happening is because that time is 123456 in the posix date command so its what golang uses for its reference time. However thats confusing and we shouldnt be exposing golang specifics to an api call so I added a special case to cut that out of the message so now they look like this:

`Invalid POST data: code=400, message=parsing time \"\"xxxx\"\`