### PR TITLE
Upgrade Gitlab to 12.7.6 (critical security upgrade)

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1,3 +1,3 @@
-gitlab_version: 12.3.5-ee.0
+gitlab_version: 12.7.6-ee.0
 gitlab_force_reconfigure: false
 gitlab_slack_notify_image_version: 2019-07-26


### PR DESCRIPTION
https://about.gitlab.com/releases/2020/02/13/critical-security-release-gitlab-12-dot-7-dot-6-released/