### PR TITLE
connect span from autoprov to controller

### DIFF
--- a/autoprov/autoprov_aggr.go
+++ b/autoprov/autoprov_aggr.go
@@ -257,7 +257,7 @@ func (s *AutoProvAggr) deploy(ctx context.Context, appKey *edgeproto.AppKey, clo
 	inst.Key.ClusterInstKey = *cinstKey
 
 	log.SpanLog(ctx, log.DebugLevelApi, "auto-prov deploy AppInst", "AppInst", inst)
-	conn, err := grpc.Dial(*ctrlAddr, dialOpts, grpc.WithBlock(), grpc.WithWaitForHandshake())
+	conn, err := grpc.Dial(*ctrlAddr, dialOpts, grpc.WithBlock(), grpc.WithWaitForHandshake(), grpc.WithUnaryInterceptor(log.UnaryClientTraceGrpc), grpc.WithStreamInterceptor(log.StreamClientTraceGrpc))
 	if err != nil {
 		return fmt.Errorf("failed to connect to controller, %v", err)
 	}


### PR DESCRIPTION
During some testing I noticed spans from autoprov were not connected to controller apis, because they were not being passed through grpc. This fixes that.