### PR TITLE
reservable ClusterInsts

### DIFF
--- a/e2e-tests/data/mc_admin_data.yml
+++ b/e2e-tests/data/mc_admin_data.yml
@@ -9,6 +9,11 @@ orgs:
   address: enterprise headquarters
   phone: 123-123-1234
   adminusername: mexadmin
+- name: MobiledgeX
+  type: developer
+  address: mobiledgex
+  phone: 123-123-1234
+  adminusername: mexadmin
 
 roles:
 - username: user3

--- a/e2e-tests/data/mc_showaudit_admin.yml
+++ b/e2e-tests/data/mc_showaudit_admin.yml
@@ -85,6 +85,6 @@
   status: 200
   starttime: "2019-11-05T17:06:33.229084-08:00"
   duration: 7.6ms
-  request: '{"Name":"enterprise","Type":"developer","Address":"enterprise headquarters","Phone":"123-123-1234","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
+  request: '{"Name":"MobiledgeX","Type":"developer","Address":"mobiledgex","Phone":"123-123-1234","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
   response: '{"message":"Organization deleted"}'
   traceid: 384d9326d52eefe9

--- a/e2e-tests/testfiles/mc_add_delete.yml
+++ b/e2e-tests/testfiles/mc_add_delete.yml
@@ -38,6 +38,11 @@ tests:
     yaml2: '{{datadir2}}/mc_user1_data_show.yml'
     filetype: mcdata
 
+- name: admin creates reservable clusterinst on user1 cloudlet
+  actions: [mcapi-create]
+  apifile: '{{datadir2}}/mc_admin_reservable.yml'
+  curuserfile: '{{datadir2}}/mc_admin.yml'
+
 - name: user2 creates apps; verify it is there
   actions: [mcapi-create, mcapi-show]
   apifile: '{{datadir2}}/mc_user2_data.yml'
@@ -89,6 +94,11 @@ tests:
     yaml1: '{{outputdir}}/show-commands.yml'
     yaml2: '{{datadir2}}/mc_user3_empty_show.yml'
     filetype: mcdata
+
+- name: admin deletes reservable ClusterInst
+  actions: [mcapi-delete]
+  apifile: '{{datadir2}}/mc_admin_reservable.yml'
+  curuserfile: '{{datadir2}}/mc_admin.yml'
 
 - name: user1 deletes operator/cloudlets; verify it is empty
   actions: [mcapi-delete, mcapi-show]

--- a/mc/mcctl/cliwrapper/clusterinst.mc2.go
+++ b/mc/mcctl/cliwrapper/clusterinst.mc2.go
@@ -23,7 +23,7 @@ var _ = math.Inf
 func (s *Client) CreateClusterInst(uri, token string, in *ormapi.RegionClusterInst) ([]edgeproto.Result, int, error) {
 	args := []string{"region", "CreateClusterInst"}
 	outlist := []edgeproto.Result{}
-	noconfig := strings.Split("Liveness,Auto,MasterFlavor,NodeFlavor,ExternalVolumeSize,AllocatedIp,Status", ",")
+	noconfig := strings.Split("Liveness,Auto,MasterFlavor,NodeFlavor,ExternalVolumeSize,AllocatedIp,Status,ReservedBy", ",")
 	ops := []runOp{
 		withIgnore(noconfig),
 		withStreamOutIncremental(),
@@ -35,7 +35,7 @@ func (s *Client) CreateClusterInst(uri, token string, in *ormapi.RegionClusterIn
 func (s *Client) DeleteClusterInst(uri, token string, in *ormapi.RegionClusterInst) ([]edgeproto.Result, int, error) {
 	args := []string{"region", "DeleteClusterInst"}
 	outlist := []edgeproto.Result{}
-	noconfig := strings.Split("Liveness,Auto,MasterFlavor,NodeFlavor,ExternalVolumeSize,AllocatedIp,Status", ",")
+	noconfig := strings.Split("Liveness,Auto,MasterFlavor,NodeFlavor,ExternalVolumeSize,AllocatedIp,Status,ReservedBy", ",")
 	ops := []runOp{
 		withIgnore(noconfig),
 		withStreamOutIncremental(),
@@ -47,7 +47,7 @@ func (s *Client) DeleteClusterInst(uri, token string, in *ormapi.RegionClusterIn
 func (s *Client) UpdateClusterInst(uri, token string, in *ormapi.RegionClusterInst) ([]edgeproto.Result, int, error) {
 	args := []string{"region", "UpdateClusterInst"}
 	outlist := []edgeproto.Result{}
-	noconfig := strings.Split("Liveness,Auto,MasterFlavor,NodeFlavor,ExternalVolumeSize,AllocatedIp,Status", ",")
+	noconfig := strings.Split("Liveness,Auto,MasterFlavor,NodeFlavor,ExternalVolumeSize,AllocatedIp,Status,ReservedBy", ",")
 	ops := []runOp{
 		withIgnore(noconfig),
 		withStreamOutIncremental(),
@@ -59,7 +59,7 @@ func (s *Client) UpdateClusterInst(uri, token string, in *ormapi.RegionClusterIn
 func (s *Client) ShowClusterInst(uri, token string, in *ormapi.RegionClusterInst) ([]edgeproto.ClusterInst, int, error) {
 	args := []string{"region", "ShowClusterInst"}
 	outlist := []edgeproto.ClusterInst{}
-	noconfig := strings.Split("Liveness,Auto,MasterFlavor,NodeFlavor,ExternalVolumeSize,AllocatedIp,Status", ",")
+	noconfig := strings.Split("Liveness,Auto,MasterFlavor,NodeFlavor,ExternalVolumeSize,AllocatedIp,Status,ReservedBy", ",")
 	ops := []runOp{
 		withIgnore(noconfig),
 	}

--- a/mc/mcctl/ormctl/clusterinst.mc2.go
+++ b/mc/mcctl/ormctl/clusterinst.mc2.go
@@ -136,6 +136,7 @@ var ClusterInstOptionalArgs = []string{
 	"autoscalepolicy",
 	"availabilityzone",
 	"imagename",
+	"reservable",
 }
 var ClusterInstAliasArgs = []string{
 	"cluster=clusterinst.key.clusterkey.name",
@@ -162,6 +163,8 @@ var ClusterInstAliasArgs = []string{
 	"autoscalepolicy=clusterinst.autoscalepolicy",
 	"availabilityzone=clusterinst.availabilityzone",
 	"imagename=clusterinst.imagename",
+	"reservable=clusterinst.reservable",
+	"reservedby=clusterinst.reservedby",
 }
 var ClusterInstComments = map[string]string{
 	"cluster":            "Cluster name",
@@ -184,6 +187,8 @@ var ClusterInstComments = map[string]string{
 	"autoscalepolicy":    "Auto scale policy name",
 	"availabilityzone":   "Optional Resource AZ if any",
 	"imagename":          "Optional resource specific image to launch",
+	"reservable":         "If ClusterInst is reservable",
+	"reservedby":         "For reservable MobiledgeX ClusterInsts, the current developer tenant",
 }
 var ClusterInstSpecialArgs = map[string]string{
 	"errors": "StringArray",


### PR DESCRIPTION
Adds check to prevent Developers from using reservable ClusterInsts. It is intended that the auto-provisioning service is the only entity that can create AppInsts on reservable ClusterInsts.