### PR TITLE
EDGECLOUD-1724 EDGECLOUD-1725 EDGECLOUD-1728 mc orgcloudletpool error…

### DIFF
--- a/mc/orm/authz_cloudletpool.go
+++ b/mc/orm/authz_cloudletpool.go
@@ -1,0 +1,31 @@
+package orm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/labstack/echo"
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+)
+
+func authzDeleteCloudletPool(ctx context.Context, region, username string, obj *edgeproto.CloudletPool, resource, action string) error {
+	if !authorized(ctx, username, "", resource, action) {
+		return echo.ErrForbidden
+	}
+
+	// check if cloudletpool is in use by orgcloudletpool
+	lookup := ormapi.OrgCloudletPool{}
+	pools := make([]ormapi.OrgCloudletPool, 0)
+	lookup.Region = region
+	lookup.CloudletPool = obj.Key.Name
+	db := loggedDB(ctx)
+	res := db.Where(&lookup).Find(&pools)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RecordNotFound() || len(pools) == 0 {
+		return nil
+	}
+	return fmt.Errorf("Cannot delete CloudletPool region %s name %s because it in use by OrgCloudletPool org %s", region, obj.Key.Name, pools[0].Org)
+}

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -126,6 +126,9 @@ func DeleteOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.Organizat
 	db := loggedDB(ctx)
 	err := db.Delete(&org).Error
 	if err != nil {
+		if strings.Contains(err.Error(), "violates foreign key constraint \"org_cloudlet_pools_org_fkey\"") {
+			return fmt.Errorf("Cannot delete organization because it is referenced by an OrgCloudletPool")
+		}
 		return dbErr(err)
 	}
 	// delete all casbin groups associated with org

--- a/mc/orm/orgcloudletpools.go
+++ b/mc/orm/orgcloudletpools.go
@@ -65,20 +65,20 @@ func CreateOrgCloudletPoolObj(ctx context.Context, claims *UserClaims, op *ormap
 		return err
 	}
 	if !found {
-		return fmt.Errorf("Specified CloudletPool for region not found")
+		return fmt.Errorf("Specified CloudletPool %s for region %s not found", op.CloudletPool, op.Region)
 	}
 	// create org cloudletpool
 	db := loggedDB(ctx)
 	err = db.Create(&op).Error
 	if err != nil {
 		if strings.Contains(err.Error(), "violates foreign key constraint \"org_cloudlet_pools_org_fkey\"") {
-			return fmt.Errorf("Specified Organization does not exist")
+			return fmt.Errorf("Specified Organization %s does not exist", op.Org)
 		}
 		if strings.Contains(err.Error(), "violates foreign key constraint \"org_cloudlet_pools_region_fkey\"") {
-			return fmt.Errorf("Specified Region does not exist")
+			return fmt.Errorf("Specified Region %s does not exist", op.Region)
 		}
 		if strings.Contains(err.Error(), "duplicate key value violates unique") {
-			return fmt.Errorf("Already exists")
+			return fmt.Errorf("OrgCloudletPool org %s, region %s, pool %s already exists", op.Org, op.Region, op.CloudletPool)
 		}
 		return dbErr(err)
 	}


### PR DESCRIPTION
MC API error case fixes:
1724: add name to error message for CreateOrgCloudletPool already exists
1725: replace database error message with better error message for deleting an org in use by an orgcloudletpool
1728: disallow DeleteCloudletPool if in use by OrgCloudletPool (authz_cloudletpool.go)