### PR TITLE
EDGECLOUD-1826 edgebox configuration changes

### DIFF
--- a/e2e-tests/edgebox/edgebox_vars.yml
+++ b/e2e-tests/edgebox/edgebox_vars.yml
@@ -12,3 +12,4 @@ mc_user: ENV=MC_USER
 operator: mex
 region: EU
 vault: https://vault-main.mobiledgex.net
+outputdir: /tmp/edgebox

--- a/e2e-tests/setups/edgebox.yml
+++ b/e2e-tests/setups/edgebox.yml
@@ -1,6 +1,6 @@
 mcs:
 - name: mc1
-  addr: {{mc}}:9900
+  addr: {{mc}}:443
   hostname: {{mc}}
 
 crms:


### PR DESCRIPTION
Edgebox configuration changes:

- stage environment mcctl now runs on 443 (instead of 9900). This is due to latest changes to make console-stage webgui and mcctl coexist in same vm.

- default edgebox_var.yml  should have "outputdir: /tmp/edgebox" line