### PR TITLE
add second region to e2e tests

### DIFF
--- a/e2e-tests/data/mc_admin_data.yml
+++ b/e2e-tests/data/mc_admin_data.yml
@@ -2,6 +2,9 @@ controllers:
 - region: local
   address: "127.0.0.1:55001"
   influxdb: "http://127.0.0.1:8086"
+- region: locala
+  address: "127.0.0.1:55011"
+  influxdb: "http://127.0.0.1:8087"
 
 orgs:
 - name: enterprise
@@ -104,3 +107,82 @@ regiondata:
       cloudletkey:
         organization: enterprise
         name: enterprise-1
+
+- region: locala
+  appdata:
+    settings:
+      shepherdmetricscollectioninterval: 1s
+      shepherdhealthcheckretries: 3
+      shepherdhealthcheckinterval: 5s
+      autodeployintervalsec: 1
+      autodeployoffsetsec: 0.3
+      autodeploymaxintervals: 10
+      createappinsttimeout: 3s
+      updateappinsttimeout: 2s
+      deleteappinsttimeout: 2s
+      createclusterinsttimeout: 3s
+      updateclusterinsttimeout: 2s
+      deleteclusterinsttimeout: 2s
+      masternodeflavor: x1.tiny
+      loadbalancermaxportrange: 100
+      maxtrackeddmeclients: 100
+    flavors:
+    - key:
+        name: x1.tiny
+      ram: 1024
+      vcpus: 1
+      disk: 1
+    - key:
+        name: x1.small
+      ram: 2048
+      vcpus: 2
+      disk: 2
+    - key:
+        name: x1.medium
+      ram: 4096
+      vcpus: 4
+      disk: 4
+    cloudletinfos:
+    - key:
+        organization: enterprise
+        name: enterprise-2
+      state: CloudletStateReady
+      notifyid: 0
+      controller: MCHU-MAC.local@127.0.0.1:55001
+      osmaxram: 500
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.small
+        vcpus: 10
+        ram: 101024
+        disk: 500
+      status:
+        tasknumber: 3
+        taskname: Gathering Cloudlet Info
+      containerversion: "2019-10-24"
+    cloudlets:
+    - key:
+        organization: enterprise
+        name: enterprise-2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      platformtype: PlatformTypeFake
+      notifysrvaddr: 127.0.0.1:51016
+      flavor:
+        name: x1.small
+      physicalname: enterprise-2
+      containerversion: 2019-10-24
+      state: Ready
+    cloudletpools:
+    - key:
+        name: enterprise-pool
+    cloudletpoolmembers:
+    - poolkey:
+        name: enterprise-pool
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-2

--- a/e2e-tests/data/mc_enabledebug_output.yml
+++ b/e2e-tests/data/mc_enabledebug_output.yml
@@ -17,6 +17,14 @@ requests:
       region: local
     output: etcd,api,notify,metrics,upgrade
   - node:
+      type: controller
+      region: locala
+    output: etcd,api,notify,metrics,upgrade
+  - node:
+      type: controller
+      region: locala
+    output: etcd,api,notify,metrics,upgrade
+  - node:
       type: dme
       region: local
       cloudletkey:
@@ -29,6 +37,20 @@ requests:
       cloudletkey:
         organization: tmus
         name: tmus-cloud-2
+    output: etcd,notify,dmedb,dmereq,locapi,metrics,sampled
+  - node:
+      type: dme
+      region: locala
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-3
+    output: etcd,notify,dmedb,dmereq,locapi,metrics,sampled
+  - node:
+      type: dme
+      region: locala
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-4
     output: etcd,notify,dmedb,dmereq,locapi,metrics,sampled
   - node:
       type: crm
@@ -66,16 +88,49 @@ requests:
         name: gcp-cloud-5
     output: api,notify,mexos,metrics,upgrade,info,sampled
   - node:
+      type: crm
+      region: locala
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-2
+    output: api,notify,mexos,metrics,upgrade,info,sampled
+  - node:
+      type: crm
+      region: locala
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-3
+    output: api,notify,mexos,metrics,upgrade,info,sampled
+  - node:
+      type: crm
+      region: locala
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-4
+    output: api,notify,mexos,metrics,upgrade,info,sampled
+  - node:
       type: cluster-svc
       region: local
     output: etcd,api,notify,mexos,metrics
   - node:
       type: cluster-svc
       region: local
+    output: etcd,api,notify,mexos,metrics
+  - node:
+      type: cluster-svc
+      region: locala
+    output: etcd,api,notify,mexos,metrics
+  - node:
+      type: cluster-svc
+      region: locala
     output: etcd,api,notify,mexos,metrics
   - node:
       type: autoprov
       region: local
+    output: api,notify,metrics,sampled
+  - node:
+      type: autoprov
+      region: locala
     output: api,notify,metrics,sampled
   - node:
       type: shepherd
@@ -83,4 +138,11 @@ requests:
         organization: tmus
         name: tmus-cloud-1
       region: local
+    output: api,notify,mexos,metrics,info,sampled
+  - node:
+      type: shepherd
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-3
+      region: locala
     output: api,notify,mexos,metrics,info,sampled

--- a/e2e-tests/data/mc_flavors.yml
+++ b/e2e-tests/data/mc_flavors.yml
@@ -2,6 +2,9 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
+- region: locala
+  address: 127.0.0.1:55011
+  influxdb: http://127.0.0.1:8087
 regiondata:
 - region: local
   appdata:
@@ -21,3 +24,21 @@ regiondata:
       ram: 2048
       vcpus: 2
       disk: 2
+- region: locala
+  appdata:
+    flavors:
+    - key:
+        name: x1.tiny
+      ram: 1024
+      vcpus: 1
+      disk: 1
+    - key:
+        name: x1.small
+      ram: 2048
+      vcpus: 2
+      disk: 2
+    - key:
+        name: x1.medium
+      ram: 4096
+      vcpus: 4
+      disk: 4

--- a/e2e-tests/data/mc_orgsinuse_error.yml
+++ b/e2e-tests/data/mc_orgsinuse_error.yml
@@ -1,16 +1,16 @@
 errors:
 - desc: DeleteOrg[0]
   status: 400
-  err: 'Organization tmus in use or check failed: region local: in use by some AppInst, Cloudlet, ClusterInst, OperatorCode'
+  err: 'Organization tmus in use or check failed: region local: in use by some AppInst, Cloudlet, ClusterInst, OperatorCode; region locala: in use by some AppInst, Cloudlet, ClusterInst, OperatorCode'
 - desc: DeleteOrg[1]
   status: 400
-  err: 'Organization AcmeAppCo in use or check failed: region local: in use by some App, AppInst, AutoProvPolicy, AutoScalePolicy, ClusterInst'
+  err: 'Organization AcmeAppCo in use or check failed: region local: in use by some App, AppInst, AutoProvPolicy, AutoScalePolicy, ClusterInst; region locala: in use by some App, AppInst, AutoProvPolicy, AutoScalePolicy, ClusterInst'
 - desc: DeleteOrg[2]
   status: 400
