### PR TITLE
proto import cleanup

### DIFF
--- a/mc/mcctl/cliwrapper/exec.mc2.go
+++ b/mc/mcctl/cliwrapper/exec.mc2.go
@@ -10,7 +10,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/mcctl/cliwrapper/refs.mc2.go
+++ b/mc/mcctl/cliwrapper/refs.mc2.go
@@ -9,7 +9,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/mcctl/ormctl/exec.mc2.go
+++ b/mc/mcctl/ormctl/exec.mc2.go
@@ -10,7 +10,6 @@ import "github.com/mobiledgex/edge-cloud/cli"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/mcctl/ormctl/refs.mc2.go
+++ b/mc/mcctl/ormctl/refs.mc2.go
@@ -10,7 +10,6 @@ import "github.com/mobiledgex/edge-cloud/cli"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/orm/exec.mc2.go
+++ b/mc/orm/exec.mc2.go
@@ -13,7 +13,6 @@ import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/orm/exec_mc2_test.go
+++ b/mc/orm/exec_mc2_test.go
@@ -12,7 +12,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/orm/testutil"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/orm/refs.mc2.go
+++ b/mc/orm/refs.mc2.go
@@ -12,7 +12,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/orm/refs_mc2_test.go
+++ b/mc/orm/refs_mc2_test.go
@@ -12,7 +12,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/orm/testutil"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/orm/testutil/exec_mc2_testutil.go
+++ b/mc/orm/testutil/exec_mc2_testutil.go
@@ -9,7 +9,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/orm/testutil/refs_mc2_testutil.go
+++ b/mc/orm/testutil/refs_mc2_testutil.go
@@ -9,7 +9,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/ormapi/exec.mc2.go
+++ b/mc/ormapi/exec.mc2.go
@@ -7,7 +7,6 @@ import edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/ormapi/refs.mc2.go
+++ b/mc/ormapi/refs.mc2.go
@@ -7,7 +7,6 @@ import edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/ormclient/exec_client.go
+++ b/mc/ormclient/exec_client.go
@@ -10,7 +10,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 

--- a/mc/ormclient/refs_client.go
+++ b/mc/ormclient/refs_client.go
@@ -8,7 +8,6 @@ import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
 import _ "github.com/gogo/protobuf/gogoproto"
 


### PR DESCRIPTION
Remove unused imports from proto files. Gets rid of all those warnings during build.