### PR TITLE
local edgebox requires mexenv.json 

### DIFF
--- a/e2e-tests/int-process/process_local.go
+++ b/e2e-tests/int-process/process_local.go
@@ -386,6 +386,10 @@ func SetupVault(p *process.Vault, opts ...process.StartOp) (*VaultRoles, error) 
 	p.GetAppRole("", "rotator", &roles.RotatorRoleID, &roles.RotatorSecretID, &err)
 	p.PutSecret("", "mcorm", mcormSecret+"-old", &err)
 	p.PutSecret("", "mcorm", mcormSecret, &err)
+	// Set up local mexenv.json in the vault to allow local edgebox to run
+	localMexenv := gopath + "/src/github.com/mobiledgex/edge-cloud-infra/mgmt/cloudlets/mexenv.json"
+	p.Run("vault", fmt.Sprintf("write %s @%s", "/secret/data/cloudlet/openstack/mexenv.json", localMexenv), &err)
+
 	if err != nil {
 		return &roles, err
 	}


### PR DESCRIPTION
 - `make edgebox-start` was failing because it couldn't find mexenv.json in the local vault
- added mexenv.json to local vault, when running local vault
- thanks @mchu1195  for figuring this out
