### PR TITLE
EDGECLOUD-1748: Stream* API should not be part of Audit Log

### DIFF
--- a/mc/orm/auditlog.go
+++ b/mc/orm/auditlog.go
@@ -30,6 +30,7 @@ func logger(next echo.HandlerFunc) echo.HandlerFunc {
 			strings.Contains(req.RequestURI, "Show") ||
 			strings.Contains(req.RequestURI, "/auth/user/current") ||
 			strings.Contains(req.RequestURI, "/metrics/") ||
+			strings.Contains(req.RequestURI, "/ctrl/Stream") ||
 			strings.Contains(req.RequestURI, "/auth/audit/") {
 			// don't log (fills up Audit logs)
 			lvl = log.SuppressLvl


### PR DESCRIPTION
Have suppressed Stream* APIs in Auditlog, as it fills up the logs