### PR TITLE
Speedup CRM bringup

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -152,7 +152,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 			}
 		}
 
-		finfo, _, _, err := mexos.GetFlavorInfo(ctx)
+		finfo, err := mexos.GetFlavorInfo(ctx)
 		if err != nil {
 			return err
 		}

--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -278,7 +278,7 @@ func (s *Platform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 	}
 
 	// Get Closest Platform Flavor
-	finfo, _, _, err := mexos.GetFlavorInfo(ctx)
+	finfo, err := mexos.GetFlavorInfo(ctx)
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/openstack/openstack.go
+++ b/crm-platforms/openstack/openstack.go
@@ -61,7 +61,7 @@ func (s *Platform) Init(ctx context.Context, platformConfig *platform.PlatformCo
 	if mexos.CloudletInfraCommon.NetworkScheme == "" {
 		mexos.CloudletInfraCommon.NetworkScheme = "name=mex-k8s-net-1,cidr=10.101.X.0/24"
 	}
-	s.flavorList, _, _, err = mexos.GetFlavorInfo(ctx)
+	s.flavorList, err = mexos.GetFlavorInfo(ctx)
 	if err != nil {
 		return err
 	}

--- a/mexos/oscli.go
+++ b/mexos/oscli.go
@@ -843,7 +843,7 @@ func OSGetLimits(ctx context.Context, info *edgeproto.CloudletInfo) error {
 		}
 	}
 
-	finfo, _, _, err := GetFlavorInfo(ctx)
+	finfo, err := GetFlavorInfo(ctx)
 	if err != nil {
 		return err
 	}
@@ -867,13 +867,13 @@ func OSGetAllLimits(ctx context.Context) ([]OSLimit, error) {
 	return limits, nil
 }
 
-func GetFlavorInfo(ctx context.Context) ([]*edgeproto.FlavorInfo, []OSAZone, []OSImageDetail, error) {
+func GetFlavorInfo(ctx context.Context) ([]*edgeproto.FlavorInfo, error) {
 	osflavors, err := ListFlavors(ctx)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get flavors, %v", err.Error())
+		return nil, fmt.Errorf("failed to get flavors, %v", err.Error())
 	}
 	if len(osflavors) == 0 {
-		return nil, nil, nil, fmt.Errorf("no flavors found")
+		return nil, fmt.Errorf("no flavors found")
 	}
 	var finfo []*edgeproto.FlavorInfo
 	for _, f := range osflavors {
@@ -887,12 +887,7 @@ func GetFlavorInfo(ctx context.Context) ([]*edgeproto.FlavorInfo, []OSAZone, []O
 				Properties: f.Properties},
 		)
 	}
-	zones, err := ListAZones(ctx)
-	images, err := ListImagesDetail(ctx)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	return finfo, zones, images, nil
+	return finfo, nil
 }
 
 func GetSecurityGroupIDForProject(ctx context.Context, grpname string, projectID string) (string, error) {


### PR DESCRIPTION
* On CRM bringup, FlavorInfo calls ListImages, which does `image show` for each image. This takes lot of time, if there are many images in Glance.
* I don't see images data being used anywhere, hence removing it. If required, we can have a separate call to list images, rather than making it part of FlavorInfo.