### PR TITLE
Deploy the notifyroot service in all setups

### DIFF
--- a/ansible/development/group_vars/all
+++ b/ansible/development/group_vars/all
@@ -1,6 +1,7 @@
 jaeger_hostname: jaeger-dev.mobiledgex.net
 jaeger_endpoint: "https://{{ jaeger_hostname }}:14268/api/traces"
 console_vnc_hostname: console-dev-vnc.mobiledgex.net
+notifyroot_hostname: notifyroot-dev.mobiledgex.net
 vault_address: https://vault-dev.mobiledgex.net
 vault_ha_zones:
   us: us-west2-a

--- a/ansible/development/list
+++ b/ansible/development/list
@@ -23,6 +23,9 @@ influxdb_volume_size=1Gi
 vault_firewall_setup=no
 vault_ha_domain="vault-{{ deploy_environ }}.mobiledgex.net"
 
+[notifyroot]
+notifyroot-dev.mobiledgex.net
+
 [platform]
 localhost	ansible_connection=local
 

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -15,6 +15,8 @@ etcd_opetator_crd: etcdclusters.etcd.database.coreos.com
 mc_api_port: 9900
 mc_ldap_port: 9389
 mc_vnc_port: 6080
+mc_notify_srv_port: 52001
+notifyroot_port: 53001
 postgres_server: postgres.mobiledgex.net:5432
 influxdb_name: monitoring-influxdb
 etcd_cluster_name: mex-etcd

--- a/ansible/main/group_vars/all
+++ b/ansible/main/group_vars/all
@@ -2,6 +2,7 @@ mc_artifactory_address: https://artifactory.mobiledgex.net/artifactory
 jaeger_hostname: jaeger.mobiledgex.net
 jaeger_endpoint: "https://{{ jaeger_hostname }}:14268/api/traces"
 console_vnc_hostname: console-vnc.mobiledgex.net
+notifyroot_hostname: notifyroot.mobiledgex.net
 vault_address: https://vault-main.mobiledgex.net
 vault_ha_zones:
   us: us-central1-a

--- a/ansible/main/list
+++ b/ansible/main/list
@@ -16,6 +16,9 @@ vault_firewall_setup=no
 letsencrypt_env=production
 console_vm_hostname=console.mobiledgex.net
 
+[notifyroot]
+notifyroot.mobiledgex.net
+
 [artifactory]
 artifactory.mobiledgex.net	ubuntu_release=xenial docker_skip_install=true artifactory_preconfigured=true install_webhook=true
 

--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -159,6 +159,14 @@
     - import_role:
         name: mc
 
+- hosts: notifyroot
+  tasks:
+    - import_role:
+        name: telegraf
+      tags: [ 'monitoring', 'setup' ]
+    - import_role:
+        name: notifyroot
+
 - hosts: registry_replicas
   tasks:
     - import_role:

--- a/ansible/qa/group_vars/all
+++ b/ansible/qa/group_vars/all
@@ -1,6 +1,7 @@
 jaeger_hostname: jaeger-{{ deploy_environ }}.mobiledgex.net
 jaeger_endpoint: "https://{{ jaeger_hostname }}:14268/api/traces"
 console_vnc_hostname: console-qa-vnc.mobiledgex.net
+notifyroot_hostname: notifyroot-qa.mobiledgex.net
 vault_address: https://vault-qa.mobiledgex.net
 vault_ha_zones:
   us: us-west2-a

--- a/ansible/qa/list
+++ b/ansible/qa/list
@@ -24,6 +24,9 @@ dme_carrier=TDG
 operator_key=TDG
 deploy_target="mexplat-{{ deploy_environ }}"
 
+[notifyroot]
+notifyroot-qa.mobiledgex.net
+
 [platform]
 localhost	ansible_connection=local
 

--- a/ansible/roles/mc/tasks/main.yml
+++ b/ansible/roles/mc/tasks/main.yml
@@ -25,6 +25,10 @@
       - mc
       - "-addr"
       - "0.0.0.0:{{ mc_api_port }}"
+      - "-notifyAddrs"
+      - "{{ notifyroot_hostname }}:{{ notifyroot_port }}"
+      - "-notifySrvAddr"
+      - "0.0.0.0:{{ mc_notify_srv_port }}"
       - "-sqlAddr"
       - "{{ postgres_hostname }}:5432"
       - "-vaultAddr"
@@ -65,6 +69,7 @@
       - "127.0.0.1:{{ mc_api_port }}:{{ mc_api_port }}"
       - "{{ mc_ldap_port }}:{{ mc_ldap_port }}"
       - "127.0.0.1:{{ mc_vnc_port }}:{{ mc_vnc_port }}"
