### PR TITLE
switched developer to organization for cloudcommon

### DIFF
--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -342,7 +342,7 @@ func TestController(t *testing.T) {
 		// developers can't create AppInsts on other developer's ClusterInsts
 		appinst := edgeproto.AppInst{}
 		appinst.Key.AppKey.Organization = org1
-		appinst.Key.ClusterInstKey.Organization = cloudcommon.DeveloperMobiledgeX
+		appinst.Key.ClusterInstKey.Organization = cloudcommon.OrganizationMobiledgeX
 		_, status, err := ormtestutil.TestCreateAppInst(mcClient, uri, tokenDev, ctrl.Region, &appinst)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "AppInst organization must match ClusterInst organization")

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -68,7 +68,7 @@ func CreateOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.Organizat
 	if strings.ToLower(claims.Username) == strings.ToLower(org.Name) {
 		return fmt.Errorf("org name cannot be same as existing user name")
 	}
-	if strings.ToLower(org.Name) == strings.ToLower(cloudcommon.DeveloperMobiledgeX) || strings.ToLower(org.Name) == strings.ToLower(cloudcommon.DeveloperEdgeBox) {
+	if strings.ToLower(org.Name) == strings.ToLower(cloudcommon.OrganizationMobiledgeX) || strings.ToLower(org.Name) == strings.ToLower(cloudcommon.OrganizationEdgeBox) {
 		if err := authorized(ctx, claims.Username, "", ResourceUsers, ActionManage); err != nil {
 			return fmt.Errorf("Not authorized to create reserved org %s", org.Name)
 		}

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -198,7 +198,7 @@ func TestServer(t *testing.T) {
 
 	orgMex := ormapi.Organization{
 		Type:    "developer",
-		Name:    cloudcommon.DeveloperMobiledgeX,
+		Name:    cloudcommon.OrganizationMobiledgeX,
 		Address: "123",
 		Phone:   "123",
 	}


### PR DESCRIPTION
Switched cloudcommon.DeveloperMobiledgeX in edge-cloud to cloudcommon.OrganizationMopbiledgeX as part of a bigger PR. Changed the names where they are used here in infra:

edge-cloud pr: https://github.com/mobiledgex/edge-cloud/pull/868