### PR TITLE
EDGECLOUD-2235 edgectl ShowNode is not working

### DIFF
--- a/ansible/roles/controller/templates/deploy.yml.j2
+++ b/ansible/roles/controller/templates/deploy.yml.j2
@@ -30,6 +30,8 @@ spec:
          - "0.0.0.0:37001"
          - "--notifyParentAddrs"
          - "{{ console_vm_hostname }}:{{ mc_notify_srv_port }}"
+         - "--notifyRootAddrs"
+         - "{{ notifyroot_hostname }}:{{ notifyroot_port }}"
          - "--etcdUrls"  
          - "{{ etcd_cluster_client }}:2379"
          - "--vaultAddr"

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -27,7 +27,8 @@ vault_github_user_roles:
 
   editor: &github_role_editor
     - *github_role_viewer
-    - approle-accessors.read.v1
+    - approle-accessors.write.v1
+    - auth-approle.write.v1
     - auth-approle.destroy.v1
     - auth-github-config.read.v1
     - certs.read.v1


### PR DESCRIPTION
Add the --notifyRootAddrs param to the controller.
Also fix vault's Github editor role privileges.