### PR TITLE
EDGECLOUD-2048/2191: Fixes cloudlet upgrade & stales files from VM image download

### DIFF
--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -586,6 +586,10 @@ func (s *Platform) UpdateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 		mexos.RootLBVMDeployment:   rlbClient,
 	}
 	for vmType, client := range upgradeMap {
+		if cloudlet.PackageVersion == "" {
+			// No package upgrade required
+			break
+		}
 		pkgVersion, err := getCRMPkgVersion(ctx, client)
 		if err != nil {
 			return defCloudletAction, err
@@ -601,7 +605,6 @@ func (s *Platform) UpdateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 			updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Failed to upgrade cloudlet packages of vm type %s to version %s, please upgrade them manually!", vmType, cloudlet.PackageVersion))
 			return defCloudletAction, err
 		}
-
 	}
 
 	if containerVersion == cloudlet.ContainerVersion {

--- a/mexos/oscli.go
+++ b/mexos/oscli.go
@@ -682,6 +682,12 @@ func CreateImageFromUrl(ctx context.Context, imageName, imageUrl, md5Sum string)
 		return err
 	}
 	filePath := "/tmp/" + fileExt
+	defer func() {
+		// Stale file might be present if download fails/succeeds, deleting it
+		if delerr := DeleteFile(filePath); delerr != nil {
+			log.SpanLog(ctx, log.DebugLevelMexos, "delete file failed", "filePath", filePath)
+		}
+	}()
 	err = DownloadFile(ctx, imageUrl, filePath)
 	if err != nil {
 		return fmt.Errorf("error downloading image from %s, %v", imageUrl, err)
@@ -699,9 +705,6 @@ func CreateImageFromUrl(ctx context.Context, imageName, imageUrl, md5Sum string)
 	}
 
 	err = CreateImage(ctx, imageName, filePath)
-	if delerr := DeleteFile(filePath); delerr != nil {
-		log.SpanLog(ctx, log.DebugLevelMexos, "delete file failed", "filePath", filePath)
-	}
 	if err != nil {
 		return fmt.Errorf("error creating image %v", err)
 	}


### PR DESCRIPTION
Fixes two issues:
1. On UpdateCloudlet, if packageversion is not specified, then it should not be upgraded. Currently it was upgrading it
2. When a VM image is being deployed for the first time in a cloudlet, the CRM downloads the image and then uploads it to glance.  If a download fails (typically a timeout with a large image), the images are being left behind in /tmp and these fill up space especially fast as the images can be 10-15GB in size