-  err: 'Organization enterprise in use or check failed: region local: in use by some App, AppInst, Cloudlet, ClusterInst'
+  err: 'Organization enterprise in use or check failed: region local: in use by some App, AppInst, Cloudlet, ClusterInst; region locala: in use by some Cloudlet'
 - desc: DeleteOrg[3]
   status: 400
-  err: 'Organization MobiledgeX in use or check failed: region local: in use by some App, AppInst, ClusterInst'
+  err: 'Organization MobiledgeX in use or check failed: region local: in use by some App, AppInst, ClusterInst; region locala: in use by some App, AppInst'
 - desc: DeleteOrg[4]
   status: 400
   err: 'Organization azure in use or check failed: region local: in use by some Cloudlet'
@@ -19,4 +19,4 @@ errors:
   err: 'Organization gcp in use or check failed: region local: in use by some Cloudlet'
 - desc: DeleteOrg[6]
   status: 400
-  err: 'Organization Samsung in use or check failed: region local: in use by some App'
+  err: 'Organization Samsung in use or check failed: region local: in use by some App; region locala: in use by some App'

--- a/e2e-tests/data/mc_showaudit_admin.yml
+++ b/e2e-tests/data/mc_showaudit_admin.yml
@@ -65,6 +65,15 @@
   username: mexadmin
   clientip: 127.0.0.1
   status: 200
+  starttime: "2020-03-18T13:52:16.890688-07:00"
+  duration: 1.574ms
+  request: '{"Region":"locala","Address":"127.0.0.1:55011","InfluxDB":"http://127.0.0.1:8087","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
+  response: '{"message":"Controller deregistered"}'
+  traceid: 1413d0f02192c9e4
+- operationname: /api/v1/auth/controller/delete
+  username: mexadmin
+  clientip: 127.0.0.1
+  status: 200
   starttime: "2019-09-26T15:31:34.960139-07:00"
   duration: 1.48ms
   request: '{"Region":"local","Address":"127.0.0.1:55001","InfluxDB":"http://127.0.0.1:8086","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
@@ -79,12 +88,3 @@
   request: '{"org":"enterprise","username":"user3","role":"DeveloperManager"}'
   response: '{"message":"Role removed from user"}'
   traceid: 1c1aff34d0d8f0a9
-- operationname: /api/v1/auth/org/delete
-  username: mexadmin
-  clientip: 127.0.0.1
-  status: 200
-  starttime: "2019-11-05T17:06:33.229084-08:00"
-  duration: 7.6ms
-  request: '{"Name":"MobiledgeX","Type":"developer","Address":"mobiledgex","Phone":"123-123-1234","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
-  response: '{"message":"Organization deleted"}'
-  traceid: 384d9326d52eefe9

--- a/e2e-tests/data/mc_showaudit_all.yml
+++ b/e2e-tests/data/mc_showaudit_all.yml
@@ -85,6 +85,6 @@
   status: 200
   starttime: "2019-09-26T15:30:00.278638-07:00"
   duration: 1.413ms
-  request: '{"Region":"local","Address":"127.0.0.1:55001","InfluxDB":"http://127.0.0.1:8086","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
+  request: '{"Region":"locala","Address":"127.0.0.1:55011","InfluxDB":"http://127.0.0.1:8087","CreatedAt":"0001-01-01T00:00:00Z","UpdatedAt":"0001-01-01T00:00:00Z"}'
   response: '{"message":"Controller deregistered"}'
   traceid: 7e61d350f6c309c3

--- a/e2e-tests/data/mc_showaudit_org.yml
+++ b/e2e-tests/data/mc_showaudit_org.yml
@@ -14,7 +14,7 @@
   status: 200
   starttime: "2019-12-18T13:36:59.484291-08:00"
   duration: 18.885ms
-  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}]}}'
+  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}]}}'
   response: '{}'
   traceid: 7d0896601b1411aa
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy
@@ -23,7 +23,7 @@
   status: 200
   starttime: "2019-10-23T17:28:29.223902-07:00"
   duration: 18.577ms
-  request: '{"Region":"local","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
+  request: '{"Region":"locala","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
   response: '{}'
   traceid: 1e71004f9d5966b1
 - operationname: /api/v1/auth/ctrl/DeleteClusterInst
@@ -32,7 +32,7 @@
   status: 200
   starttime: "2019-08-10T16:04:18.731179-07:00"
   duration: 83.626ms
-  request: '{"Region":"local","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":3,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{}}}'
+  request: '{"Region":"locala","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":3,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{}}}'
   response: |
     {"data":{"message":"Autodeleting AppInst MEXPrometheusAppName"}}
     {"data":{"message":"Deleting"}}
@@ -48,7 +48,7 @@
   status: 200
   starttime: "2019-08-10T16:04:18.643366-07:00"
   duration: 82.835ms
-  request: '{"Region":"local","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":1,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{},"auto_scale_policy":"scale1"}}'
+  request: '{"Region":"locala","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-3"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":1,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{},"auto_scale_policy":"scale1"}}'
   response: |
     {"data":{"message":"Autodeleting AppInst MEXPrometheusAppName"}}
     {"data":{"message":"Deleting"}}
@@ -64,7 +64,7 @@
   status: 200
   starttime: "2019-12-18T13:36:59.224084-08:00"
   duration: 19.191ms
-  request: '{"Region":"local","App":{"key":{"organization":"AcmeAppCo","name":"autoprovapp","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:81","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","auto_prov_policy":"autoprov1"}}'
+  request: '{"Region":"locala","App":{"key":{"organization":"AcmeAppCo","name":"autoprovapp","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:81","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","auto_prov_policy":"autoprov1"}}'
   response: '{}'
   traceid: 55f7274f5eddb00b
 - operationname: /api/v1/auth/ctrl/DeleteApp
@@ -73,7 +73,7 @@
   status: 200
   starttime: "2019-08-10T16:04:18.59613-07:00"
   duration: 20.296ms
-  request: '{"Region":"local","App":{"key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:80,http:443,udp:10002","default_flavor":{"name":"x1.small"},"auth_public_key":"-----BEGIN
+  request: '{"Region":"locala","App":{"key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:80,http:443,udp:10002","default_flavor":{"name":"x1.small"},"auth_public_key":"-----BEGIN
     PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij\nTkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0\nVU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC\nGJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS\nz3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m\nQnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C\n/QIDAQAB\n-----END
     PUBLIC KEY-----\n","deployment":"kubernetes","android_package_name":"com.acme.someapplication1"}}'
   response: '{}'
@@ -84,7 +84,7 @@
   status: 200
   starttime: "2019-08-10T16:04:18.551272-07:00"
   duration: 41.518ms
