### PR TITLE
Pass GCP/Azure envvars explicitly for CRMs

### DIFF
--- a/ansible/qa/group_vars/all
+++ b/ansible/qa/group_vars/all
@@ -21,6 +21,7 @@ crm_instances:
     platform: PLATFORM_TYPE_AZURE
     azure_instance: centralus
     controller_region: US
+    notify_srv_port: 51091
 
   - cloudlet_name: automationGcpCentralCloudlet
     operator_key: gcp
@@ -28,3 +29,4 @@ crm_instances:
     platform: PLATFORM_TYPE_GCP
     gcp_zone: us-central1-c
     controller_region: US
+    notify_srv_port: 51092

--- a/ansible/roles/crm/tasks/main.yml
+++ b/ansible/roles/crm/tasks/main.yml
@@ -1,5 +1,9 @@
 - debug: var=item
 
+- import_role:
+    name: load-vault-creds
+    tasks_from: mexenv
+
 - azure_rm_aks_facts:
     tags:
       - "Environment:mexplat-{{ deploy_environ }}"
@@ -81,6 +85,8 @@
     - set_fact:
         crm_env_azure:
           MEX_AZURE_LOCATION: "{{ item.azure_instance }}"
+          MEX_AZURE_USER: "{{ mexenv.MEX_AZURE_USER }}"
+          MEX_AZURE_PASS: "{{ mexenv.MEX_AZURE_PASS }}"
           MEXENV_URL: "https://{{ vault_vm_hostname}}:{{ vault_port }}/v1/secret/data/cloudlet/openstack/mexenv.json"
     - set_fact:
         crm_env: "{{ crm_env | combine(crm_env_azure) }}"
@@ -92,6 +98,7 @@
         crm_env_gcp:
           MEX_GCP_PROJECT: "{{ gcp_project }}"
           MEX_GCP_ZONE: "{{ item.gcp_zone }}"
+          MEX_GCP_SERVICE_ACCOUNT: "{{ mexenv.MEX_GCP_SERVICE_ACCOUNT }}"
           MEXENV_URL: "https://{{ vault_vm_hostname}}:{{ vault_port }}/v1/secret/data/cloudlet/openstack/mexenv.json"
     - set_fact:
         crm_env: "{{ crm_env | combine(crm_env_gcp) }}"

--- a/ansible/roles/load-vault-creds/defaults/main.yml
+++ b/ansible/roles/load-vault-creds/defaults/main.yml
@@ -6,3 +6,4 @@ locapi_account_path: secret/ansible/common/accounts/locapi
 mex_docker_account_path: secret/ansible/common/accounts/mex_docker
 sendgrid_account_path: secret/ansible/common/accounts/sendgrid
 slack_org_mgmt_path: secret/ansible/internal/accounts/slack_org_mgmt
+mexenv_path: secret/cloudlet/openstack/mexenv.json

--- a/ansible/roles/load-vault-creds/tasks/mexenv.yml
+++ b/ansible/roles/load-vault-creds/tasks/mexenv.yml
@@ -1,0 +1,8 @@
+- name: Look up mexenv parameters in vault
+  set_fact:
+    vault_lookup: "{{ lookup('vault', mexenv_lookup) }}"
+  vars:
+    mexenv_lookup: "{{ mexenv_path }}:mexenv"
+
+- set_fact:
+    mexenv: "{{ vault_lookup.mexenv.data.env | items2dict(key_name='name', value_name='value') }}"

--- a/ansible/roles/vault/tasks/roles.yml
+++ b/ansible/roles/vault/tasks/roles.yml
@@ -15,6 +15,7 @@
       - certs.read.v1
       - influxdb.read.v1
       - influxdb-internal.read.v1
+      - mexenv.read.v1
       - pki-global-config.read.v1
       - pki-global-roles.read.v1
       - pki-regional-cloudlet-config.read.v1


### PR DESCRIPTION
After the envvars change, GCP/Azure-specific parameters are not loaded
from mexenv.  Loading these parameters in Ansible and passing them
to the CRMs at deployment time.