### PR TITLE
Don't normalize the appName for Client metric MC api

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -279,7 +279,7 @@ func ClientMetricsQuery(obj *ormapi.RegionClientMetrics) string {
 	arg := influxQueryArgs{
 		Selector:      getFields(obj.Selector, CLIENT),
 		Measurement:   getMeasurementString(obj.Selector, CLIENT),
-		AppInstName:   k8smgmt.NormalizeName(obj.AppInst.AppKey.Name),
+		AppInstName:   obj.AppInst.AppKey.Name,
 		DeveloperName: obj.AppInst.AppKey.DeveloperKey.Name,
 		CloudletName:  obj.AppInst.ClusterInstKey.CloudletKey.Name,
 		ClusterName:   obj.AppInst.ClusterInstKey.ClusterKey.Name,


### PR DESCRIPTION
dme-api metrics are stored in the influxDB in a regular(not normalized) format. Therefore we should not Normalize the AppName when we call the metrics/client api