### PR TITLE
EDGECLOUD-2148  Metrics - VM App Inst metrics are not being collected

### DIFF
--- a/shepherd/shepherd.go
+++ b/shepherd/shepherd.go
@@ -61,7 +61,13 @@ func appInstCb(ctx context.Context, old *edgeproto.AppInst, new *edgeproto.AppIn
 
 	collectInterval := settings.ShepherdMetricsCollectionInterval.TimeDuration()
 	// check cluster name if this is a VM App
-	if new.Key.ClusterInstKey.ClusterKey.Name == cloudcommon.DefaultVMCluster {
+	app := edgeproto.App{}
+	found := AppCache.Get(&new.Key.AppKey, &app)
+	if !found {
+		log.SpanLog(ctx, log.DebugLevelMetrics, "Unable to find app", "app", new.Key.AppKey.Name)
+		return
+	}
+	if app.Deployment == cloudcommon.AppDeploymentTypeVM {
 		mapKey = new.Key.GetKeyString()
 		stats, exists := vmAppWorkerMap[mapKey]
 		if new.State == edgeproto.TrackedState_READY && !exists {


### PR DESCRIPTION
Check app deployment type for VM deployments.
We can create a cluster with a non-default name, which means that a check against the default VM cluster name is invalid.