### PR TITLE
add cloudlet wide secgrp when using floating ip

### DIFF
--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -172,6 +172,9 @@ var vmTemplateResources = `
             - subnet_id: {{.SubnetName}}
            security_groups:
             - { get_resource: vm_security_group }
+           {{if .CloudletSecurityGroup}}
+            - {{ .CloudletSecurityGroup}}
+           {{- end}}
    floatingip:
        type: OS::Neutron::FloatingIPAssociation
        properties:


### PR DESCRIPTION
During WWT setup of a new cloudlet using floating IPs, I found that the cloudlet-wide security group used for SSH was not included.  

