### PR TITLE
EDGECLOUD-1610 invalid image path error, vault handling tweaks

### DIFF
--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -255,8 +255,10 @@ func (s *Platform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 
 	log.SpanLog(ctx, log.DebugLevelMexos, "Creating cloudlet", "cloudletName", cloudlet.Key.Name)
 
-	vaultAuth := vault.NewAppRoleAuth(pfConfig.CrmRoleId, pfConfig.CrmSecretId)
-	vaultConfig := vault.NewConfig(pfConfig.VaultAddr, vaultAuth)
+	vaultConfig, err := vault.BestConfig(pfConfig.VaultAddr, vault.WithEnvMap(pfConfig.EnvVar))
+	if err != nil {
+		return err
+	}
 	// Source OpenRC file to access openstack API endpoint
 	updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Sourcing platform variables for %s cloudlet", cloudlet.PhysicalName))
 	err = mexos.InitOpenstackProps(ctx, cloudlet.Key.OperatorKey.Name, cloudlet.PhysicalName, vaultConfig)
@@ -361,10 +363,12 @@ func (s *Platform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 
 	updateCallback(edgeproto.UpdateTask, "Deleting cloudlet")
 
-	vaultAuth := vault.NewAppRoleAuth(pfConfig.CrmRoleId, pfConfig.CrmSecretId)
-	vaultConfig := vault.NewConfig(pfConfig.VaultAddr, vaultAuth)
+	vaultConfig, err := vault.BestConfig(pfConfig.VaultAddr, vault.WithEnvMap(pfConfig.EnvVar))
+	if err != nil {
+		return err
+	}
 	// Source OpenRC file to access openstack API endpoint
-	err := mexos.InitOpenstackProps(ctx, cloudlet.Key.OperatorKey.Name, cloudlet.PhysicalName, vaultConfig)
+	err = mexos.InitOpenstackProps(ctx, cloudlet.Key.OperatorKey.Name, cloudlet.PhysicalName, vaultConfig)
 	if err != nil {
 		// ignore this error, as no creation would've happened on infra, so nothing to delete
 		log.SpanLog(ctx, log.DebugLevelMexos, "failed to source platform variables", "cloudletName", cloudlet.Key.Name, "err", err)
@@ -399,11 +403,13 @@ func handleUpgradeError(ctx context.Context, client ssh.Client) error {
 func (s *Platform) UpdateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelMexos, "Updating cloudlet", "cloudletName", cloudlet.Key.Name)
 
-	vaultAuth := vault.NewAppRoleAuth(pfConfig.CrmRoleId, pfConfig.CrmSecretId)
-	vaultConfig := vault.NewConfig(pfConfig.VaultAddr, vaultAuth)
+	vaultConfig, err := vault.BestConfig(pfConfig.VaultAddr, vault.WithEnvMap(pfConfig.EnvVar))
+	if err != nil {
+		return err
+	}
 	// Source OpenRC file to access openstack API endpoint
 	updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Sourcing platform variables for %s cloudlet", cloudlet.PhysicalName))
-	err := mexos.InitOpenstackProps(ctx, cloudlet.Key.OperatorKey.Name, cloudlet.PhysicalName, vaultConfig)
+	err = mexos.InitOpenstackProps(ctx, cloudlet.Key.OperatorKey.Name, cloudlet.PhysicalName, vaultConfig)
 	if err != nil {
 		return err
 	}

--- a/e2e-tests/int-process/services.go
+++ b/e2e-tests/int-process/services.go
@@ -26,9 +26,10 @@ func getShepherdProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformC
 	vaultAddr := ""
 	span := ""
 	if pfConfig != nil {
-		// Same role-id/secret-id as CRM
-		envVars["VAULT_ROLE_ID"] = pfConfig.CrmRoleId
-		envVars["VAULT_SECRET_ID"] = pfConfig.CrmSecretId
+		// Same vault role-id/secret-id as CRM
+		for k, v := range pfConfig.EnvVar {
+			envVars[k] = v
+		}
 		notifyAddr = cloudlet.NotifySrvAddr
 		tlsCertFile = pfConfig.TlsCertFile
 		vaultAddr = pfConfig.VaultAddr

--- a/e2e-tests/setups/local_dind.yml
+++ b/e2e-tests/setups/local_dind.yml
@@ -56,6 +56,7 @@ controllers:
   apiaddr: "0.0.0.0:55001"
   httpaddr: "0.0.0.0:36001"
   notifyaddr: "127.0.0.1:37001"
+  vaultaddr: "http://127.0.0.1:8200"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -71,6 +72,7 @@ dmes:
   toksrvurl: "{{toksrvurl}}"
   carrier: TDG
   cloudletkey: '{"operator_key":{"name":"mexdev"},"name":"mexdev-cloud-1"}'
+  vaultaddr: "http://127.0.0.1:8200"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"

--- a/e2e-tests/setups/local_multi.yml
+++ b/e2e-tests/setups/local_multi.yml
@@ -59,6 +59,7 @@ controllers:
   apiaddr: "127.0.0.1:55001"
   httpaddr: "0.0.0.0:36001"
   notifyaddr: "127.0.0.1:37001"
+  vaultaddr: "http://127.0.0.1:8200"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -71,6 +72,7 @@ controllers:
   apiaddr: "127.0.0.1:55002"
   httpaddr: "0.0.0.0:36002"
   notifyaddr: "127.0.0.1:37002"
+  vaultaddr: "http://127.0.0.1:8200"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -105,6 +107,7 @@ dmes:
   toksrvurl: "{{toksrvurl}}"
   carrier: TDG
   cloudletkey: '{"operator_key":{"name":"tmus"},"name":"tmus-cloud-1"}'
+  vaultaddr: "http://127.0.0.1:8200"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -121,6 +124,7 @@ dmes:
   toksrvurl: "{{toksrvurl}}"
   carrier: TDG
   cloudletkey: '{"operator_key":{"name":"tmus"},"name":"tmus-cloud-2"}'
+  vaultaddr: "http://127.0.0.1:8200"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"

--- a/mc/mcctl/ormctl/alert.mc2.go
+++ b/mc/mcctl/ormctl/alert.mc2.go
@@ -154,25 +154,3 @@ var AlertSpecialArgs = map[string]string{
 	"annotations": "StringToString",
 	"labels":      "StringToString",
 }
-var LabelsEntryRequiredArgs = []string{}
-var LabelsEntryOptionalArgs = []string{
-	"key",
-	"value",
-}
-var LabelsEntryAliasArgs = []string{
-	"key=labelsentry.key",
-	"value=labelsentry.value",
-}
-var LabelsEntryComments = map[string]string{}
-var LabelsEntrySpecialArgs = map[string]string{}
-var AnnotationsEntryRequiredArgs = []string{}
-var AnnotationsEntryOptionalArgs = []string{
-	"key",
-	"value",
-}
-var AnnotationsEntryAliasArgs = []string{
-	"key=annotationsentry.key",
-	"value=annotationsentry.value",
-}
-var AnnotationsEntryComments = map[string]string{}
-var AnnotationsEntrySpecialArgs = map[string]string{}

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -320,17 +320,6 @@ var OpenStackPropertiesComments = map[string]string{
 var OpenStackPropertiesSpecialArgs = map[string]string{
 	"openrcvars": "StringToString",
 }
-var OpenRcVarsEntryRequiredArgs = []string{}
-var OpenRcVarsEntryOptionalArgs = []string{
-	"key",
-	"value",
-}
-var OpenRcVarsEntryAliasArgs = []string{
-	"key=openrcvarsentry.key",
-	"value=openrcvarsentry.value",
-}
-var OpenRcVarsEntryComments = map[string]string{}
-var OpenRcVarsEntrySpecialArgs = map[string]string{}
 var CloudletInfraPropertiesRequiredArgs = []string{}
 var CloudletInfraPropertiesOptionalArgs = []string{
 	"cloudletkind",
@@ -393,8 +382,7 @@ var PlatformConfigOptionalArgs = []string{
 	"notifyctrladdrs",
 	"vaultaddr",
 	"tlscertfile",
-	"crmroleid",
-	"crmsecretid",
+	"envvar",
 	"platformtag",
 	"testmode",
 	"span",
@@ -406,8 +394,7 @@ var PlatformConfigAliasArgs = []string{
 	"notifyctrladdrs=platformconfig.notifyctrladdrs",
 	"vaultaddr=platformconfig.vaultaddr",
 	"tlscertfile=platformconfig.tlscertfile",
-	"crmroleid=platformconfig.crmroleid",
-	"crmsecretid=platformconfig.crmsecretid",
+	"envvar=platformconfig.envvar",
 	"platformtag=platformconfig.platformtag",
 	"testmode=platformconfig.testmode",
 	"span=platformconfig.span",
@@ -419,14 +406,15 @@ var PlatformConfigComments = map[string]string{
 	"notifyctrladdrs": "Address of controller notify port (can be multiple of these)",
 	"vaultaddr":       "Vault address",
 	"tlscertfile":     "TLS cert file",
-	"crmroleid":       "Vault role ID for CRM",
-	"crmsecretid":     "Vault secret ID for CRM",
+	"envvar":          "Environment variables",
 	"platformtag":     "Tag of edge-cloud image",
 	"testmode":        "Internal Test flag",
 	"span":            "Span string",
 	"cleanupmode":     "Internal cleanup flag",
 }
-var PlatformConfigSpecialArgs = map[string]string{}
+var PlatformConfigSpecialArgs = map[string]string{
+	"envvar": "StringToString",
+}
 var CloudletResMapRequiredArgs = []string{
 	"operator",
 	"name",
@@ -446,17 +434,6 @@ var CloudletResMapComments = map[string]string{
 var CloudletResMapSpecialArgs = map[string]string{
 	"mapping": "StringToString",
 }
-var MappingEntryRequiredArgs = []string{}
-var MappingEntryOptionalArgs = []string{
-	"key",
-	"value",
-}
-var MappingEntryAliasArgs = []string{
-	"key=mappingentry.key",
-	"value=mappingentry.value",
-}
-var MappingEntryComments = map[string]string{}
-var MappingEntrySpecialArgs = map[string]string{}
 var CloudletRequiredArgs = []string{
 	"operator",
 	"name",
@@ -525,8 +502,7 @@ var CloudletAliasArgs = []string{
 	"config.notifyctrladdrs=cloudlet.config.notifyctrladdrs",
 	"config.vaultaddr=cloudlet.config.vaultaddr",
 	"config.tlscertfile=cloudlet.config.tlscertfile",
-	"config.crmroleid=cloudlet.config.crmroleid",
-	"config.crmsecretid=cloudlet.config.crmsecretid",
+	"config.envvar=cloudlet.config.envvar",
 	"config.platformtag=cloudlet.config.platformtag",
 	"config.testmode=cloudlet.config.testmode",
 	"config.span=cloudlet.config.span",
@@ -570,8 +546,7 @@ var CloudletComments = map[string]string{
 	"config.notifyctrladdrs":              "Address of controller notify port (can be multiple of these)",
 	"config.vaultaddr":                    "Vault address",
 	"config.tlscertfile":                  "TLS cert file",
-	"config.crmroleid":                    "Vault role ID for CRM",
-	"config.crmsecretid":                  "Vault secret ID for CRM",
+	"config.envvar":                       "Environment variables",
 	"config.platformtag":                  "Tag of edge-cloud image",
 	"config.testmode":                     "Internal Test flag",
 	"config.span":                         "Span string",
@@ -580,36 +555,10 @@ var CloudletComments = map[string]string{
 	"restagmap.value.operatorkey.name":    "Company or Organization name of the operator",
 }
 var CloudletSpecialArgs = map[string]string{
-	"envvar": "StringToString",
-	"errors": "StringArray",
+	"config.envvar": "StringToString",
+	"envvar":        "StringToString",
+	"errors":        "StringArray",
 }
-var EnvVarEntryRequiredArgs = []string{}
-var EnvVarEntryOptionalArgs = []string{
-	"key",
-	"value",
-}
-var EnvVarEntryAliasArgs = []string{
-	"key=envvarentry.key",
-	"value=envvarentry.value",
-}
-var EnvVarEntryComments = map[string]string{}
-var EnvVarEntrySpecialArgs = map[string]string{}
-var ResTagMapEntryRequiredArgs = []string{}
-var ResTagMapEntryOptionalArgs = []string{
-	"key",
-	"value.name",
-	"value.operatorkey.name",
-}
-var ResTagMapEntryAliasArgs = []string{
-	"key=restagmapentry.key",
-	"value.name=restagmapentry.value.name",
-	"value.operatorkey.name=restagmapentry.value.operatorkey.name",
-}
-var ResTagMapEntryComments = map[string]string{
-	"value.name":             "Resource Table Name",
-	"value.operatorkey.name": "Company or Organization name of the operator",
-}
-var ResTagMapEntrySpecialArgs = map[string]string{}
 var FlavorMatchRequiredArgs = []string{
 	"operator",
 	"cloudlet",

--- a/mc/mcctl/ormctl/flavor.mc2.go
+++ b/mc/mcctl/ormctl/flavor.mc2.go
@@ -155,14 +155,3 @@ var FlavorComments = map[string]string{
 var FlavorSpecialArgs = map[string]string{
 	"optresmap": "StringToString",
 }
-var OptResMapEntryRequiredArgs = []string{}
-var OptResMapEntryOptionalArgs = []string{
-	"key",
-	"value",
-}
-var OptResMapEntryAliasArgs = []string{
-	"key=optresmapentry.key",
-	"value=optresmapentry.value",
-}
-var OptResMapEntryComments = map[string]string{}
-var OptResMapEntrySpecialArgs = map[string]string{}

--- a/mc/mcctl/ormctl/refs.mc2.go
+++ b/mc/mcctl/ormctl/refs.mc2.go
@@ -96,28 +96,6 @@ var CloudletRefsComments = map[string]string{
 	"usedstaticips":        "Used static IPs",
 }
 var CloudletRefsSpecialArgs = map[string]string{}
-var RootLbPortsEntryRequiredArgs = []string{}
-var RootLbPortsEntryOptionalArgs = []string{
-	"key",
-	"value",
-}
-var RootLbPortsEntryAliasArgs = []string{
-	"key=rootlbportsentry.key",
-	"value=rootlbportsentry.value",
-}
-var RootLbPortsEntryComments = map[string]string{}
-var RootLbPortsEntrySpecialArgs = map[string]string{}
-var OptResUsedMapEntryRequiredArgs = []string{}
-var OptResUsedMapEntryOptionalArgs = []string{
-	"key",
-	"value",
-}
-var OptResUsedMapEntryAliasArgs = []string{
-	"key=optresusedmapentry.key",
-	"value=optresusedmapentry.value",
-}
-var OptResUsedMapEntryComments = map[string]string{}
-var OptResUsedMapEntrySpecialArgs = map[string]string{}
 var ClusterRefsRequiredArgs = []string{
 	"key.clusterkey.name",
 	"key.cloudletkey.operatorkey.name",


### PR DESCRIPTION
Associated infra changes for https://github.com/mobiledgex/edge-cloud/pull/718

Primarily, the openstack CreateCloudlet funcs can use the standard vault.BestConfig() function by telling it to pull env vars from the platformConfig env var map, instead of the actual system which is actually the controller's environment.