### PR TITLE
EDGECLOUD-1741 DeleteCloudletPool without params

### DIFF
--- a/mc/orm/authz_cloudletpool.go
+++ b/mc/orm/authz_cloudletpool.go
@@ -15,12 +15,10 @@ func authzDeleteCloudletPool(ctx context.Context, region, username string, obj *
 	}
 
 	// check if cloudletpool is in use by orgcloudletpool
-	lookup := ormapi.OrgCloudletPool{}
 	pools := make([]ormapi.OrgCloudletPool, 0)
-	lookup.Region = region
-	lookup.CloudletPool = obj.Key.Name
 	db := loggedDB(ctx)
-	res := db.Where(&lookup).Find(&pools)
+	// explicitly list fields to avoid being ignored if 0 or emtpy string
+	res := db.Where(map[string]interface{}{"region": region, "cloudlet_pool": obj.Key.Name}).Find(&pools)
 	if res.Error != nil {
 		return res.Error
 	}

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -432,6 +432,11 @@ func TestController(t *testing.T) {
 	goodPermTestShowCloudlet(t, mcClient, uri, tokenDev2, ctrl.Region, "", count)
 	goodPermTestShowCloudlet(t, mcClient, uri, tokenOper, ctrl.Region, "", ccount)
 	goodPermTestShowCloudlet(t, mcClient, uri, tokenOper2, ctrl.Region, "", count)
+	// bug1741 - empty args to Delete CloudletPool when pools are present
+	// Should allow delete to continue to controller which always returns success
+	_, status, err = ormtestutil.TestDeleteCloudletPool(mcClient, uri, tokenAd, ctrl.Region, &edgeproto.CloudletPool{})
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, status)
 
 	// delete org cloudlet pools
 	status, err = mcClient.DeleteOrgCloudletPool(uri, token, &op1)


### PR DESCRIPTION
Fix bug where specifying empty params to DeleteCloudletPool returned a weird error referencing a random Org (whatever first orgcloudletpool that's in the database).

This bug was caused because of how gorm does SQL lookups based on params in a lookup struct. It ignores any fields that are 0 or "". The lookup then basically returned all orgcloudletpools in the database. To avoid this, we need to explicitly specify the fields that much be matched for the query.
