### PR TITLE
EDGECLOUD-1494: Unable to find vaultConfig to access artifactory

### DIFF
--- a/crm-platforms/openstack/openstack-appinst.go
+++ b/crm-platforms/openstack/openstack-appinst.go
@@ -122,7 +122,7 @@ func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.Clu
 		if err != nil {
 			return err
 		}
-		sourceImageTime, md5Sum, err := mexos.GetUrlInfo(ctx, app.ImagePath)
+		sourceImageTime, md5Sum, err := mexos.GetUrlInfo(ctx, s.vaultConfig, app.ImagePath)
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelMexos, "failed to fetch source image info, skip image validity checks")
 		}

--- a/crm-platforms/openstack/openstack-cmd.go
+++ b/crm-platforms/openstack/openstack-cmd.go
@@ -1038,7 +1038,7 @@ func (s *Platform) AddImageIfNotPresent(ctx context.Context, imgPathPrefix, imgV
 	}
 	if err != nil {
 		// Validate if pfImageName is same as we expected
-		_, md5Sum, err := mexos.GetUrlInfo(ctx, imgPath)
+		_, md5Sum, err := mexos.GetUrlInfo(ctx, s.vaultConfig, imgPath)
 		if err != nil {
 			return "", err
 		}

--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -47,7 +47,6 @@ type CommonPlatform struct {
 var MEXInfraVersion = "3.0.3"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
-var VaultConfig *vault.Config
 var ImageFormatQcow2 = "qcow2"
 
 // Default CloudletVM/Registry paths should only be used for local testing.
@@ -125,7 +124,6 @@ func (c *CommonPlatform) InitInfraCommon(ctx context.Context, vaultConfig *vault
 	if vaultConfig.Addr == "" {
 		return fmt.Errorf("vaultAddr is not specified")
 	}
-	VaultConfig = vaultConfig
 
 	// set default properties
 	c.envVars = infraCommonProps

--- a/mexos/uri.go
+++ b/mexos/uri.go
@@ -17,6 +17,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/vault"
 	"gortc.io/stun"
 )
 
@@ -50,9 +51,9 @@ func GetHTTPFile(ctx context.Context, uri string) ([]byte, error) {
 	return nil, fmt.Errorf("http status not OK, %v", resp.StatusCode)
 }
 
-func GetUrlInfo(ctx context.Context, fileUrlPath string) (time.Time, string, error) {
+func GetUrlInfo(ctx context.Context, vaultConfig *vault.Config, fileUrlPath string) (time.Time, string, error) {
 	log.SpanLog(ctx, log.DebugLevelMexos, "get url last-modified time", "file-url", fileUrlPath)
-	resp, err := cloudcommon.SendHTTPReq(ctx, "HEAD", fileUrlPath, VaultConfig, nil)
+	resp, err := cloudcommon.SendHTTPReq(ctx, "HEAD", fileUrlPath, vaultConfig, nil)
 	if err != nil {
 		return time.Time{}, "", err
 	}


### PR DESCRIPTION
Removed global vaultConfig in mexos package. This causes issues if we fail to set it. Now we pass vaultConfig as argument, rather than using global variable.