### PR TITLE
Alternate main console

### DIFF
--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -540,7 +540,7 @@
 
 - hosts: slack
   vars:
-    slack_org_mgmt_image: "registry.mobiledgex.net:5000/mobiledgex/slack-org-mgmt:1.2.0"
+    slack_org_mgmt_image: "registry.mobiledgex.net:5000/mobiledgex/slack-org-mgmt:1.2.1"
     slack_org_mgmt_log: slack-org-mgmt.log
     skipped_channel_file: "{{ ansible_env.HOME }}/skipped-channels.txt"
     support_users:

--- a/ansible/main/list
+++ b/ansible/main/list
@@ -14,12 +14,13 @@ vault_ha_domain=vault-main.mobiledgex.net
 vault_port=443
 vault_firewall_setup=no
 letsencrypt_env=production
+console_vm_hostname=console.mobiledgex.net
 
 [artifactory]
 artifactory.mobiledgex.net	ubuntu_release=xenial docker_skip_install=true artifactory_preconfigured=true install_webhook=true
 
 [console]
-console.mobiledgex.net		skip_console_setup=true
+console.mobiledgex.net
 
 [mc]
 mc.mobiledgex.net	

--- a/mgmt/slack/Makefile
+++ b/mgmt/slack/Makefile
@@ -1,5 +1,5 @@
 IMAGE = slack-org-mgmt
-VERSION = 1.2.0
+VERSION = 1.2.1
 REGISTRY = registry.mobiledgex.net:5000/mobiledgex
 
 build:

--- a/mgmt/slack/slack-org-mgmt.py
+++ b/mgmt/slack/slack-org-mgmt.py
@@ -10,7 +10,7 @@ import sys
 import traceback
 
 LOG_WEBHOOK = os.environ.get('LOG_WEBHOOK', None)
-MC = os.environ.get('MC', 'https://mc.mobiledgex.net:9900')
+MC = os.environ.get('MC', 'https://console.mobiledgex.net')
 SLACK = 'https://slack.com/api/'
 
 TEST_MODE_FORMAT = "slacktest2+{}@venky.duh-uh.com".format

--- a/terraform/mexplat/main/main.tf
+++ b/terraform/mexplat/main/main.tf
@@ -97,6 +97,23 @@ module "vault_b_dns" {
   ip                            = "${module.vault_b.external_ip}"
 }
 
+# VM for console
+module "console" {
+  source              = "../../modules/vm_gcp"
+
+  instance_name       = "${var.console_instance_name}"
+  zone                = "${var.gcp_zone}"
+  boot_disk_size      = 100
+  tags                = [ "http-server", "https-server", "console-debug", "mc" ]
+  ssh_public_key_file = "${var.ssh_public_key_file}"
+}
+
+module "console_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.console_domain_name}"
+  ip                            = "${module.console.external_ip}"
+}
+
 module "mc" {
   source              = "../../modules/vm_gcp"
 

--- a/terraform/mexplat/main/variables.tf
+++ b/terraform/mexplat/main/variables.tf
@@ -86,6 +86,15 @@ variable "mc_vm_domain_name" {
   default     = "mc.mobiledgex.net"
 }
 
+variable "console_instance_name" {
+  default     = "console-main"
+}
+
+variable "console_domain_name" {
+  description = "Console domain name"
+  type        = "string"
+}
+
 variable "ssh_public_key_file" {
   description = "SSH public key file for the ansible account"
   type        = "string"


### PR DESCRIPTION
Set up a new console-main instance to host the co-located console/MC.  Cleanup of the old instances will be done in a follow-up push in a couple of weeks after this one has proved to be stable.