### PR TITLE
shepherd support for docker container name

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -360,7 +360,7 @@ func (s *Platform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		if err != nil {
 			return err
 		}
-		name := dockermgmt.GetContainerName(app)
+		name := dockermgmt.GetContainerName(&app.Key)
 		if !app.InternalPorts {
 			secGrp := mexos.GetSecurityGroupName(ctx, rootLBName)
 			//  the proxy does not yet exist for docker, but it eventually will.  Secgrp rules should be deleted in either case

--- a/mexos/util.go
+++ b/mexos/util.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/dockermgmt"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/access"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/dockermgmt"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/proxy"
@@ -44,7 +44,7 @@ func AddProxySecurityRulesAndPatchDNS(ctx context.Context, client pc.PlatformCli
 				}
 				ops = append(ops, proxy.WithTLSCert(&tlsCert))
 			}
-			proxyerr := proxy.CreateNginxProxy(ctx, client, dockermgmt.GetContainerName&(app.Key), listenIP, backendIP, appInst.MappedPorts, ops...)
+			proxyerr := proxy.CreateNginxProxy(ctx, client, dockermgmt.GetContainerName(&app.Key), listenIP, backendIP, appInst.MappedPorts, ops...)
 			if proxyerr == nil {
 				proxychan <- ""
 			} else {

--- a/shepherd/proxy-stats.go
+++ b/shepherd/proxy-stats.go
@@ -162,8 +162,8 @@ func QueryProxy(ctx context.Context, scrapePoint *ProxyScrapePoint) (*shepherd_c
 	if err != nil && strings.Contains(resp, "No such container") {
 		// try the docker name if it fails
 		container = proxy.GetEnvoyContainerName(dockermgmt.GetContainerName(&scrapePoint.Key.AppKey))
-		request := fmt.Sprintf("docker exec %s curl http://127.0.0.1:%d/stats", container, cloudcommon.ProxyMetricsPort)
-		resp, err := scrapePoint.Client.Output(request)
+		request = fmt.Sprintf("docker exec %s curl http://127.0.0.1:%d/stats", container, cloudcommon.ProxyMetricsPort)
+		resp, err = scrapePoint.Client.Output(request)
 	}
 	if err != nil {
 		if strings.Contains(resp, "No such container") {


### PR DESCRIPTION
shepherd will now attempt to check for a shepherd proxy with the docker naming convention (which is "envoy"+appkey.name+appkey.version , sanitized)