### PR TITLE
EDGECLOUD-1869 check org exists in cloudlet authz

### DIFF
--- a/mc/orm/authz_cloudlet.go
+++ b/mc/orm/authz_cloudlet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
 )
 
 // AuthzCloudlet provides an efficient way to check if the user
@@ -40,6 +41,15 @@ func (s *AuthzCloudlet) populate(ctx context.Context, region, username, orgfilte
 			s.allowAll = true
 			return nil
 		} else {
+			// make sure org actually exists
+			found, err := orgExists(ctx, orgfilter)
+			if err != nil {
+				return err
+			}
+			if !found {
+				log.SpanLog(ctx, log.DebugLevelApi, "admin authorized, but org does not exist", "org", orgfilter)
+				return nil
+			}
 			// ensure access (admin may not have explicit perms
 			// for specified org).
 			orgs[orgfilter] = struct{}{}


### PR DESCRIPTION
Additional fix for https://github.com/mobiledgex/edge-cloud-infra/pull/583

I forgot that some APIs have custom authorization functions related to the Cloudlet and CloudletPool restrictions. Those APIs weren't checking the existence of the specified Org.

Added unit-tests for all controller APIs that reference an Org that should exist.