### PR TITLE
EDGECLOUD-1943  Docker apps with no proxy are marked HealthCheckFailRootlbOffline

### DIFF
--- a/shepherd/envoy-stats_test.go
+++ b/shepherd/envoy-stats_test.go
@@ -52,6 +52,7 @@ backend4321::10.192.1.2:4321::health_flags::/failed_active_hc`
 	testApp = edgeproto.App{
 		Key:         testAppKey,
 		AccessPorts: "tcp:1234",
+		AccessType:  edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
 	}
 	testAppInstKey = edgeproto.AppInstKey{
 		AppKey:         testAppKey,

--- a/shepherd/proxy-stats.go
+++ b/shepherd/proxy-stats.go
@@ -70,6 +70,8 @@ func CollectProxyStats(ctx context.Context, appInst *edgeproto.AppInst) {
 		return
 	} else if app.InternalPorts {
 		return
+	} else if app.AccessType != edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER {
+		return
 	}
 	ProxyMapKey := getProxyKey(appInst.GetKey())
 	// add/remove from the list of proxy endpoints to hit


### PR DESCRIPTION
 - Add a check for loadBalancer access type, we don't need to run proxy checks for the non-rootLB appInstances.