### PR TITLE
updated unit tests

### DIFF
--- a/mc/orm/appstore_sync_test.go
+++ b/mc/orm/appstore_sync_test.go
@@ -297,7 +297,6 @@ func mcClientDelete(t *testing.T, v entry, mcClient *ormclient.Client, uri, toke
 			Org:      v.Org,
 			Role:     userType,
 		}
-		fmt.Printf("blah %+v\n", roleArg)
 		// admin user can remove role
 		status, err := mcClient.RemoveUserRole(uri, tokenAdmin, &roleArg)
 		require.Nil(t, err, "remove user role")


### PR DESCRIPTION
removing the last manager of an org is no longer allowed, so skip removing the operatorManager role in addition to the developerManager