### PR TITLE
fix intermittent ctrl_restart e2e failure

### DIFF
--- a/e2e-tests/e2e-setup/cmp.go
+++ b/e2e-tests/e2e-setup/cmp.go
@@ -110,27 +110,6 @@ func CompareYamlFiles(firstYamlFile string, secondYamlFile string, fileType stri
 
 		err1 = util.ReadYamlFile(firstYamlFile, &a1)
 		err2 = util.ReadYamlFile(secondYamlFile, &a2)
-
-		// remove cloudletinfos that are offline so they are ignored
-		for i, region := range a1.RegionData {
-			onlineCloudlets := make([]edgeproto.CloudletInfo, 0)
-			for _, cloudletinfo := range region.AppData.CloudletInfos {
-				if cloudletinfo.State != edgeproto.CloudletState_CLOUDLET_STATE_OFFLINE {
-					onlineCloudlets = append(onlineCloudlets, cloudletinfo)
-				}
-			}
-			a1.RegionData[i].AppData.CloudletInfos = onlineCloudlets
-		}
-		for i, region := range a2.RegionData {
-			onlineCloudlets := make([]edgeproto.CloudletInfo, 0)
-			for _, cloudletinfo := range region.AppData.CloudletInfos {
-				if cloudletinfo.State != edgeproto.CloudletState_CLOUDLET_STATE_OFFLINE {
-					onlineCloudlets = append(onlineCloudlets, cloudletinfo)
-				}
-			}
-			a2.RegionData[i].AppData.CloudletInfos = onlineCloudlets
-		}
-
 		copts = []cmp.Option{
 			cmpopts.IgnoreTypes(time.Time{}, dmeproto.Timestamp{}),
 			IgnoreAdminRole,

--- a/e2e-tests/test-mex-infra/test-mex-infra.go
+++ b/e2e-tests/test-mex-infra/test-mex-infra.go
@@ -38,6 +38,7 @@ func main() {
 	log.InitTracer("")
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
+	util.SetLogFormat()
 
 	config := e2eapi.TestConfig{}
 	spec := e2esetup.TestSpec{}
@@ -92,14 +93,15 @@ func main() {
 	if spec.CompareYaml.Yaml1 != "" && spec.CompareYaml.Yaml2 != "" {
 		retryOk := true
 		pass := false
-		for ii := 0; ii < 5 && retryOk; ii++ {
+		maxTries := 5
+		for ii := 0; ii < maxTries && retryOk; ii++ {
 			pass = e2esetup.CompareYamlFiles(spec.CompareYaml.Yaml1,
 				spec.CompareYaml.Yaml2, spec.CompareYaml.FileType)
-			if pass || len(retryActions) == 0 {
+			if pass || len(retryActions) == 0 || ii == maxTries-1 {
 				break
 			}
 			// retry (typically retry show command)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 			msg := fmt.Sprintf("re-running actions %v count %d due to compare yaml failure", retryActions, ii)
 			util.PrintStepBanner(msg)
 			for _, a := range retryActions {


### PR DESCRIPTION
Infra changes for https://github.com/mobiledgex/edge-cloud/pull/877

Infra was actually already checking most CloudletInfo state. It ignored the "offline" ones, but those were from previous tests that weren't cleaned up.

Also once saw an issue e2e failed talking to MC right after starting MC, probably because the MC process wasn't ready yet.

Also got rid of an extra "show" during the show retry that isn't needed.