-  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
   response: |
     {"data":{"message":"Deleting"}}
     {"data":{"message":"NotPresent"}}
@@ -96,21 +96,18 @@
   status: 200
   starttime: "2019-08-10T16:04:18.492601-07:00"
   duration: 55.309ms
-  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-3"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
   response: |
     {"data":{"message":"Deleting"}}
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted AppInst successfully"}}
   traceid: 16280f277fec9a7a
-- operationname: /api/v1/auth/ctrl/DeleteAppInst
+- operationname: /api/v1/auth/ctrl/DeleteAutoProvPolicy
   username: user2
   clientip: 127.0.0.1
   status: 200
-  starttime: "2019-12-18T13:36:58.791711-08:00"
-  duration: 65.903ms
-  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"autoprovapp","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"Reservable1"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"MobiledgeX"}},"cloudlet_loc":{},"mapped_ports":null,"flavor":{},"runtime_info":{},"created_at":{},"status":{}}}'
-  response: |
-    {"data":{"message":"Deleting"}}
-    {"data":{"message":"NotPresent"}}
-    {"data":{"message":"Deleted AppInst successfully"}}
-  traceid: 4dbca5d8d3be6f8e
+  starttime: "2020-03-18T11:41:44.411308-07:00"
+  duration: 14.622ms
+  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}]}}'
+  response: '{}'
+  traceid: 73cbbf9e2299ef79

--- a/e2e-tests/data/mc_showaudit_user2.yml
+++ b/e2e-tests/data/mc_showaudit_user2.yml
@@ -20,6 +20,15 @@
   username: user2
   clientip: 127.0.0.1
   status: 403
+  starttime: "2020-03-18T14:06:20.216288-07:00"
+  duration: 671µs
+  request: '{"Region":"locala","Settings":{}}'
+  response: '{"message":"code=403, message=Forbidden"}'
+  traceid: 33f2e0e8baa458b5
+- operationname: /api/v1/auth/ctrl/ShowSettings
+  username: user2
+  clientip: 127.0.0.1
+  status: 403
   starttime: "2020-01-16T16:24:05.019808-08:00"
   duration: 578µs
   request: '{"Region":"local","Settings":{}}'
@@ -60,7 +69,7 @@
   status: 200
   starttime: "2019-12-18T13:42:42.48365-08:00"
   duration: 18.759ms
-  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}]}}'
+  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}]}}'
   response: '{}'
   traceid: 7af113ec2d0b698c
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy
@@ -69,7 +78,7 @@
   status: 200
   starttime: "2019-10-23T17:33:40.487278-07:00"
   duration: 14.316ms
-  request: '{"Region":"local","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
+  request: '{"Region":"locala","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
   response: '{}'
   traceid: 382475ae5bd5fddb
 - operationname: /api/v1/auth/ctrl/DeleteClusterInst
@@ -78,7 +87,7 @@
   status: 200
   starttime: "2019-08-11T09:36:02.782934-07:00"
   duration: 114.968ms
-  request: '{"Region":"local","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":3,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{}}}'
+  request: '{"Region":"locala","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":3,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{}}}'
   response: |
     {"data":{"message":"Autodeleting AppInst MEXPrometheusAppName"}}
     {"data":{"message":"Deleting"}}
@@ -88,19 +97,3 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted ClusterInst successfully"}}
   traceid: 35078d27e23052f5
-- operationname: /api/v1/auth/ctrl/DeleteClusterInst
-  username: user2
-  clientip: 127.0.0.1
-  status: 200
-  starttime: "2019-08-11T09:36:02.685286-07:00"
-  duration: 93.375ms
-  request: '{"Region":"local","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":1,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{},"auto_scale_policy":"scale1"}}'
-  response: |
-    {"data":{"message":"Autodeleting AppInst MEXPrometheusAppName"}}
-    {"data":{"message":"Deleting"}}
-    {"data":{"message":"NotPresent"}}
-    {"data":{"message":"Deleted AppInst successfully"}}
-    {"data":{"message":"Deleting"}}
-    {"data":{"message":"NotPresent"}}
-    {"data":{"message":"Deleted ClusterInst successfully"}}
-  traceid: 79331c0ec70fb2d6

--- a/e2e-tests/data/mc_showaudit_user2org.yml
+++ b/e2e-tests/data/mc_showaudit_user2org.yml
@@ -14,7 +14,7 @@
   status: 200
   starttime: "2019-12-18T13:44:44.543446-08:00"
   duration: 16.81ms
-  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}]}}'
+  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}]}}'
   response: '{}'
   traceid: 1b1f287407047931
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy
@@ -23,7 +23,7 @@
   status: 200
   starttime: "2019-10-23T17:37:07.310346-07:00"
   duration: 14.924ms
-  request: '{"Region":"local","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
+  request: '{"Region":"locala","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
   response: '{}'
   traceid: 4e507c541c45009a
 - operationname: /api/v1/auth/ctrl/DeleteClusterInst
@@ -32,7 +32,7 @@
   status: 200
   starttime: "2019-08-10T16:13:42.071157-07:00"
   duration: 98.232ms
-  request: '{"Region":"local","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":3,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{}}}'
+  request: '{"Region":"locala","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":3,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{}}}'
   response: |
     {"data":{"message":"Autodeleting AppInst MEXPrometheusAppName"}}
     {"data":{"message":"Deleting"}}
@@ -48,7 +48,7 @@
   status: 200
   starttime: "2019-08-10T16:13:41.979993-07:00"
   duration: 87.801ms
-  request: '{"Region":"local","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":1,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{},"auto_scale_policy":"scale1"}}'
+  request: '{"Region":"locala","ClusterInst":{"key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-3"},"organization":"AcmeAppCo"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":1,"node_flavor":"x1.small","num_masters":1,"num_nodes":1,"status":{},"auto_scale_policy":"scale1"}}'
   response: |
     {"data":{"message":"Autodeleting AppInst MEXPrometheusAppName"}}
     {"data":{"message":"Deleting"}}
@@ -64,7 +64,7 @@
   status: 200
   starttime: "2019-12-18T13:44:44.285586-08:00"
   duration: 17.826ms
-  request: '{"Region":"local","App":{"key":{"organization":"AcmeAppCo","name":"autoprovapp","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:81","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","auto_prov_policy":"autoprov1"}}'
+  request: '{"Region":"locala","App":{"key":{"organization":"AcmeAppCo","name":"autoprovapp","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:81","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","auto_prov_policy":"autoprov1"}}'
   response: '{}'
   traceid: 38d6124bc329b12
 - operationname: /api/v1/auth/ctrl/DeleteApp
@@ -73,7 +73,7 @@
   status: 200
   starttime: "2019-08-10T16:13:41.93511-07:00"
   duration: 19.104ms
