### PR TITLE
Jaeger needs wildcard cert

### DIFF
--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -531,7 +531,8 @@
         name: web
       vars:
         nginx_config_template: "internal/jaeger/nginx-config.j2"
-        cert_domains: [ "{{ inventory_hostname }}" ]
+        cert_domains: [ "*.{{ cloudflare_zone }}" ]
+        cert_name: "{{ inventory_hostname }}"
       tags: setup
 
     - import_role:

--- a/ansible/roles/web/tasks/certs.yml
+++ b/ansible/roles/web/tasks/certs.yml
@@ -31,7 +31,7 @@
     certbot certonly
       --dns-cloudflare --dns-cloudflare-credentials {{ cloudflare_credentials_file }}
       --agree-tos --email {{ mex_ops_email }} --non-interactive
-      -d {{ cert_domains | join(" -d ") }}
+      -d {{ cert_domains | join(" -d ") }} --cert-name "{{ cert_name | default(cert_domains[0]) }}"
   become: yes
   args:
     creates: "{{ letsencrypt_root }}/{{ cert_domains[0] }}/fullchain.pem"


### PR DESCRIPTION
TELUS setup uses CRM-GW proxies which end up accessing jaeger with
hostnames like "montreal-jaeger.mobiledgex.net".