### PR TITLE
EDGECLOUD-1722 Make console live with MC. So they stay together forever. (follow-up)

### DIFF
--- a/ansible/templates/mexplat/gitlab.rb.j2
+++ b/ansible/templates/mexplat/gitlab.rb.j2
@@ -257,7 +257,7 @@ gitlab_rails['ldap_enabled'] = true
 gitlab_rails['ldap_servers'] = YAML.load <<-'EOS'
   main: # 'main' is the GitLab 'provider ID' of this LDAP server
     label: 'LDAP'
-    host: '{{ mc_ldap_hostname | default(mc_vm_hostname) }}'
+    host: '{{ mc_ldap_hostname | default(console_vm_hostname) }}'
     port: 9389
     uid: 'sAMAccountName'
     bind_dn: 'cn=gitlab,ou=users'


### PR DESCRIPTION
Switch Gitlab's LDAP to the new MC hostname, which is now the same as
the console.