-  request: '{"Region":"local","App":{"key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:80,http:443,udp:10002","default_flavor":{"name":"x1.small"},"auth_public_key":"-----BEGIN
+  request: '{"Region":"locala","App":{"key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:80,http:443,udp:10002","default_flavor":{"name":"x1.small"},"auth_public_key":"-----BEGIN
     PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij\nTkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0\nVU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC\nGJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS\nz3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m\nQnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C\n/QIDAQAB\n-----END
     PUBLIC KEY-----\n","deployment":"kubernetes","android_package_name":"com.acme.someapplication1"}}'
   response: '{}'
@@ -84,7 +84,7 @@
   status: 200
   starttime: "2019-08-10T16:13:41.888583-07:00"
   duration: 42.802ms
-  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
   response: |
     {"data":{"message":"Deleting"}}
     {"data":{"message":"NotPresent"}}
@@ -96,21 +96,18 @@
   status: 200
   starttime: "2019-08-10T16:13:41.844651-07:00"
   duration: 40.222ms
-  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-3"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
   response: |
     {"data":{"message":"Deleting"}}
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted AppInst successfully"}}
   traceid: 4242788f1d2a702f
-- operationname: /api/v1/auth/ctrl/DeleteAppInst
+- operationname: /api/v1/auth/ctrl/DeleteAutoProvPolicy
   username: user2
   clientip: 127.0.0.1
   status: 200
-  starttime: "2019-12-18T13:44:43.822848-08:00"
-  duration: 66.315ms
-  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"autoprovapp","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"Reservable1"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"MobiledgeX"}},"cloudlet_loc":{},"mapped_ports":null,"flavor":{},"runtime_info":{},"created_at":{},"status":{}}}'
-  response: |
-    {"data":{"message":"Deleting"}}
-    {"data":{"message":"NotPresent"}}
-    {"data":{"message":"Deleted AppInst successfully"}}
-  traceid: 67db76c01ae25287
+  starttime: "2020-03-18T14:19:48.41892-07:00"
+  duration: 13.994ms
+  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}]}}'
+  response: '{}'
+  traceid: 1bf7b6b1f18e9fe3

--- a/e2e-tests/data/mc_showdebug_output.yml
+++ b/e2e-tests/data/mc_showdebug_output.yml
@@ -17,6 +17,14 @@ requests:
       region: local
     output: etcd,api,notify,metrics
   - node:
+      type: controller
+      region: locala
+    output: etcd,api,notify,metrics
+  - node:
+      type: controller
+      region: locala
+    output: etcd,api,notify,metrics
+  - node:
       type: dme
       region: local
       cloudletkey:
@@ -29,6 +37,20 @@ requests:
       cloudletkey:
         organization: tmus
         name: tmus-cloud-2
+    output: notify,dmedb,dmereq,locapi,metrics
+  - node:
+      type: dme
+      region: locala
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-3
+    output: notify,dmedb,dmereq,locapi,metrics
+  - node:
+      type: dme
+      region: locala
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-4
     output: notify,dmedb,dmereq,locapi,metrics
   - node:
       type: crm
@@ -66,16 +88,49 @@ requests:
         name: gcp-cloud-5
     output: api,notify,mexos,info
   - node:
+      type: crm
+      region: locala
+      cloudletkey:
+        organization: enterprise
+        name: enterprise-2
+    output: api,notify,mexos,info
+  - node:
+      type: crm
+      region: locala
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-3
+    output: api,notify,mexos,info
+  - node:
+      type: crm
+      region: locala
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-4
+    output: api,notify,mexos,info
+  - node:
       type: cluster-svc
       region: local
     output: api,notify,mexos
   - node:
       type: cluster-svc
       region: local
+    output: api,notify,mexos
+  - node:
+      type: cluster-svc
+      region: locala
+    output: api,notify,mexos
+  - node:
+      type: cluster-svc
+      region: locala
     output: api,notify,mexos
   - node:
       type: autoprov
       region: local
+    output: api,notify,metrics
+  - node:
+      type: autoprov
+      region: locala
     output: api,notify,metrics
   - node:
       type: shepherd
@@ -83,4 +138,11 @@ requests:
         organization: tmus
         name: tmus-cloud-1
       region: local
+    output: api,notify,mexos,metrics
+  - node:
+      type: shepherd
+      cloudletkey:
+        organization: tmus
+        name: tmus-cloud-3
+      region: locala
     output: api,notify,mexos,metrics

--- a/e2e-tests/data/mc_user1_data.yml
+++ b/e2e-tests/data/mc_user1_data.yml
@@ -66,3 +66,31 @@ regiondata:
     operatorcodes:
     - code: 31026
       organization: tmus
+- region: locala
+  appdata:
+    cloudlets:
+    - key:
+        organization: tmus
+        name: tmus-cloud-3
+      accessuri: cloud1.tmo
+      location:
+        latitude: 32
+        longitude: -92
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      platformtype: PlatformTypeFakeinfra
+      notifysrvaddr: 127.0.0.1:51017
+    - key:
+        organization: tmus
+        name: tmus-cloud-4
+      accessuri: cloud2.tmo
+      location:
+        latitude: 36
+        longitude: -96
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      platformtype: PlatformTypeFake
+      notifysrvaddr: 127.0.0.1:51018
+    operatorcodes:
+    - code: 31026
+      organization: tmus

--- a/e2e-tests/data/mc_user1_data_show.yml
+++ b/e2e-tests/data/mc_user1_data_show.yml
@@ -2,6 +2,9 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
+- region: locala
+  address: 127.0.0.1:55011
+  influxdb: http://127.0.0.1:8087
 orgs:
 - name: tmus
   type: operator
@@ -173,3 +176,91 @@ regiondata:
     operatorcodes:
     - code: 31026
       organization: tmus
+- region: locala
+  appdata:
+    flavors:
+    - key:
+        name: x1.tiny
+      ram: 1024
+      vcpus: 1
+      disk: 1
+    - key:
+        name: x1.small
+      ram: 2048
+      vcpus: 2
+      disk: 2
+    - key:
+        name: x1.medium
+      ram: 4096
+      vcpus: 4
+      disk: 4
+    operatorcodes:
+    - code: "31026"
+      organization: tmus
+    cloudlets:
+    - key:
+        organization: tmus
+        name: tmus-cloud-3
+      location:
+        latitude: 32
+        longitude: -92
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      platformtype: PlatformTypeFakeinfra
+      notifysrvaddr: 127.0.0.1:51017
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-3
+      containerversion: "2019-10-24"
+    - key:
+        organization: tmus
+        name: tmus-cloud-4
+      location:
+        latitude: 36
+        longitude: -96
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      notifysrvaddr: 127.0.0.1:51018
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-4
+      containerversion: "2019-10-24"
+    cloudletinfos:
+    - key:
+        organization: tmus
+        name: tmus-cloud-3
+      state: CloudletStateReady
+      notifyid: 2
+      controller: Jon-Mex@127.0.0.1:55011
+      osmaxram: 500
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.small
+        vcpus: 10
+        ram: 101024
+        disk: 500
+      status:
+        tasknumber: 3
+        taskname: Gathering Cloudlet Info
+      containerversion: "2019-10-24"
+    - key:
+        organization: tmus
+        name: tmus-cloud-4
+      state: CloudletStateReady
+      notifyid: 3
+      controller: Jon-Mex@127.0.0.1:55011
+      osmaxram: 500
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.small
+        vcpus: 10
+        ram: 101024
+        disk: 500
+      status:
+        tasknumber: 3
+        taskname: Gathering Cloudlet Info
+      containerversion: "2019-10-24"

