### PR TITLE
EDGECLOUD-782 better message for expired JWT

### DIFF
--- a/mc/orm/userauth.go
+++ b/mc/orm/userauth.go
@@ -147,6 +147,14 @@ func AuthCookie(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set("user", token)
 			return next(c)
 		}
+		// display error regarding token valid time/expired
+		if err != nil && strings.Contains(err.Error(), "expired") {
+			return &echo.HTTPError{
+				Code:     http.StatusBadRequest,
+				Message:  err.Error(),
+				Internal: err,
+			}
+		}
 		return &echo.HTTPError{
 			Code:     http.StatusUnauthorized,
 			Message:  "invalid or expired jwt",


### PR DESCRIPTION
before:

> mcctl user show
Error: Unauthorized, invalid or expired jwt

after:

> mcctl user show
Error: Bad Request, token is expired by 7m0s