### PR TITLE
EDGECLOUD-2083 Downloading app VM image of larger size times out

### DIFF
--- a/mexos/util.go
+++ b/mexos/util.go
@@ -3,8 +3,10 @@ package mexos
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/access"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/dockermgmt"
@@ -106,4 +108,14 @@ func ParseFlavorProperties(f OSFlavorDetail) map[string]string {
 
 	}
 	return props
+}
+
+// 5GB = 10minutes
+func GetTimeout(cLen int) time.Duration {
+	fileSizeInGB := float64(cLen) / (1024.0 * 1024.0 * 1024.0)
+	timeoutUnit := int(math.Ceil(fileSizeInGB / 5.0))
+	if fileSizeInGB > 5 {
+		return time.Duration(timeoutUnit) * 10 * time.Minute
+	}
+	return 10 * time.Minute
 }

--- a/mexos/util_test.go
+++ b/mexos/util_test.go
@@ -2,6 +2,7 @@ package mexos
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -66,4 +67,16 @@ func TestParseFlavorProps(t *testing.T) {
 	propmap = ParseFlavorProperties(OSFlavors[2])
 	require.Equal(t, testprop3_map, propmap)
 
+}
+
+func TestTimeout(t *testing.T) {
+	var val time.Duration
+
+	oneG := 1073741824
+	val = GetTimeout(0)
+	require.Equal(t, val, 10*time.Minute)
+	val = GetTimeout(5 * oneG)
+	require.Equal(t, val, 10*time.Minute)
+	val = GetTimeout(10 * oneG)
+	require.Equal(t, val, 20*time.Minute)
 }


### PR DESCRIPTION
This was seen with one of the developers. They have VM image of size ~20G. CreateAppInst fails with timeout because downloading file times out. This change adds adaptive timeouts based on Image size. And defaults to 10mins for small size images.

Corresponding PR: https://github.com/mobiledgex/edge-cloud/pull/818

