### PR TITLE
EDGECLOUD-1734 updates for AutoProvPolicy

### DIFF
--- a/autoprov/autoprov_aggr.go
+++ b/autoprov/autoprov_aggr.go
@@ -181,26 +181,8 @@ func (s *AutoProvAggr) runIter(ctx context.Context, init bool) error {
 	for appKey, cloudlets := range stats {
 		appStats, found := s.allStats[appKey]
 		if !found {
-			// lookup policy
-			// TODO: update cached policy params if policy changes
-			app := edgeproto.App{}
-			if !s.appCache.Get(&appKey, &app) {
-				log.SpanLog(ctx, log.DebugLevelMetrics, "cannot find app", "app", appKey)
-				continue
-			}
-			policy := edgeproto.AutoProvPolicy{}
-			policyKey := edgeproto.PolicyKey{}
-			policyKey.Name = app.AutoProvPolicy
-			policyKey.Developer = appKey.DeveloperKey.Name
-			if !s.policyCache.Get(&policyKey, &policy) {
-				log.SpanLog(ctx, log.DebugLevelMetrics, "cannot find policy for app", "app", appKey, "policy", app.AutoProvPolicy)
-				continue
-			}
-			appStats = &apAppStats{}
-			appStats.cloudlets = make(map[edgeproto.CloudletKey]*apCloudletStats)
-			appStats.deployClientCount = policy.DeployClientCount
-			appStats.deployIntervalCount = policy.DeployIntervalCount
-			s.allStats[appKey] = appStats
+			// may have been deleted
+			continue
 		}
 		for ckey, count := range cloudlets {
 			cstats, found := appStats.cloudlets[ckey]
@@ -218,15 +200,17 @@ func (s *AutoProvAggr) runIter(ctx context.Context, init bool) error {
 			}
 			// We are looking for consecutive intervals that
 			// match the deployment/undeployment criteria.
-			if (s.intervalNum-1) == cstats.intervalNum &&
-				(count-cstats.count) >= uint64(appStats.deployClientCount) {
-				cstats.deployIntervalsMet++
-			} else {
+			if (s.intervalNum - 1) != cstats.intervalNum {
+				// missed interval means no change, so reset
+				// consecutive counter
 				cstats.deployIntervalsMet = 0
+			}
+			if (count - cstats.count) >= uint64(appStats.deployClientCount) {
+				cstats.deployIntervalsMet++
 			}
 			cstats.count = count
 			cstats.intervalNum = s.intervalNum
-			log.DebugLog(log.DebugLevelMetrics, "intervalsMet", "app", appKey, "cloudlet", ckey, "deploysMet", cstats.deployIntervalsMet)
+			log.DebugLog(log.DebugLevelMetrics, "intervalsMet", "app", appKey, "cloudlet", ckey, "deploysMet", cstats.deployIntervalsMet, "count", count)
 
 			if cstats.deployIntervalsMet >= appStats.deployIntervalCount {
 				go func() {
@@ -292,14 +276,10 @@ func (s *AutoProvAggr) deploy(ctx context.Context, appKey *edgeproto.AppKey, clo
 	return err
 }
 
-func (s *AutoProvAggr) Clear(appKey *edgeproto.AppKey) {
+func (s *AutoProvAggr) DeleteApp(ctx context.Context, appKey *edgeproto.AppKey) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	for akey, _ := range s.allStats {
-		if akey.Matches(appKey) {
-			delete(s.allStats, akey)
-		}
-	}
+	delete(s.allStats, *appKey)
 }
 
 func (s *AutoProvAggr) Prune(apps map[edgeproto.AppKey]struct{}) {
@@ -309,5 +289,52 @@ func (s *AutoProvAggr) Prune(apps map[edgeproto.AppKey]struct{}) {
 		if _, found := apps[akey]; !found {
 			delete(s.allStats, akey)
 		}
+	}
+}
+
+func (s *AutoProvAggr) UpdateApp(ctx context.Context, appKey *edgeproto.AppKey) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	app := edgeproto.App{}
+	if !s.appCache.Get(appKey, &app) {
+		// must have been deleted
+		delete(s.allStats, *appKey)
+		return
+	}
+	if app.AutoProvPolicy == "" {
+		delete(s.allStats, app.Key)
+		return
+	}
+	appStats, found := s.allStats[app.Key]
+	if !found {
+		appStats = &apAppStats{}
+		appStats.cloudlets = make(map[edgeproto.CloudletKey]*apCloudletStats)
+		s.allStats[app.Key] = appStats
+	}
+	policy := edgeproto.AutoProvPolicy{}
+	policyKey := edgeproto.PolicyKey{}
+	policyKey.Name = app.AutoProvPolicy
+	policyKey.Developer = appKey.DeveloperKey.Name
+	if !s.policyCache.Get(&policyKey, &policy) {
+		log.SpanLog(ctx, log.DebugLevelMetrics, "cannot find policy for app", "app", app.Key, "policy", app.AutoProvPolicy)
+		return
+	}
+	appStats.deployClientCount = policy.DeployClientCount
+	appStats.deployIntervalCount = policy.DeployIntervalCount
+}
+
+func (s *AutoProvAggr) UpdatePolicy(ctx context.Context, policy *edgeproto.AutoProvPolicy) {
+	appKeys := make([]edgeproto.AppKey, 0)
+	s.appCache.Mux.Lock()
+	for key, app := range s.appCache.Objs {
+		if app.AutoProvPolicy == policy.Key.Name && key.DeveloperKey.Name == policy.Key.Developer {
+			appKeys = append(appKeys, key)
+		}
+	}
+	s.appCache.Mux.Unlock()
+
+	for _, key := range appKeys {
+		s.UpdateApp(ctx, &key)
 	}
 }

--- a/autoprov/autoprov_app.go
+++ b/autoprov/autoprov_app.go
@@ -16,12 +16,15 @@ func (s *AppHandler) Init() {
 
 func (s *AppHandler) Update(ctx context.Context, in *edgeproto.App, rev int64) {
 	s.cache.Update(ctx, in, rev)
+	if autoProvAggr != nil {
+		autoProvAggr.UpdateApp(ctx, &in.Key)
+	}
 }
 
 func (s *AppHandler) Delete(ctx context.Context, in *edgeproto.App, rev int64) {
 	s.cache.Delete(ctx, in, rev)
 	if autoProvAggr != nil {
-		autoProvAggr.Clear(&in.Key)
+		autoProvAggr.DeleteApp(ctx, &in.Key)
 	}
 }
 

--- a/autoprov/autoprov_handler.go
+++ b/autoprov/autoprov_handler.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+)
+
+type AutoProvPolicyHandler struct {
+	cache edgeproto.AutoProvPolicyCache
+}
+
+func (s *AutoProvPolicyHandler) Init() {
+	edgeproto.InitAutoProvPolicyCache(&s.cache)
+}
+
+func (s *AutoProvPolicyHandler) Update(ctx context.Context, in *edgeproto.AutoProvPolicy, rev int64) {
+	s.cache.Update(ctx, in, rev)
+	if autoProvAggr != nil {
+		autoProvAggr.UpdatePolicy(ctx, in)
+	}
+}
+
+func (s *AutoProvPolicyHandler) Delete(ctx context.Context, in *edgeproto.AutoProvPolicy, rev int64) {
+	s.cache.Delete(ctx, in, rev)
+}
+
+func (s *AutoProvPolicyHandler) Prune(ctx context.Context, keys map[edgeproto.PolicyKey]struct{}) {
+	s.cache.Prune(ctx, keys)
+}
+
+func (s *AutoProvPolicyHandler) Flush(ctx context.Context, notifyId int64) {
+	s.cache.Flush(ctx, notifyId)
+}

--- a/autoprov/autoprov_test.go
+++ b/autoprov/autoprov_test.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
 
+	influxdb "github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/influxdb/models"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
@@ -18,7 +23,7 @@ import (
 )
 
 func TestAutoProv(t *testing.T) {
-	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi)
+	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi | log.DebugLevelMetrics)
 	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
@@ -26,6 +31,11 @@ func TestAutoProv(t *testing.T) {
 
 	*ctrlAddr = "127.0.0.1:9998"
 	*notifyAddrs = "127.0.0.1:9999"
+	// httpmock doesn't work for influx client because it
+	// doesn't use the default transport, so use httptest instead
+	influxServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer influxServer.Close()
+	*influxAddr = influxServer.URL
 
 	// dummy server to recv api calls
 	dc := grpc.NewServer(
@@ -40,7 +50,7 @@ func TestAutoProv(t *testing.T) {
 	}()
 	defer dc.Stop()
 
-	// dummy notify to inject alerts
+	// dummy notify to inject alerts and other objects from controller
 	dn := notify.NewDummyHandler()
 	serverMgr := notify.ServerMgr{}
 	dn.RegisterServer(&serverMgr)
@@ -50,6 +60,11 @@ func TestAutoProv(t *testing.T) {
 	start()
 	defer stop()
 
+	testAutoScale(t, ctx, ds, dn)
+	testAutoProv(t, ctx, ds, dn, influxServer)
+}
+
+func testAutoScale(t *testing.T, ctx context.Context, ds *testutil.DummyServer, dn *notify.DummyHandler) {
 	// initial state of ClusterInst
 	cinst := testutil.ClusterInstData[2]
 	numnodes := int(testutil.ClusterInstData[2].NumNodes)
@@ -92,6 +107,8 @@ func TestAutoProv(t *testing.T) {
 	dn.AlertCache.Update(ctx, &scaledown, 0)
 	requireClusterInstNumNodes(t, &ds.ClusterInstCache, &cinst.Key, numnodes-1)
 	dn.AlertCache.Delete(ctx, &scaledown, 0)
+	ds.ClusterInstCache.Delete(ctx, &cinst, 0)
+	require.Equal(t, 0, len(frClusterInsts.InstsByCloudlet))
 }
 
 func requireClusterInstNumNodes(t *testing.T, cache *edgeproto.ClusterInstCache, key *edgeproto.ClusterInstKey, numnodes int) {
@@ -109,4 +126,156 @@ func requireClusterInstNumNodes(t *testing.T, cache *edgeproto.ClusterInstCache,
 		break
 	}
 	require.Equal(t, numnodes, checkCount, "ClusterInst NumNodes count mismatch")
+}
+
+func testAutoProv(t *testing.T, ctx context.Context, ds *testutil.DummyServer, dn *notify.DummyHandler, influxServer *httptest.Server) {
+	require.NotNil(t, autoProvAggr)
+	// we will run iterations manually so set interval to large number
+	autoProvAggr.UpdateSettings(300, 0)
+
+	// add reservable ClusterInst
+	rcinst := testutil.ClusterInstData[7]
+	dn.ClusterInstCache.Update(ctx, &rcinst, 0)
+	cloudletKey := rcinst.Key.CloudletKey
+	// add policy
+	policy := testutil.AutoProvPolicyData[0]
+	policy.Cloudlets = []*edgeproto.AutoProvCloudlet{
+		&edgeproto.AutoProvCloudlet{
+			Key: rcinst.Key.CloudletKey,
+		},
+	}
+	dn.AutoProvPolicyCache.Update(ctx, &policy, 0)
+	// add app that uses above policy
+	app := testutil.AppData[11]
+	dn.AppCache.Update(ctx, &app, 0)
+
+	notify.WaitFor(&appHandler.cache, 1)
+	notify.WaitFor(&autoProvPolicyHandler.cache, 1)
+
+	// check stats exist for app, check cached policy values
+	appStats, found := autoProvAggr.allStats[app.Key]
+	require.True(t, found)
+	require.Equal(t, policy.DeployClientCount, appStats.deployClientCount)
+	require.Equal(t, policy.DeployIntervalCount, appStats.deployIntervalCount)
+	// allow for testing non-trigger condition
+	require.True(t, policy.DeployClientCount > 1)
+
+	// define influxdb response
+	// this will return the "count" each time it is called, for
+	// the target app + cloudlet, in the form of an influxdb measurement.
+	count := uint64(0)
+	influxServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		row := models.Row{
+			Name: "auto-prov-counts",
+			Columns: []string{
+				"time",
+				"app",
+				"cloudlet",
+				"count",
+				"dev",
+				"oper",
+				"ver",
+			},
+			Values: [][]interface{}{
+				[]interface{}{
+					time.Now().Format(time.RFC3339),
+					app.Key.Name,
+					cloudletKey.Name,
+					count,
+					app.Key.DeveloperKey.Name,
+					cloudletKey.OperatorKey.Name,
+					app.Key.Version,
+				},
+			},
+		}
+		res := influxdb.Result{
+			Series: []models.Row{row},
+		}
+		dbresp := influxdb.Response{
+			Results: []influxdb.Result{res},
+		}
+		w.Header().Set("X-Influxdb-Version", "1.0")
+		w.Header().Set("Content-Type", "application/json")
+		data, err := json.Marshal(dbresp)
+		require.Nil(t, err)
+		w.Write(data)
+	})
+
+	// expected AppInst key
+	appInst := edgeproto.AppInst{
+		Key: edgeproto.AppInstKey{
+			AppKey:         app.Key,
+			ClusterInstKey: rcinst.Key,
+		},
+	}
+
+	// init first iter
+	err := autoProvAggr.runIter(ctx, true)
+	require.Nil(t, err)
+
+	// non-trigger condition
+	for ii := uint32(0); ii < policy.DeployIntervalCount; ii++ {
+		count += uint64(1)
+		err := autoProvAggr.runIter(ctx, false)
+		require.Nil(t, err)
+		cstats, found := appStats.cloudlets[cloudletKey]
+		require.True(t, found)
+		require.Equal(t, uint32(0), cstats.deployIntervalsMet)
+	}
+
+	// iterate to satisfy policy
+	for ii := uint32(0); ii < policy.DeployIntervalCount; ii++ {
+		count += uint64(policy.DeployClientCount)
+		err := autoProvAggr.runIter(ctx, false)
+		require.Nil(t, err)
+	}
+
+	cstats, found := appStats.cloudlets[cloudletKey]
+	require.True(t, found, "found cloudlet stats")
+	require.Equal(t, count, cstats.count)
+
+	// check that auto-prov AppInst was created
+	notify.WaitFor(&ds.AppInstCache, 1)
+	found = ds.AppInstCache.Get(&appInst.Key, &edgeproto.AppInst{})
+	require.True(t, found, "found auto-provisioned AppInst")
+
+	// manually delete AppInst (auto-unprovision not supported yet)
+	ds.AppInstCache.Delete(ctx, &appInst, 0)
+
+	// update policy
+	policy.DeployClientCount *= 2
+	policy.DeployIntervalCount *= 2
+	dn.AutoProvPolicyCache.Update(ctx, &policy, 0)
+	// wait for changes to take effect
+	for ii := 0; ii < 10; ii++ {
+		if appStats.deployClientCount == policy.DeployClientCount && appStats.deployIntervalCount == policy.DeployIntervalCount {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// verify changes
+	appStats, found = autoProvAggr.allStats[app.Key]
+	require.True(t, found)
+	require.Equal(t, policy.DeployClientCount, appStats.deployClientCount)
+	require.Equal(t, policy.DeployIntervalCount, appStats.deployIntervalCount)
+
+	// remove policy from App
+	app.AutoProvPolicy = ""
+	dn.AppCache.Update(ctx, &app, 0)
+	// wait for changes to take effect
+	for ii := 0; ii < 10; ii++ {
+		_, found = autoProvAggr.allStats[app.Key]
+		if !found {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// stats for app will be deleted if policy is removed from app
+	_, found = autoProvAggr.allStats[app.Key]
+	require.False(t, found)
+
+	// clean up
+	dn.AppCache.Delete(ctx, &app, 0)
+	dn.AutoProvPolicyCache.Delete(ctx, &policy, 0)
+	dn.ClusterInstCache.Delete(ctx, &rcinst, 0)
 }


### PR DESCRIPTION
Handle updates to existing AutoProvPolicy or removal of AutoProvPolicy from App. 

For updates to AutoProvPolicy, we need to update the cached parameters in the app stats. For removal of policy from app (or deletion of app), we delete the appStats objects from the aggr map.

Added an AutoProvPolicy handler so we can trigger a call when an AutoProvPolicy gets updated. It's mostly a no-op wrapper around the AutoProvPolicy cache.

Added a bunch of unit tests around checking the internal stats of autoprov_aggr and the overall behavior in terms of creating an auto-provisioned AppInst. This required a fake influxdb server, and adds on to the existing AutoScalePolicy test that leverages a fake controller DummyServer and fake DummyNotify.