### PR TITLE
EDGECLOUD-1772 Add flavor name to CreateClusterInst error msg if reso…

### DIFF
--- a/crm-platforms/openstack/openstack-cluster.go
+++ b/crm-platforms/openstack/openstack-cluster.go
@@ -173,8 +173,12 @@ func (s *Platform) createClusterInternal(ctx context.Context, rootLBName string,
 		if reterr == nil {
 			return
 		}
-
-		log.SpanLog(ctx, log.DebugLevelMexos, "error in CreateCluster", "err", reterr)
+		if strings.Contains(reterr.Error(), "ResourceInError") &&
+			strings.Contains(reterr.Error(), "Exhausted all hosts") {
+			log.SpanLog(ctx, log.DebugLevelMexos, "error in CreateCluster using", "flavor", clusterInst.NodeFlavor, "err", reterr)
+		} else {
+			log.SpanLog(ctx, log.DebugLevelMexos, "error in CreateCluster", "err", reterr)
+		}
 		if mexos.GetCleanupOnFailure(ctx) {
 			log.SpanLog(ctx, log.DebugLevelMexos, "cleaning up cluster resources after cluster fail, set envvar CLEANUP_ON_FAILURE to 'no' to avoid this")
 			delerr := s.deleteCluster(ctx, rootLBName, clusterInst)


### PR DESCRIPTION
…urce related
This addresses only the second half of this Jira: improve allocation error message of openstack. 
In cases of Resource error, add the given flavor name to the error message. In general, if the OS flavor supplies > 1 resource, we don't know which has been exhausted, openstack flavor show on the given os flavor will list the possibilities.
Inventory and resource allocation tracking will have their own Jiras.