--- a/e2e-tests/data/mc_user1_data_upgrade_show.yml
+++ b/e2e-tests/data/mc_user1_data_upgrade_show.yml
@@ -2,6 +2,9 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
+- region: locala
+  address: 127.0.0.1:55011
+  influxdb: http://127.0.0.1:8087
 orgs:
 - name: tmus
   type: operator
@@ -173,3 +176,91 @@ regiondata:
     operatorcodes:
     - code: 31026
       organization: tmus
+- region: locala
+  appdata:
+    flavors:
+    - key:
+        name: x1.tiny
+      ram: 1024
+      vcpus: 1
+      disk: 1
+    - key:
+        name: x1.small
+      ram: 2048
+      vcpus: 2
+      disk: 2
+    - key:
+        name: x1.medium
+      ram: 4096
+      vcpus: 4
+      disk: 4
+    operatorcodes:
+    - code: "31026"
+      organization: tmus
+    cloudlets:
+    - key:
+        organization: tmus
+        name: tmus-cloud-3
+      location:
+        latitude: 32
+        longitude: -92
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      platformtype: PlatformTypeFakeinfra
+      notifysrvaddr: 127.0.0.1:51017
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-3
+      containerversion: "2019-10-24"
+    - key:
+        organization: tmus
+        name: tmus-cloud-4
+      location:
+        latitude: 36
+        longitude: -96
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      notifysrvaddr: 127.0.0.1:51018
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-4
+      containerversion: "2019-10-24"
+    cloudletinfos:
+    - key:
+        organization: tmus
+        name: tmus-cloud-3
+      state: CloudletStateReady
+      notifyid: 4
+      controller: Jon-Mex@127.0.0.1:55011
+      osmaxram: 500
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.small
+        vcpus: 10
+        ram: 101024
+        disk: 500
+      status:
+        tasknumber: 3
+        taskname: Gathering Cloudlet Info
+      containerversion: "2019-10-24"
+    - key:
+        organization: tmus
+        name: tmus-cloud-4
+      state: CloudletStateReady
+      notifyid: 5
+      controller: Jon-Mex@127.0.0.1:55011
+      osmaxram: 500
+      osmaxvcores: 50
+      osmaxvolgb: 5000
+      flavors:
+      - name: x1.small
+        vcpus: 10
+        ram: 101024
+        disk: 500
+      status:
+        tasknumber: 3
+        taskname: Gathering Cloudlet Info
+      containerversion: "2019-10-24"

--- a/e2e-tests/data/mc_user2_data.yml
+++ b/e2e-tests/data/mc_user2_data.yml
@@ -147,3 +147,140 @@ regiondata:
       - key:
           organization: tmus
           name: tmus-cloud-2
+
+- region: locala
+  appdata:
+    clusterinsts:
+    - key:
+        clusterkey:
+          name: SmallCluster
+        cloudletkey:
+          organization: tmus
+          name: tmus-cloud-3
+        organization: AcmeAppCo
+      flavor:
+        name: x1.small
+      liveness: LivenessStatic
+      ipaccess: IpAccessDedicated
+      nodeflavor: x1.small
+      masterflavor: x1.small
+      nummasters: 1
+      numnodes: 1
+      autoscalepolicy: scale1
+    - key:
+        clusterkey:
+          name: SmallCluster
+        cloudletkey:
+          organization: tmus
+          name: tmus-cloud-4
+        organization: AcmeAppCo
+      flavor:
+        name: x1.small
+      liveness: LivenessStatic
+      ipaccess: IpAccessShared
+      nodeflavor: x1.small
+      masterflavor: x1.small
+      nummasters: 1
+      numnodes: 1
+
+    apps:
+    - key:
+        organization: AcmeAppCo
+        name: someapplication1
+        version: "1.0"
+      imagepath: registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0
+      imagetype: ImageTypeDocker
+      deployment: "kubernetes"
+      defaultflavor:
+        name: x1.small
+      cluster:
+        name: SmallCluster
+      accessports: "tcp:80,http:443,udp:10002"
+      androidpackagename: com.acme.someapplication1
+      permitsplatformapps: true
+      authpublickey: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij\nTkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0\nVU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC\nGJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS\nz3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m\nQnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C\n/QIDAQAB\n-----END PUBLIC KEY-----\n"
+    - key:
+        organization: AcmeAppCo
+        name: autoprovapp
+        version: "1.0"
+      imagepath: registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0
+      imagetype: ImageTypeDocker
+      deployment: "kubernetes"
+      defaultflavor:
+        name: x1.small
+      accessports: "tcp:81"
+      autoprovpolicy: autoprov1
+    - key:
+        organization: Samsung
+        name: SamsungEnablingLayer
+        version: "1.0"
+      imagepath: registry.mobiledgex.net/Samsung/dummyvalue
+      imagetype: ImageTypeDocker
+      deployment: "kubernetes"
+      defaultflavor:
+        name: x1.small
+      cluster:
+        name: SmallCluster
+      accessports: "tcp:64000"
+
+    appinstances:
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: someapplication1
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: SmallCluster
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-3
+          organization: AcmeAppCo
+      cloudletloc:
+        latitude: 31
+        longitude: -91
+      liveness: LivenessStatic
+      flavor:
+        name: x1.small
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: someapplication1
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: SmallCluster
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-4
+          organization: AcmeAppCo
+      cloudletloc:
+        latitude: 35
+        longitude: -95
+      liveness: LivenessStatic
+      flavor:
+        name: x1.small
+
+    autoscalepolicies:
+    - key:
+        organization: AcmeAppCo
+        name: scale1
+      minnodes: 1
+      maxnodes: 3
+      scaleupcputhresh: 85
+      scaledowncputhresh: 20
+      triggertimesec: 60
+
+    autoprovpolicies:
+    - key:
+        name: autoprov1
+        organization: AcmeAppCo
+      deployclientcount: 3
+      deployintervalcount: 3
+      cloudlets:
+      - key:
+          organization: tmus
+          name: tmus-cloud-3
+      - key:
+          organization: tmus
+          name: tmus-cloud-4

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -2,6 +2,9 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
+- region: locala
+  address: 127.0.0.1:55011
+  influxdb: http://127.0.0.1:8087
 orgs:
 - name: AcmeAppCo
   type: developer
