### PR TITLE
EDGECLOUD-2073: Fix MC console proxy issues + websocket proxy support

### DIFF
--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -695,6 +695,8 @@ func (s *Server) setupConsoleProxy(ctx context.Context) {
 			if len(addrObj) == 2 {
 				req.URL.Host = strings.Replace(req.URL.Host, addrObj[1], port, -1)
 			}
+		} else {
+			req.Close = true
 		}
 		if _, ok := req.Header["User-Agent"]; !ok {
 			// explicitly disable User-Agent so it's not set to default value
@@ -720,10 +722,9 @@ func (s *Server) setupConsoleProxy(ctx context.Context) {
 			token := tokenVals[0]
 			expire := time.Now().Add(10 * time.Minute)
 			cookie := http.Cookie{
-				Name:     "mextoken",
-				Value:    tokenVals[0],
-				Expires:  expire,
-				SameSite: http.SameSiteStrictMode,
+				Name:    "mextoken",
+				Value:   tokenVals[0],
+				Expires: expire,
 			}
 			http.SetCookie(w, &cookie)
 			log.SpanLog(ctx, log.DebugLevelInfo, "setup console proxy cookies", "url", r.URL, "token", token)

--- a/mc/ormclient/rest_client.go
+++ b/mc/ormclient/rest_client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/mitchellh/mapstructure"
@@ -364,7 +365,11 @@ func (s *Client) WebsocketConn(uri, token string, reqData interface{}) (*websock
 	var ws *websocket.Conn
 	var err error
 	if strings.HasPrefix(uri, "wss") {
-		d := websocket.Dialer{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		d := websocket.Dialer{
+			Proxy:            http.ProxyFromEnvironment,
+			HandshakeTimeout: 45 * time.Second,
+			TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
+		}
 		ws, _, err = d.Dial(uri, nil)
 	} else {
 		ws, _, err = websocket.DefaultDialer.Dial(uri, nil)


### PR DESCRIPTION
* UI uses IFrame to open VM console URL, but since it is cross-domain request, browser will not pass cookie as part of the request. This is because of the SameSite restriction. Hence, removed it.
* Because cookie was not being set (because of above issue), internal look up for port based on token didn't happen, keeping the port as is. This caused internal loop (see Director function at line 671) causing MC to crash. Added code to close the connection if cookie is not set.
* Added proxy support for WebSocket connection