### PR TITLE
Do not revoke controller CRM secret IDs

### DIFF
--- a/ansible/lookup_plugins/approle.py
+++ b/ansible/lookup_plugins/approle.py
@@ -144,6 +144,7 @@ class LookupModule(LookupBase):
         display.vvv("Vault token: {0}".format(vault_token))
 
         lookup_id = kwargs.get('id', role_name)
+        revoke_old = kwargs.get('revoke_old', 'yes')
         token_scope = kwargs.get('scope', None)
         if token_scope:
             scope_val = self._templar.template(myvars.get(token_scope))
@@ -156,7 +157,11 @@ class LookupModule(LookupBase):
         resp.update(lookup('secret-id'))
 
         accessor = resp.pop('secret_id_accessor')
-        self._store_accessor(vault_addr, vault_token, role_name, accessor, lookup_id)
+        if revoke_old == 'yes':
+            # Revoke old secret and store accessor for current
+            self._store_accessor(vault_addr, vault_token, role_name, accessor, lookup_id)
+        else:
+            display.v("NOT storing accessor or revoking old secret")
 
         ret.append(resp)
 

--- a/ansible/roles/controller/tasks/main.yml
+++ b/ansible/roles/controller/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Fetch CRM vault role
   set_fact:
-    crm_role: "{{ lookup('approle', 'crm.v1', scope='region') }}"
+    crm_role: "{{ lookup('approle', 'crm.v1', revoke_old='no') }}"
 
 - name: Deploy the Mex Controller
   k8s:


### PR DESCRIPTION
During deployment, the controller's vault role secret ID gets
regenerated, and the previous secret revoked.  That way, there is only
one valid role/secret for each controller instance.  However, we can't
do the same for the CRM role/secret of the controller as revoking the
secret would break any CRMs set up by a previous instance of the
controller.

This change disables revocation of previous CRM role secret IDs when the
controller is redeployed.