@@ -437,3 +440,389 @@ regiondata:
         loc:
           latitude: 35
           longitude: -95
+- region: locala
+  appdata:
+    flavors:
+    - key:
+        name: x1.tiny
+      ram: 1024
+      vcpus: 1
+      disk: 1
+    - key:
+        name: x1.small
+      ram: 2048
+      vcpus: 2
+      disk: 2
+    - key:
+        name: x1.medium
+      ram: 4096
+      vcpus: 4
+      disk: 4
+    cloudlets:
+    - key:
+        organization: tmus
+        name: tmus-cloud-3
+      location:
+        latitude: 32
+        longitude: -92
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      platformtype: PlatformTypeFakeinfra
+      notifysrvaddr: 127.0.0.1:51017
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-3
+      containerversion: "2019-10-24"
+    - key:
+        organization: tmus
+        name: tmus-cloud-4
+      location:
+        latitude: 36
+        longitude: -96
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      notifysrvaddr: 127.0.0.1:51018
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-4
+      containerversion: "2019-10-24"
+    autoprovpolicies:
+    - key:
+        organization: AcmeAppCo
+        name: autoprov1
+      deployclientcount: 3
+      deployintervalcount: 3
+      cloudlets:
+      - key:
+          organization: tmus
+          name: tmus-cloud-3
+        loc:
+          latitude: 32
+          longitude: -92
+      - key:
+          organization: tmus
+          name: tmus-cloud-4
+        loc:
+          latitude: 36
+          longitude: -96
+    autoscalepolicies:
+    - key:
+        organization: AcmeAppCo
+        name: scale1
+      minnodes: 1
+      maxnodes: 3
+      scaleupcputhresh: 85
+      scaledowncputhresh: 20
+      triggertimesec: 60
+    clusterinsts:
+    - key:
+        clusterkey:
+          name: SmallCluster
+        cloudletkey:
+          organization: tmus
+          name: tmus-cloud-3
+        organization: AcmeAppCo
+      flavor:
+        name: x1.small
+      liveness: LivenessStatic
+      state: Ready
+      ipaccess: IpAccessDedicated
+      allocatedip: dynamic
+      nodeflavor: x1.small
+      deployment: kubernetes
+      nummasters: 1
+      numnodes: 1
+      autoscalepolicy: scale1
+      masternodeflavor: x1.small
+    - key:
+        clusterkey:
+          name: SmallCluster
+        cloudletkey:
+          organization: tmus
+          name: tmus-cloud-4
+        organization: AcmeAppCo
+      flavor:
+        name: x1.small
+      liveness: LivenessStatic
+      state: Ready
+      ipaccess: IpAccessShared
+      nodeflavor: x1.small
+      deployment: kubernetes
+      nummasters: 1
+      numnodes: 1
+      masternodeflavor: x1.small
+    apps:
+    - key:
+        organization: AcmeAppCo
+        name: autoprovapp
+        version: "1.0"
+      imagepath: registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0
+      imagetype: ImageTypeDocker
+      accessports: tcp:81
+      defaultflavor:
+        name: x1.small
+      deployment: kubernetes
+      deploymentmanifest: |
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: autoprovapp-tcp
+          labels:
+            run: autoprovapp
+        spec:
+          type: LoadBalancer
+          ports:
+          - name: tcp81
+            protocol: TCP
+            port: 81
+            targetPort: 81
+          selector:
+            run: autoprovapp
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: autoprovapp-deployment
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              run: autoprovapp
+          template:
+            metadata:
+              labels:
+                run: autoprovapp
+            spec:
+              volumes:
+              imagePullSecrets:
+              - name: registry.mobiledgex.net
+              containers:
+              - name: autoprovapp
+                image: registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0
+                imagePullPolicy: Always
+                ports:
+                - containerPort: 81
+                  protocol: TCP
+      deploymentgenerator: kubernetes-basic
+      autoprovpolicy: autoprov1
+      accesstype: AccessTypeLoadBalancer
+    - key:
+        organization: Samsung
+        name: SamsungEnablingLayer
+        version: "1.0"
+      imagepath: registry.mobiledgex.net/Samsung/dummyvalue
+      imagetype: ImageTypeDocker
+      accessports: tcp:64000
+      defaultflavor:
+        name: x1.small
+      deployment: kubernetes
+      deploymentmanifest: |
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: samsungenablinglayer-tcp
+          labels:
+            run: samsungenablinglayer
+        spec:
+          type: LoadBalancer
+          ports:
+          - name: tcp64000
+            protocol: TCP
+            port: 64000
+            targetPort: 64000
+          selector:
+            run: samsungenablinglayer
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: samsungenablinglayer-deployment
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              run: samsungenablinglayer
+          template:
+            metadata:
+              labels:
+                run: samsungenablinglayer
+            spec:
+              volumes:
+              imagePullSecrets:
+              - name: registry.mobiledgex.net
+              containers:
+              - name: samsungenablinglayer
+                image: registry.mobiledgex.net/Samsung/dummyvalue
+                imagePullPolicy: Always
+                ports:
+                - containerPort: 64000
+                  protocol: TCP
+      deploymentgenerator: kubernetes-basic
+      accesstype: AccessTypeLoadBalancer
+    - key:
+        organization: AcmeAppCo
+        name: someapplication1
+        version: "1.0"
+      imagepath: registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0
+      imagetype: ImageTypeDocker
+      accessports: tcp:80,http:443,udp:10002
+      defaultflavor:
+        name: x1.small
+      authpublickey: |
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij
+        TkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0
+        VU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC
+        GJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS
+        z3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m
+        QnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C
+        /QIDAQAB
+        -----END PUBLIC KEY-----
+      deployment: kubernetes
+      deploymentmanifest: |
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: someapplication1-tcp
+          labels:
+            run: someapplication1
+        spec:
+          type: LoadBalancer
+          ports:
+          - name: tcp80
+            protocol: TCP
+            port: 80
+            targetPort: 80
+          - name: http443
+            protocol: TCP
+            port: 443
+            targetPort: 443
+          selector:
+            run: someapplication1
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: someapplication1-udp
+          labels:
+            run: someapplication1
+        spec:
+          type: LoadBalancer
+          ports:
+          - name: udp10002
+            protocol: UDP
+            port: 10002
+            targetPort: 10002
+          selector:
+            run: someapplication1
+        ---
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: someapplication1-deployment
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              run: someapplication1
+          template:
+            metadata:
+              labels:
+                run: someapplication1
+            spec:
+              volumes:
+              imagePullSecrets:
+              - name: registry.mobiledgex.net
+              containers:
+              - name: someapplication1
+                image: registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0
+                imagePullPolicy: Always
+                ports:
+                - containerPort: 80
+                  protocol: TCP
+                - containerPort: 443
+                  protocol: TCP
+                - containerPort: 10002
+                  protocol: UDP
+      deploymentgenerator: kubernetes-basic
+      androidpackagename: com.acme.someapplication1
+      accesstype: AccessTypeLoadBalancer
+    appinstances:
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: someapplication1
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: SmallCluster
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-3
+          organization: AcmeAppCo
+      cloudletloc:
+        latitude: 32
+        longitude: -92
+      uri: smallcluster.tmus-cloud-3.tmus.mobiledgex.net
+      liveness: LivenessStatic
+      mappedports:
+      - proto: LProtoTcp
+        internalport: 80
+        publicport: 80
+        fqdnprefix: someapplication1-tcp.
+      - proto: LProtoTcp
+        internalport: 443
+        publicport: 443
+        fqdnprefix: someapplication1-tcp.
+      - proto: LProtoUdp
+        internalport: 10002
+        publicport: 10002
+        fqdnprefix: someapplication1-udp.
+      flavor:
+        name: x1.small
+      state: Ready
+      createdat:
+        seconds: 1584553776
+        nanos: 473764000
+      powerstate: PowerOn
+      vmflavor: x1.small
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: someapplication1
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: SmallCluster
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-4
+          organization: AcmeAppCo
+      cloudletloc:
+        latitude: 36
+        longitude: -96
+      uri: tmus-cloud-4.tmus.mobiledgex.net
+      liveness: LivenessStatic
+      mappedports:
+      - proto: LProtoTcp
+        internalport: 80
+        publicport: 80
+        fqdnprefix: someapplication1-tcp.
+      - proto: LProtoHttp
+        internalport: 443
+        publicport: 443
+        pathprefix: acmeappco/someapplication110/p443
+      - proto: LProtoUdp
+        internalport: 10002
+        publicport: 10002
+        fqdnprefix: someapplication1-udp.
+      flavor:
+        name: x1.small
+      state: Ready
+      createdat:
+        seconds: 1584553776
+        nanos: 585740000
+      powerstate: PowerOn
+      vmflavor: x1.small

