### PR TITLE
EDGECLOUD-2073: mcctl websockets support for RunConsole

### DIFF
--- a/mc/mcctl/mcctl.go
+++ b/mc/mcctl/mcctl.go
@@ -28,7 +28,9 @@ func main() {
 	logsCmd := ormctl.GetShowLogsCmd()
 	logsCmd.PersistentFlags().BoolVar(&ormctl.McProxy, "mcproxy", false, "use MC as proxy for WebRTC connection")
 	regionCmds.AddCommand(logsCmd)
-	regionCmds.AddCommand(ormctl.GetRunConsoleCmd())
+	consoleCmd := ormctl.GetRunConsoleCmd()
+	consoleCmd.PersistentFlags().BoolVar(&ormctl.McProxy, "mcproxy", false, "use MC as proxy for WebRTC connection")
+	regionCmds.AddCommand(consoleCmd)
 
 	rootCmd.AddCommand(regionCmds)
 	rootCmd.AddCommand(ormctl.GetConfigCommand())


### PR DESCRIPTION
* Missed adding `mcproxy` argument for RunConsole in my earlier commit.
* This will let mcctl connect to MC over websockets to fetch console URL