### PR TITLE
EDGECLOUD-2303 Add delete support roles in vault

### DIFF
--- a/ansible/roles/vault/tasks/region-roles.yml
+++ b/ansible/roles/vault/tasks/region-roles.yml
@@ -11,7 +11,7 @@
     policies:
       - approle.login.v1
       - registry.read.v1
-      - "{{ region_prefix }}.cloudlets.write.v1"
+      - "{{ region_prefix }}.cloudlets.delete.v1"
       - "{{ region_prefix }}.accounts.read.v1"
     token_type: batch
 


### PR DESCRIPTION
Controller needs to be able to delete openrc data added during a
CreateCloudlet.