### PR TITLE
docker LB with floating IP fix

### DIFF
--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -315,11 +315,11 @@ func setupPlatformVM(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig
 	}
 	updateCallback(edgeproto.UpdateTask, "Successfully Deployed Platform VM")
 
-	external_ip, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), platform_vm_name, mexos.ExternalIPType)
+	ip, err := mexos.GetServerIPAddr(ctx, mexos.GetCloudletExternalNetwork(), platform_vm_name)
 	if err != nil {
 		return nil, err
 	}
-	updateCallback(edgeproto.UpdateTask, "Platform VM external IP: "+external_ip)
+	updateCallback(edgeproto.UpdateTask, "Platform VM external IP: "+ip.ExternalAddr)
 
 	client, err := mexos.GetSSHClient(ctx, platform_vm_name, mexos.GetCloudletExternalNetwork(), mexos.SSHUser)
 	if err != nil {
@@ -329,7 +329,7 @@ func setupPlatformVM(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig
 	// setup SSH access to cloudlet for CRM
 	updateCallback(edgeproto.UpdateTask, "Setting up security group for SSH access")
 
-	if err := mexos.AddSecurityRuleCIDR(ctx, external_ip, "tcp", secGrp, "22"); err != nil {
+	if err := mexos.AddSecurityRuleCIDR(ctx, ip.ExternalAddr, "tcp", secGrp, "22"); err != nil {
 		return nil, fmt.Errorf("unable to add security rule for ssh access, err: %v", err)
 	}
 

--- a/mexos/lb.go
+++ b/mexos/lb.go
@@ -347,7 +347,7 @@ func AttachAndEnableRootLBInterface(ctx context.Context, client ssh.Client, root
 	if err != nil {
 		return err
 	}
-	rootLbIp, err := GetServerIPAddr(ctx, GetCloudletExternalNetwork(), rootLBName, InternalIPType)
+	rootLbIp, err := GetServerIPAddr(ctx, GetCloudletExternalNetwork(), rootLBName)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelMexos, "fail to get RootLB IP address", "rootLBName", rootLBName)
 
@@ -358,7 +358,7 @@ func AttachAndEnableRootLBInterface(ctx context.Context, client ssh.Client, root
 		return err
 	}
 
-	err = configureInternalInterfaceAndExternalForwarding(ctx, client, rootLbIp, internalPortName, internalIPAddr, actionAdd)
+	err = configureInternalInterfaceAndExternalForwarding(ctx, client, rootLbIp.InternalAddr, internalPortName, internalIPAddr, actionAdd)
 	if err != nil {
 		deterr := DetachPortFromServer(ctx, rootLBName, internalPortName)
 		if deterr != nil {
@@ -377,7 +377,10 @@ func DetachAndDisableRootLBInterface(ctx context.Context, client ssh.Client, roo
 		// this is unexpected
 		return fmt.Errorf("Cannot find rootLB %s", rootLBName)
 	}
-	err = configureInternalInterfaceAndExternalForwarding(ctx, client, rootLB.IP, internalPortName, internalIPAddr, actionDelete)
+	if rootLB.IP == nil {
+		return fmt.Errorf("rootLB has no IP %s", rootLBName)
+	}
+	err = configureInternalInterfaceAndExternalForwarding(ctx, client, rootLB.IP.ExternalAddr, internalPortName, internalIPAddr, actionDelete)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelMexos, "error in configureInternalInterfaceAndExternalForwarding", "err", err)
 	}

--- a/mexos/rootlb.go
+++ b/mexos/rootlb.go
@@ -20,7 +20,7 @@ import (
 //MEXRootLB has rootLB data
 type MEXRootLB struct {
 	Name string
-	IP   string
+	IP   *ServerIP
 }
 
 var rootLBLock sync.Mutex
@@ -167,12 +167,12 @@ func SetupRootLB(
 		log.SpanLog(ctx, log.DebugLevelMexos, "timeout waiting for agent to run", "name", rootLB.Name)
 		return fmt.Errorf("Error waiting for rootLB %v", err)
 	}
-	extIP, err := GetServerIPAddr(ctx, GetCloudletExternalNetwork(), rootLBName, ExternalIPType)
+	ip, err := GetServerIPAddr(ctx, GetCloudletExternalNetwork(), rootLBName)
 	if err != nil {
 		return fmt.Errorf("cannot get rootLB IP %sv", err)
 	}
-	log.SpanLog(ctx, log.DebugLevelMexos, "set rootLB IP to", "ip", extIP)
-	rootLB.IP = extIP
+	log.SpanLog(ctx, log.DebugLevelMexos, "set rootLB IP to", "ip", ip)
+	rootLB.IP = ip
 
 	client, err := SetupSSHUser(ctx, rootLB, SSHUser)
 	if err != nil {
@@ -188,7 +188,7 @@ func SetupRootLB(
 	if err != nil {
 		return fmt.Errorf("failed to LBAddRouteAndSecRules %v", err)
 	}
-	if err = ActivateFQDNA(ctx, rootLBName, extIP); err != nil {
+	if err = ActivateFQDNA(ctx, rootLBName, ip.ExternalAddr); err != nil {
 		return err
 	}
 	log.SpanLog(ctx, log.DebugLevelMexos, "DNS A record activated", "name", rootLB.Name)


### PR DESCRIPTION
EDGECLOUD-2185:

When creating a load balancer for docker app instances, the proxy listens to the interface that the traffic comes in from and the docker container listens to the docker bridge port.

The proxy listen IP is currently the rootLB IP for docker.  This this fine if the rootLB's IP is the same within the VM as it is externally.  In the floating IP case however, it is not: the IP address that the VM sees internally is different than the external world delivers to -- the latter is a floating IP

The solution is to refactor the code that finds the rootLB's IP and provide both the internal and external side of this interface.   For things like DNS and security group rules the external IP is used.  For listening via the proxy, the internal address needs to be used.  If there is no floating IP, both addresses are the same.