### PR TITLE
Fixes for running QA against local services

### DIFF
--- a/e2e-tests/data/appdata_automation.yml
+++ b/e2e-tests/data/appdata_automation.yml
@@ -149,21 +149,16 @@ appinstances:
         name: automation_api
       name: automation_api_app
       version: "1.0"
-    cloudletkey:
-      operatorkey:
-        name: tmus
-      name: tmocloud-1
-    id: 123
+    clusterinstkey:
+      clusterkey:
+        name: autocluster1
+      cloudletkey:
+        operatorkey:
+          name: tmus
+        name: tmocloud-1
   cloudletloc:
     latitude: 31
     longitude: -91
-  clusterinstkey:
-    clusterkey:
-      name: autocluster
-    cloudletkey:
-      operatorkey:
-        name: tmus
-      name: tmocloud-1
   liveness: LivenessStatic
   flavor:
     name: automation_api_flavor

--- a/e2e-tests/setups/local_multi_automation.yml
+++ b/e2e-tests/setups/local_multi_automation.yml
@@ -266,3 +266,37 @@ clustersvcs:
      clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
 
+traefiks:
+- name: traefik-e2e
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    serverkey: "{{tlsoutdir}}/mex-server.key"
+    cacert: "{{tlsoutdir}}/mex-ca.crt"
+  hostname: "127.0.0.1"
+
+jaegers:
+- name: jaeger-e2e
+  hostname: "127.0.0.1"
+
+autoprovs:
+- name: autoprov1
+  notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
+  ctrladdrs: "127.0.0.1:55001"
+  vaultaddr: "http://127.0.0.1:8200"
+  influxaddr: "http://127.0.0.1:8086"
+  shorttimeouts: true
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"
+
+prometheus:
+- name: prom-e2e
+  hostname: "127.0.0.1"
+  port: 9090
+
+exporter:
+- name: fakePromExporter
+  datafile: "{{datadir2}}/mc_metrics.yml"
+  port: 9100
+  hostname: "127.0.0.1"

--- a/e2e-tests/testfiles/deploy_start_create_automation.yml
+++ b/e2e-tests/testfiles/deploy_start_create_automation.yml
@@ -4,6 +4,8 @@ description: Deploys and starts a system, adds provisioning. Does not stop or cl
 
 tests:
 
+- includefile: {{edge-cloud-testfiles}}/stop_cleanup.yml
+
 - name: deploy and start services 
   actions: [deploy,start,sleep=3]
 


### PR DESCRIPTION
Some fixes for running services locally for local QA robot tests. Also updated Robot Framework confluence page guide.

Mainly the format of the AppInst key in the appdata file was out of date, but also some newer services were not captured in the setup file.