+      - "{{ mc_notify_srv_port }}:{{ mc_notify_srv_port }}"
     env:
       db_name: "{{ mc_postgres_db }}"
       db_username: "{{ mc_postgres_username }}"

--- a/ansible/roles/notifyroot/tasks/main.yml
+++ b/ansible/roles/notifyroot/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Deploy the notifyroot service
+  docker_container:
+    name: notifyroot
+    image: "{{ edge_cloud_image }}:{{ edge_cloud_version }}"
+    restart_policy: unless-stopped
+    network_mode: host
+    command:
+      - notifyroot
+      - "--notifyAddr"
+      - "0.0.0.0:{{ notifyroot_port }}"
+      - "-tls"
+      - "/root/tls/mex-server.crt"
+    env:
+      JAEGER_ENDPOINT: "{{ jaeger_endpoint }}"
+      JAEGER_TAGS: "environ={{ deploy_environ }},version={{ edge_cloud_version }}"

--- a/ansible/staging/group_vars/all
+++ b/ansible/staging/group_vars/all
@@ -1,6 +1,7 @@
 jaeger_hostname: jaeger-stage.mobiledgex.net
 jaeger_endpoint: "https://{{ jaeger_hostname }}:14268/api/traces"
 console_vnc_hostname: console-stage-vnc.mobiledgex.net
+notifyroot_hostname: notifyroot-stage.mobiledgex.net
 vault_address: https://vault-stage.mobiledgex.net
 vault_ha_zones:
   us: us-west2-a

--- a/ansible/staging/list
+++ b/ansible/staging/list
@@ -23,6 +23,9 @@ azure_volume_storage_class=managed-premium
 influxdb_volume_size=5Gi
 letsencrypt_env=production
 
+[notifyroot]
+notifyroot-stage.mobiledgex.net
+
 [platform]
 localhost	ansible_connection=local
 

--- a/ansible/templates/mexplat/mex-controller-deploy.yml.j2
+++ b/ansible/templates/mexplat/mex-controller-deploy.yml.j2
@@ -28,6 +28,8 @@ spec:
          - "0.0.0.0:36001"
          - "--notifyAddr"
          - "0.0.0.0:37001"
+         - "--notifyParentAddrs"
+         - "{{ console_vm_hostname }}:{{ mc_notify_srv_port }}"
          - "--etcdUrls"  
          - "{{ etcd_cluster_client }}:2379"
          - "--vaultAddr"

--- a/ansible/templates/mexplat/terraform.tfvars.j2
+++ b/ansible/templates/mexplat/terraform.tfvars.j2
@@ -13,5 +13,6 @@
 {% if vault_vm_hostname is defined %}  "vault_vm_domain_name": "{{ vault_vm_hostname }}",{{ "\n" }}{% endif %}
 {% if postgres_hostname is defined %}  "postgres_domain_name": "{{ postgres_hostname }}",{{ "\n" }}{% endif %}
 {% if console_vnc_hostname is defined %}  "console_vnc_domain_name": "{{ console_vnc_hostname }}",{{ "\n" }}{% endif %}
+{% if notifyroot_hostname is defined %}  "notifyroot_domain_name": "{{ notifyroot_hostname }}",{{ "\n" }}{% endif %}
   "__terraform_vars_done": true
 }