--- a/e2e-tests/data/mc_user3_data_show.yml
+++ b/e2e-tests/data/mc_user3_data_show.yml
@@ -2,16 +2,15 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
-  createdat: 2019-09-26T14:54:12.019247-07:00
-  updatedat: 2019-09-26T14:54:12.019247-07:00
+- region: locala
+  address: 127.0.0.1:55011
+  influxdb: http://127.0.0.1:8087
 orgs:
 - name: enterprise
   type: developer
   address: enterprise headquarters
   phone: 123-123-1234
   adminusername: mexadmin
-  createdat: 2019-09-26T14:54:12.023243-07:00
-  updatedat: 2019-09-26T14:54:12.023243-07:00
 roles:
 - org: enterprise
   username: mexadmin
@@ -187,3 +186,65 @@ regiondata:
       createdat:
         seconds: 1569534854
         nanos: 528573000
+- region: locala
+  appdata:
+    flavors:
+    - key:
+        name: x1.tiny
+      ram: 1024
+      vcpus: 1
+      disk: 1
+    - key:
+        name: x1.small
+      ram: 2048
+      vcpus: 2
+      disk: 2
+    - key:
+        name: x1.medium
+      ram: 4096
+      vcpus: 4
+      disk: 4
+    cloudlets:
+    - key:
+        organization: enterprise
+        name: enterprise-2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      notifysrvaddr: 127.0.0.1:51016
+      flavor:
+        name: x1.small
+      physicalname: enterprise-2
+      containerversion: "2019-10-24"
+    - key:
+        organization: tmus
+        name: tmus-cloud-3
+      location:
+        latitude: 32
+        longitude: -92
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      platformtype: PlatformTypeFakeinfra
+      notifysrvaddr: 127.0.0.1:51017
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-3
+      containerversion: "2019-10-24"
+    - key:
+        organization: tmus
+        name: tmus-cloud-4
+      location:
+        latitude: 36
+        longitude: -96
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      notifysrvaddr: 127.0.0.1:51018
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-4
+      containerversion: "2019-10-24"

--- a/e2e-tests/data/mc_user3_empty_show.yml
+++ b/e2e-tests/data/mc_user3_empty_show.yml
@@ -2,16 +2,15 @@ controllers:
 - region: local
   address: 127.0.0.1:55001
   influxdb: http://127.0.0.1:8086
-  createdat: 2019-09-26T15:12:31.962691-07:00
-  updatedat: 2019-09-26T15:12:31.962691-07:00
+- region: locala
+  address: 127.0.0.1:55011
+  influxdb: http://127.0.0.1:8087
 orgs:
 - name: enterprise
   type: developer
   address: enterprise headquarters
   phone: 123-123-1234
   adminusername: mexadmin
-  createdat: 2019-09-26T15:12:31.966526-07:00
-  updatedat: 2019-09-26T15:12:31.966526-07:00
 roles:
 - org: enterprise
   username: mexadmin
@@ -53,3 +52,65 @@ regiondata:
       ram: 4096
       vcpus: 4
       disk: 4
+- region: locala
+  appdata:
+    flavors:
+    - key:
+        name: x1.tiny
+      ram: 1024
+      vcpus: 1
+      disk: 1
+    - key:
+        name: x1.small
+      ram: 2048
+      vcpus: 2
+      disk: 2
+    - key:
+        name: x1.medium
+      ram: 4096
+      vcpus: 4
+      disk: 4
+    cloudlets:
+    - key:
+        organization: tmus
+        name: tmus-cloud-4
+      location:
+        latitude: 36
+        longitude: -96
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      notifysrvaddr: 127.0.0.1:51018
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-4
+      containerversion: "2019-10-24"
+    - key:
+        organization: enterprise
+        name: enterprise-2
+      location:
+        latitude: 31
+        longitude: -91
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      notifysrvaddr: 127.0.0.1:51016
+      flavor:
+        name: x1.small
+      physicalname: enterprise-2
+      containerversion: "2019-10-24"
+    - key:
+        organization: tmus
+        name: tmus-cloud-3
+      location:
+        latitude: 32
+        longitude: -92
+      ipsupport: IpSupportDynamic
+      numdynamicips: 254
+      state: Ready
+      platformtype: PlatformTypeFakeinfra
+      notifysrvaddr: 127.0.0.1:51017
+      flavor:
+        name: DefaultPlatformFlavor
+      physicalname: tmus-cloud-3
+      containerversion: "2019-10-24"

--- a/e2e-tests/setups/local_multi.yml
+++ b/e2e-tests/setups/local_multi.yml
@@ -31,6 +31,12 @@ influxs:
   httpaddr: "http://127.0.0.1:8086"
   hostname: "127.0.0.1"
 
