### PR TITLE
EDGECLOUD-1756 bad org in ImagePath better error message

### DIFF
--- a/mc/orm/auditlog.go
+++ b/mc/orm/auditlog.go
@@ -190,7 +190,7 @@ func ShowAuditOrg(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, Msg("Invalid POST data"))
 	}
 
-	if !authorized(ctx, claims.Username, query.Org, ResourceUsers, ActionView) {
+	if !authorized(ctx, claims.Username, query.Org, ResourceUsers, ActionView, withShowAudit()) {
 		if query.Org == "" {
 			return fmt.Errorf("Organization not specified or no permissions")
 		}

--- a/mc/orm/authz_app.go
+++ b/mc/orm/authz_app.go
@@ -73,11 +73,17 @@ func checkImagePath(ctx context.Context, obj *edgeproto.App) error {
 		return fmt.Errorf("Empty URL path in ImagePath")
 	}
 	targetOrg := pathNames[0]
+	if targetOrg == "" {
+		return fmt.Errorf("Empty organization name in ImagePath")
+	}
 
 	lookup := ormapi.Organization{}
 	lookup.Name = targetOrg
 	db := loggedDB(ctx)
-	err = db.Where(&lookup).First(&lookup).Error
+	res := db.Where(&lookup).First(&lookup)
+	if res.RecordNotFound() {
+		return fmt.Errorf("Organization %s from ImagePath not found", targetOrg)
+	}
 	if err != nil {
 		return err
 	}

--- a/mc/orm/authz_app_test.go
+++ b/mc/orm/authz_app_test.go
@@ -64,6 +64,8 @@ func testImagePaths(t *testing.T, ctx context.Context, mcClient *ormclient.Clien
 	testImagePath(t, ctx, "org1", "http://foobar.mobiledgex.net/artifactory/repo-org4/someapp", false)
 	// docker path which doesn't include http scheme
 	testImagePath(t, ctx, "org1", "foobar.mobiledgex.net/andyorg/images/server:1.0", false)
+	// test empty org name in both org and path
+	testImagePath(t, ctx, "", "docker-qa.mobiledgex.net/", false)
 
 	status, err = mcClient.DeleteOrg(uri, tokenAd, &org1)
 	require.Nil(t, err)

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -300,3 +300,18 @@ func getOrgType(orgName string, allOrgs map[string]*ormapi.Organization) string 
 	}
 	return ""
 }
+
+func orgExists(ctx context.Context, orgName string) (bool, error) {
+	lookup := ormapi.Organization{
+		Name: orgName,
+	}
+	db := loggedDB(ctx)
+	res := db.Where(&lookup).First(&ormapi.Organization{})
+	if res.RecordNotFound() {
+		return false, nil
+	}
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return true, nil
+}

--- a/mc/rbac/enforcer.go
+++ b/mc/rbac/enforcer.go
@@ -32,20 +32,24 @@ func (e *Enforcer) Init(ctx context.Context) error {
 	return e.adapter.Init(ctx)
 }
 
-func (e *Enforcer) Enforce(ctx context.Context, sub, org, obj, act string) (bool, error) {
+// Enforce checks that the action is allowed. The first boolean return
+// value indicates if the action is allowed or not, the second indicates
+// if it was allowed because the user is an admin (and thus the existence
+// of the org was not verified).
+func (e *Enforcer) Enforce(ctx context.Context, sub, org, obj, act string) (bool, bool, error) {
 	authz, err := e.adapter.GetAuthorized(ctx, obj, act)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	subj := GetCasbinGroup(org, sub)
 	_, found := authz[subj]
 	if found {
-		return true, nil
+		return true, false, nil
 	}
 	// may be admin so no org appended
 	_, found = authz[sub]
-	return found, nil
+	return found, true, nil
 }
 
 func (e *Enforcer) LogEnforce(on bool) {


### PR DESCRIPTION
Give more descriptive error message in CreateApp if org in ImagePath if org not found. Instead of "record not found", we now return "Organization xyz from ImagePath not found".

Also fixed two other issues I found. First is that if both org and org in embedded in a .mobiledgex.net ImagePath where empty, the ImagePath check was being allowed. Fix is to check for empty string for org in mobiledgex.net ImagePath. The second is that for an admin, if the org was empty and ImagePath was "", CreateApp was being allowed by rbac. This is because for admins, org in rbac is "", so the existence of the org was not being verified by the rbac tables. The fix is to add an explicit check of the org table to make sure the org exists. For the showAudit case, allow admin to see audit logs even if org no longer exists. For non-admins, the org must exist or the authorization will fail, so non-admins cannot see audit logs for deleted orgs.