### PR TITLE
Allow VM apps to work when converted to vmdk

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -140,7 +140,11 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 				return fmt.Errorf("image in store %s is not active", imageName)
 			}
 			if imageDetail.Checksum != md5Sum {
-				return fmt.Errorf("mismatch in md5sum")
+				if app.ImageType == edgeproto.ImageType_IMAGE_TYPE_QCOW && imageDetail.DiskFormat == "vmdk" {
+					log.SpanLog(ctx, log.DebugLevelMexos, "image was imported as vmdk, checksum match not possible")
+				} else {
+					return fmt.Errorf("mismatch in md5sum for image in glance: %s", imageName)
+				}
 			}
 			glanceImageTime, err := time.Parse(time.RFC3339, imageDetail.UpdatedAt)
 			if err != nil {

--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -26,6 +26,7 @@ var MEXInfraVersion = "3.0.3"
 var ImageNamePrefix = "mobiledgex-v"
 var defaultOSImageName = ImageNamePrefix + MEXInfraVersion
 var VaultConfig *vault.Config
+var ImageFormatQcow2 = "qcow2"
 
 // Default CloudletVM/Registry paths should only be used for local testing.
 // Ansible should always specify the correct ones to the controller.
@@ -285,6 +286,14 @@ func GetCloudletComputeAvailabilityZone() string {
 // optional default AZ for the cloudlet for Volumes.
 func GetCloudletVolumeAvailabilityZone() string {
 	return os.Getenv("MEX_VOLUME_AVAILABILITY_ZONE")
+}
+
+func GetCloudletImageDiskFormat() string {
+	format := os.Getenv("MEX_IMAGE_DISK_FORMAT")
+	if format == "" {
+		return ImageFormatQcow2
+	}
+	return format
 }
 
 // initMappedIPs takes the env var MEX_EXTERNAL_IP_MAP contents like:

--- a/mexos/oscli.go
+++ b/mexos/oscli.go
@@ -107,6 +107,7 @@ func GetImageDetail(ctx context.Context, name string) (*OSImageDetail, error) {
 		"-c", "status",
 		"-c", "updated_at",
 		"-c", "checksum",
+		"-c", "disk_format",
 	)
 	if err != nil {
 		err = fmt.Errorf("cannot get image Detail for %s, %s, %v", name, string(out), err)
@@ -643,15 +644,15 @@ func CreateServerImage(ctx context.Context, serverName, imageName string) error 
 }
 
 //CreateImage puts images into glance
-func CreateImage(ctx context.Context, imageName, qcowFile string) error {
-	log.SpanLog(ctx, log.DebugLevelMexos, "creating image in glance", "image", imageName, "qcow", qcowFile)
+func CreateImage(ctx context.Context, imageName, fileName string) error {
+	log.SpanLog(ctx, log.DebugLevelMexos, "creating image in glance", "image", imageName, "fileName", fileName)
 	out, err := TimedOpenStackCommand(ctx, "openstack", "image", "create",
 		imageName,
-		"--disk-format", "qcow2",
+		"--disk-format", GetCloudletImageDiskFormat(),
 		"--container-format", "bare",
-		"--file", qcowFile)
+		"--file", fileName)
 	if err != nil {
-		err = fmt.Errorf("can't create image in glance, %s, %s, %s, %v", imageName, qcowFile, out, err)
+		err = fmt.Errorf("can't create image in glance, %s, %s, %s, %v", imageName, fileName, out, err)
 		return err
 	}
 	return nil
@@ -676,7 +677,7 @@ func CreateImageFromUrl(ctx context.Context, imageName, imageUrl, md5Sum string)
 		}
 		log.SpanLog(ctx, log.DebugLevelMexos, "verify md5sum", "downloaded-md5sum", fileMd5Sum, "actual-md5sum", md5Sum)
 		if fileMd5Sum != md5Sum {
-			return fmt.Errorf("mismatch in md5sum")
+			return fmt.Errorf("mismatch in md5sum for downloaded image: %s", imageName)
 		}
 	}
 


### PR DESCRIPTION
EDGECLOUD-2125

VM apps do not work in VMware because:
1) when the image is uploaded to glance it needs to have --disk-format vmdk (instead of qcow2)
2) The md5sum of the resulting image will not match what was originally downloaded because VMware does some conversion on it when importing as a vmdk.

We still can use qcow2 images in Artifactory, but we can only validate the md5sum when downloading the file.  When spawning the VM there's no way to validate what the sum should be.   So the latter check is ignored for the vmdk case.