--- a/terraform/mexplat/dev/main.tf
+++ b/terraform/mexplat/dev/main.tf
@@ -98,6 +98,7 @@ module "console" {
     "jaeger",
     "alt-https",
     "vault-ac",
+    "notifyroot",
     "${module.fw_vault_gcp.target_tag}"
   ]
   labels              = {
@@ -135,6 +136,12 @@ module "console_dns" {
 module "console_vnc_dns" {
   source                        = "../../modules/cloudflare_record"
   hostname                      = "${var.console_vnc_domain_name}"
+  ip                            = "${module.console.external_ip}"
+}
+
+module "notifyroot_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.notifyroot_domain_name}"
   ip                            = "${module.console.external_ip}"
 }
 

--- a/terraform/mexplat/dev/variables.tf
+++ b/terraform/mexplat/dev/variables.tf
@@ -103,6 +103,11 @@ variable "console_vnc_domain_name" {
   type        = "string"
 }
 
+variable "notifyroot_domain_name" {
+  description = "Notifyroot service domain name"
+  type        = "string"
+}
+
 variable "jaeger_domain_name" {
   default     = "jaeger-dev.mobiledgex.net"
 }

--- a/terraform/mexplat/main/main.tf
+++ b/terraform/mexplat/main/main.tf
@@ -104,7 +104,7 @@ module "console" {
   instance_name       = "${var.console_instance_name}"
   zone                = "${var.gcp_zone}"
   boot_disk_size      = 100
-  tags                = [ "http-server", "https-server", "console-debug", "mc" ]
+  tags                = [ "http-server", "https-server", "console-debug", "mc", "notifyroot" ]
   ssh_public_key_file = "${var.ssh_public_key_file}"
 }
 
@@ -117,6 +117,12 @@ module "console_dns" {
 module "console_vnc_dns" {
   source                        = "../../modules/cloudflare_record"
   hostname                      = "${var.console_vnc_domain_name}"
+  ip                            = "${module.console.external_ip}"
+}
+
+module "notifyroot_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.notifyroot_domain_name}"
   ip                            = "${module.console.external_ip}"
 }
 

--- a/terraform/mexplat/main/variables.tf
+++ b/terraform/mexplat/main/variables.tf
@@ -91,6 +91,11 @@ variable "console_vnc_domain_name" {
   type        = "string"
 }
 
+variable "notifyroot_domain_name" {
+  description = "Notifyroot service domain name"
+  type        = "string"
+}
+
 variable "ssh_public_key_file" {
   description = "SSH public key file for the ansible account"
   type        = "string"

--- a/terraform/mexplat/qa/main.tf
+++ b/terraform/mexplat/qa/main.tf
@@ -106,7 +106,7 @@ module "console" {
   instance_size       = "custom-2-9216"
   zone                = "${var.gcp_zone}"
   boot_disk_size      = 100
-  tags                = [ "http-server", "https-server", "console-debug", "mc", "jaeger", "alt-https" ]
+  tags                = [ "http-server", "https-server", "console-debug", "mc", "jaeger", "alt-https", "notifyroot" ]
   ssh_public_key_file = "${var.ssh_public_key_file}"
 }
 
@@ -119,6 +119,12 @@ module "console_dns" {
 module "console_vnc_dns" {
   source                        = "../../modules/cloudflare_record"
   hostname                      = "${var.console_vnc_domain_name}"
+  ip                            = "${module.console.external_ip}"
+}
+
+module "notifyroot_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.notifyroot_domain_name}"
   ip                            = "${module.console.external_ip}"
 }
 

--- a/terraform/mexplat/qa/variables.tf
+++ b/terraform/mexplat/qa/variables.tf
@@ -105,6 +105,11 @@ variable "console_vnc_domain_name" {
   type        = "string"
 }
 
+variable "notifyroot_domain_name" {
+  description = "Notifyroot service domain name"
+  type        = "string"
+}
+
 variable "jaeger_domain_name" {
   default     = "jaeger-qa.mobiledgex.net"
 }

--- a/terraform/mexplat/stage/main.tf
+++ b/terraform/mexplat/stage/main.tf
@@ -105,7 +105,7 @@ module "console" {
   instance_name       = "${var.console_instance_name}"
   zone                = "${var.gcp_zone}"
   boot_disk_size      = 100
-  tags                = [ "http-server", "https-server", "console-debug", "mc", "jaeger", "alt-https" ]
+  tags                = [ "http-server", "https-server", "console-debug", "mc", "jaeger", "alt-https", "notifyroot" ]
   ssh_public_key_file = "${var.ssh_public_key_file}"
 }
 
@@ -118,6 +118,12 @@ module "console_dns" {
 module "console_vnc_dns" {
   source                        = "../../modules/cloudflare_record"
   hostname                      = "${var.console_vnc_domain_name}"
+  ip                            = "${module.console.external_ip}"
+}
+
+module "notifyroot_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.notifyroot_domain_name}"
   ip                            = "${module.console.external_ip}"
 }
 

--- a/terraform/mexplat/stage/variables.tf
+++ b/terraform/mexplat/stage/variables.tf
@@ -113,6 +113,11 @@ variable "console_vnc_domain_name" {
   type        = "string"
 }
 
+variable "notifyroot_domain_name" {
+  description = "Notifyroot service domain name"
+  type        = "string"
+}
+
 variable "jaeger_domain_name" {
   default     = "jaeger-stage.mobiledgex.net"
 }


### PR DESCRIPTION
The notifyroot service currently shares a VM with MC and console.  Eventually, once MC and console are migrated to kubernetes, this will be moved into a separate global kubernetes cluster.

The changes include terraform manifest changes to set up DNS entries for notifyroots pointing to the respective console IPs.