### PR TITLE
EDGECLOUD-2060: Use MasterNodeFlavor for RootLBVMDeployment

### DIFF
--- a/mexos/heat.go
+++ b/mexos/heat.go
@@ -779,7 +779,7 @@ func getClusterParams(ctx context.Context, clusterInst *edgeproto.ClusterInst, p
 		cp.VMParams, err = GetVMParams(ctx,
 			RootLBVMDeployment,
 			rootLBName,
-			clusterInst.NodeFlavor,
+			clusterInst.MasterNodeFlavor,
 			clusterInst.ExternalVolumeSize,
 			imgName,
 			GetSecurityGroupName(ctx, rootLBName),


### PR DESCRIPTION
Swap new MasterNodeFlavor for NodeFlavor for RootLBVM deployment. Avoid potential Optional resource leaks.