### PR TITLE
EDGECLOUD-1771 bad names for heat stack

### DIFF
--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/util"
 	"github.com/mobiledgex/edge-cloud/vault"
 	"github.com/mobiledgex/edge-cloud/vmspec"
 	ssh "github.com/mobiledgex/golang-ssh"
@@ -35,7 +36,7 @@ var PlatformServices = []string{
 
 func getPlatformVMName(cloudlet *edgeproto.Cloudlet) string {
 	// Form platform VM name based on cloudletKey
-	return cloudlet.Key.Name + "." + cloudlet.Key.OperatorKey.Name + ".pf"
+	return util.HeatSanitize(cloudlet.Key.Name + "." + cloudlet.Key.OperatorKey.Name + ".pf")
 }
 
 func startPlatformService(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, client ssh.Client, serviceType string, updateCallback edgeproto.CacheUpdateCallback, cDone chan error) {
@@ -470,7 +471,7 @@ func (s *Platform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 		return fmt.Errorf("DeleteCloudlet error: %v", err)
 	}
 
-	rootLBName := cloudcommon.GetRootLBFQDN(&cloudlet.Key)
+	rootLBName := getRootLBName(&cloudlet.Key)
 	updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Deleting RootLB %s", rootLBName))
 	err = mexos.HeatDeleteStack(ctx, rootLBName)
 	if err != nil {

--- a/crm-platforms/openstack/openstack.go
+++ b/crm-platforms/openstack/openstack.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/util"
 	"github.com/mobiledgex/edge-cloud/vault"
 	"github.com/mobiledgex/edge-cloud/vmspec"
 )
@@ -32,7 +33,7 @@ func (s *Platform) GetType() string {
 }
 
 func (s *Platform) Init(ctx context.Context, platformConfig *platform.PlatformConfig, updateCallback edgeproto.CacheUpdateCallback) error {
-	rootLBName := cloudcommon.GetRootLBFQDN(platformConfig.CloudletKey)
+	rootLBName := getRootLBName(platformConfig.CloudletKey)
 	s.cloudletKey = platformConfig.CloudletKey
 	s.config = *platformConfig
 	log.SpanLog(ctx,
@@ -135,4 +136,9 @@ func (s *Platform) GetPlatformClient(ctx context.Context, clusterInst *edgeproto
 		rootLBName = cloudcommon.GetDedicatedLBFQDN(s.cloudletKey, &clusterInst.Key.ClusterKey)
 	}
 	return s.GetPlatformClientRootLB(ctx, rootLBName)
+}
+
+func getRootLBName(key *edgeproto.CloudletKey) string {
+	name := cloudcommon.GetRootLBFQDN(key)
+	return util.HeatSanitize(name)
 }

--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -710,7 +710,7 @@ func HeatDeleteCluster(ctx context.Context, client pc.PlatformClient, clusterIns
 		// probably already gone
 		log.SpanLog(ctx, log.DebugLevelMexos, "unable to get cluster params, proceed with stack deletion", "err", err)
 	}
-	clusterName := k8smgmt.GetK8sNodeNameSuffix(&clusterInst.Key)
+	clusterName := util.HeatSanitize(k8smgmt.GetK8sNodeNameSuffix(&clusterInst.Key))
 	return HeatDeleteStack(ctx, clusterName)
 }
 
@@ -776,7 +776,7 @@ func getClusterParams(ctx context.Context, clusterInst *edgeproto.ClusterInst, p
 	}
 	cp.PrivacyPolicy = privacyPolicy
 	cp.CloudletSecurityGroup = cloudletGrp
-	cp.ClusterName = k8smgmt.GetK8sNodeNameSuffix(&clusterInst.Key)
+	cp.ClusterName = util.HeatSanitize(k8smgmt.GetK8sNodeNameSuffix(&clusterInst.Key))
 	rtr := GetCloudletExternalRouter()
 	if rtr == NoConfigExternalRouter {
 		log.SpanLog(ctx, log.DebugLevelMexos, "NoConfigExternalRouter in use for cluster, cluster stack with no router interfaces")

--- a/mexos/kubectl.go
+++ b/mexos/kubectl.go
@@ -67,9 +67,9 @@ func CreateClusterConfigMap(ctx context.Context, client pc.PlatformClient, clust
 	log.SpanLog(ctx, log.DebugLevelMexos, "creating cluster config map in kubernetes cluster")
 
 	cmd := fmt.Sprintf("kubectl create configmap mexcluster-info "+
-		"--from-literal=ClusterName=%s "+
-		"--from-literal=CloudletName=%s "+
-		"--from-literal=OperatorName=%s --kubeconfig=%s",
+		"--from-literal=ClusterName='%s' "+
+		"--from-literal=CloudletName='%s' "+
+		"--from-literal=OperatorName='%s' --kubeconfig=%s",
 		clusterInst.Key.ClusterKey.Name, clusterInst.Key.CloudletKey.Name,
 		clusterInst.Key.CloudletKey.OperatorKey.Name,
 		k8smgmt.GetKconfName(clusterInst))


### PR DESCRIPTION
Sanitize names used for heat stacks. Heat stack names are a little more restrictive than our usual name filters.

Bug 1771 fails with a bad cloudlet name when creating the rootLB, but checks are also needed during CreateClusterInst.

Tested on Bonn.

```
➜  berlin> edgectl controller CreateClusterInst cloudlet='0jon ber,lin&' operator=TDG cluster='0jon.-berlin' flavor=x1.medium developer=dev1 nummasters=1 numnodes=1
message: Creating
message: Creating Heat Stack for a0jonberlin-0jon.-berlin-dev1
message: 'Creating Heat Stack for a0jonberlin-0jon.-berlin-dev1, Heat Stack Status:
  CREATE_IN_PROGRESS'
message: 'Creating Heat Stack for a0jonberlin-0jon.-berlin-dev1, Heat Stack Status:
  CREATE_COMPLETE'
message: Waiting for Cluster to Initialize
message: Waiting for Cluster to Initialize, Checking Master for Available Nodes
message: Waiting for Cluster to Initialize, 1 of 1 nodes active
message: Creating config map
message: Ready
message: Created ClusterInst successfully
➜  berlin
➜  berlin
➜  berlin
➜  berlin> edgectl controller DeleteClusterInst cloudlet='0jon ber,lin&' operator=TDG cluster='0jon.-berlin' flavor=x1.medium developer=dev1 nummasters=1 numnodes=1
message: Deleting
message: NotPresent
message: Deleted ClusterInst successfully
```