+influxs:
+- name: influxa1
+  datadir: /var/tmp/edge-cloud-local-influx/influx2
+  httpaddr: "http://127.0.0.1:8087"
+  hostname: "127.0.0.1"
+
 etcds:
 - name: etcd1
   datadir: /var/tmp/edge-cloud-local-etcd/etcd1
@@ -51,6 +57,27 @@ etcds:
   peeraddrs: "http://127.0.0.1:30013"
   clientaddrs: "http://127.0.0.1:30003"
   initialcluster: "etcd1=http://127.0.0.1:30011,etcd2=http://127.0.0.1:30012,etcd3=http://127.0.0.1:30013"
+  hostname: "127.0.0.1"
+
+- name: etcda1
+  datadir: /var/tmp/edge-cloud-local-etcd/etcda1
+  peeraddrs: "http://127.0.0.1:30021"
+  clientaddrs: "http://127.0.0.1:30031"
+  initialcluster: "etcda1=http://127.0.0.1:30021,etcda2=http://127.0.0.1:30022,etcda3=http://127.0.0.1:30023"
+  hostname: "127.0.0.1"
+
+- name: etcda2
+  datadir: /var/tmp/edge-cloud-local-etcd/etcda2
+  peeraddrs: "http://127.0.0.1:30022"
+  clientaddrs: "http://127.0.0.1:30032"
+  initialcluster: "etcda1=http://127.0.0.1:30021,etcda2=http://127.0.0.1:30022,etcda3=http://127.0.0.1:30023"
+  hostname: "127.0.0.1"
+
+- name: etcda3
+  datadir: /var/tmp/edge-cloud-local-etcd/etcda3
+  peeraddrs: "http://127.0.0.1:30023"
+  clientaddrs: "http://127.0.0.1:30033"
+  initialcluster: "etcda1=http://127.0.0.1:30021,etcda2=http://127.0.0.1:30022,etcda3=http://127.0.0.1:30023"
   hostname: "127.0.0.1"
 
 controllers:
@@ -84,6 +111,38 @@ controllers:
   notifyparentaddrs: "127.0.0.1:52002"
   notifyrootaddrs: "127.0.0.1:53001"
 
+- name: ctrla1
+  etcdaddrs: "http://127.0.0.1:30031,http://127.0.0.1:30032,http://127.0.0.1:30033"
+  apiaddr: "127.0.0.1:55011"
+  httpaddr: "0.0.0.0:36011"
+  notifyaddr: "127.0.0.1:37011"
+  vaultaddr: "http://127.0.0.1:8200"
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"
+  versiontag: "2019-10-24"
+  testmode: true
+  notifyparentaddrs: "127.0.0.1:52001"
+  notifyrootaddrs: "127.0.0.1:53001"
+  region: locala
+
+- name: ctrla2
+  etcdaddrs: "http://127.0.0.1:30031,http://127.0.0.1:30032,http://127.0.0.1:30033"
+  apiaddr: "127.0.0.1:55012"
+  httpaddr: "0.0.0.0:36012"
+  notifyaddr: "127.0.0.1:37012"
+  vaultaddr: "http://127.0.0.1:8200"
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"
+  versiontag: "2019-10-24"
+  testmode: true
+  notifyparentaddrs: "127.0.0.1:52002"
+  notifyrootaddrs: "127.0.0.1:53001"
+  region: locala
+
 clustersvcs:
 - name: cluster-svc1
   notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
@@ -97,6 +156,23 @@ clustersvcs:
 - name: cluster-svc2
   notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
   ctrladdrs: "127.0.0.1:55002"
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"
+
+- name: cluster-svca1
+  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
+  ctrladdrs: "127.0.0.1:55011"
+  pluginrequired: true
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"
+
+- name: cluster-svca2
+  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
+  ctrladdrs: "127.0.0.1:55012"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -130,6 +206,44 @@ dmes:
   carrier: TDG
   cloudletkey: '{"organization":"tmus","name":"tmus-cloud-2"}'
   vaultaddr: "http://127.0.0.1:8200"
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    serverkey: "{{tlsoutdir}}/mex-server.key"
+    clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"
+  envvars:
+    LOCAPI_USER: mexserver
+    LOCAPI_PASSWD: eC2835!
+
+- name: dmea1
+  apiaddr: "0.0.0.0:50061"
+  httpaddr: "0.0.0.0:38011"
+  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
+  locverurl: "{{locverurl}}"
+  toksrvurl: "{{toksrvurl}}"
+  carrier: TDG
+  cloudletkey: '{"organization":"tmus","name":"tmus-cloud-3"}'
+  vaultaddr: "http://127.0.0.1:8200"
+  region: locala
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    serverkey: "{{tlsoutdir}}/mex-server.key"
+    clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"
+  envvars:
+    LOCAPI_USER: mexserver
+    LOCAPI_PASSWD: eC2835!
+
+- name: dmea2
+  apiaddr: "0.0.0.0:50062"
+  httpaddr: "0.0.0.0:38012"
+  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
+  locverurl: "{{locverurl}}"
+  toksrvurl: "{{toksrvurl}}"
+  carrier: TDG
+  cloudletkey: '{"organization":"tmus","name":"tmus-cloud-4"}'
+  vaultaddr: "http://127.0.0.1:8200"
+  region: locala
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
@@ -195,6 +309,16 @@ autoprovs:
   ctrladdrs: "127.0.0.1:55001"
   vaultaddr: "http://127.0.0.1:8200"
   influxaddr: "http://127.0.0.1:8086"
+  tls:
+    servercert: "{{tlsoutdir}}/mex-server.crt"
+    clientcert: "{{tlsoutdir}}/mex-client.crt"
+  hostname: "127.0.0.1"
+
+- name: autoprova1
+  notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
+  ctrladdrs: "127.0.0.1:55011"
+  vaultaddr: "http://127.0.0.1:8200"
+  influxaddr: "http://127.0.0.1:8087"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 
@@ -399,6 +400,7 @@ func orgInUse(ctx context.Context, orgName string) error {
 	if len(errs) == 0 {
 		return nil
 	}
+	sort.Strings(errs)
 	return fmt.Errorf("Organization %s in use or check failed: %s", orgName, strings.Join(errs, "; "))
 }
 


### PR DESCRIPTION
This adds a second region to the e2e tests. It was meant to be able to debug an issue with ShowNode but it turns out that issue was somehow fixed since the bug was filed. But it's good to have this extra setup so we can test any issues with multiple regions in the e2e tests.

The second region has the same set of services as the first - 3 etcds, 2 controllers, 2 dmes, etc.  (see local_multi.yml) The second region has a similar set of cloudlets/flavors/apps/clusterinsts/etc as the first region. It emulates what would happen if a user wanted to deploy the same app to two different regions.

The only code change was to sort the org-in-use check error message that comes from different regions so that the output is deterministic.