### PR TITLE
Disable DNS server provisioning on subnets to work around contrail bug

### DIFF
--- a/crm-platforms/openstack/openstack-heat.go
+++ b/crm-platforms/openstack/openstack-heat.go
@@ -45,6 +45,7 @@ type VMParams struct {
 	ComputeAvailabilityZone  string
 	VolumeAvailabilityZone   string
 	PrivacyPolicy            *edgeproto.PrivacyPolicy
+	VMDNSServers             string
 }
 
 type VMParamsOp func(vmp *VMParams) error
@@ -81,6 +82,9 @@ ssh_pwauth: False
 timezone: UTC
 runcmd:
  - [ echo, MOBILEDGEX, doing, ifconfig ]
+{{if .VMDNSServers}}
+ - echo "dns-nameservers {{.VMDNSServers}}" >> /etc/network/interfaces.d/50-cloud-init.cfg
+{{end}}
  - [ ifconfig, -a ]`
 
 // vmCloudConfigShareMount is appended optionally to vmCloudConfig.   It assumes
@@ -240,8 +244,9 @@ resources:
 
 // ClusterNode is a k8s node
 type ClusterNode struct {
-	NodeName string
-	NodeIP   string
+	NodeName     string
+	NodeIP       string
+	VMDNSServers string
 }
 
 // ClusterParams has the info needed to populate the heat template
@@ -894,6 +899,17 @@ func (s *Platform) getClusterParams(ctx context.Context, clusterInst *edgeproto.
 	cp.PrivacyPolicy = privacyPolicy
 	cp.CloudletSecurityGroup = cloudletGrp
 
+	// this is a hopefully short term workaround to a Contrail bug in which DNS resolution
+	// breaks when the DNS server is specified in the subnet on creation.  The workaround is to
+	// use cloud-init to specify the DNS server in the VM rather than the subnet.
+	dns := []string{"1.1.1.1", "1.0.0.1"}
+	if s.GetSubnetDNS() == mexos.NoSubnetDNS {
+		log.SpanLog(ctx, log.DebugLevelMexos, "subnet DNS is NONE, using VM DNS", "dns", dns)
+		cp.VMDNSServers = strings.Join(dns, " ")
+	} else {
+		log.SpanLog(ctx, log.DebugLevelMexos, "using subnet dns", "dns", dns)
+		cp.DNSServers = dns
+	}
 	nodeIPPrefix, err := s.populateCommonClusterParamFields(ctx, &cp, rootLBName, cloudletGrp, action)
 	if err != nil {
 		return nil, err
@@ -910,10 +926,9 @@ func (s *Platform) getClusterParams(ctx context.Context, clusterInst *edgeproto.
 		nn := HeatNodePrefix(i)
 		nip := fmt.Sprintf("%s.%d", nodeIPPrefix, i+100)
 		cn := ClusterNode{NodeName: nn, NodeIP: nip}
+		cn.VMDNSServers = cp.VMDNSServers
 		cp.Nodes = append(cp.Nodes, cn)
 	}
-	// cloudflare primary and backup
-	cp.DNSServers = []string{"1.1.1.1", "1.0.0.1"}
 	if clusterInst.NumNodes > 0 && clusterInst.MasterNodeFlavor != "" {
 		cp.MasterNodeFlavor = clusterInst.MasterNodeFlavor
 		log.SpanLog(ctx, log.DebugLevelMexos, "HeatGetClusterParams", "MasterNodeFlavor", cp.MasterNodeFlavor)

--- a/crm-platforms/openstack/openstack-props.go
+++ b/crm-platforms/openstack/openstack-props.go
@@ -65,6 +65,7 @@ var openstackProps = map[string]*mexos.PropertyInfo{
 	"CLEANUP_ON_FAILURE": &mexos.PropertyInfo{
 		Value: "true",
 	},
+	"MEX_SUBNET_DNS": &mexos.PropertyInfo{},
 }
 
 func GetVaultCloudletAccessPath(key *edgeproto.CloudletKey, region, physicalName string) string {
@@ -158,6 +159,10 @@ func (s *Platform) GetCloudletProjectName() string {
 
 func (s *Platform) GetCloudletFlavorMatchPattern() string {
 	return s.envVars["FLAVOR_MATCH_PATTERN"].Value
+}
+
+func (s *Platform) GetSubnetDNS() string {
+	return s.envVars["MEX_SUBNET_DNS"].Value
 }
 
 func (s *Platform) GetCloudletCRMGatewayIPAndPort() (string, int) {

--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -65,6 +65,9 @@ var NoConfigExternalRouter = "NOCONFIG"
 // this may eventually be the default and possibly only option
 var NoExternalRouter = "NONE"
 
+// NoSubnetDNS means that DNS servers are not specified when creating the subnet
+var NoSubnetDNS = "NONE"
+
 // Package level test mode variable
 var testMode = false
 


### PR DESCRIPTION
In TELUS we ran into a bug with Juniper Contrail:

When an external DNS server is provisioned for the subnet, the newest Contrail s/w allocates that IP as a contrail service IP.   So when 1.1.1.1 is used as a dns server entry when creating a subnet, Contrail will allocate that IP internally instead of sending packets out to it.  This causes our newly k8s subnets to be unable to resolve DNS.

Previous versions of Contrail did not have this bug but the new Toronto site has been "upgraded" to this new version.

Telus acknowledges that this is a bug with Contail and have a ticket opened, but it is likely to take months to resolve this basic issue.   To unblock our cloudlet in Toronto we employ a workaround based on env var MEX_SUBNET_DNS.  When set to NONE, we do not allocate dns servers on the new subnets and instead use cloud-init to provision the DNS server on on the cluster nodes.