### PR TITLE
Switch to a file-based persistent jaeger backend in QA/staging/dev

### DIFF
--- a/ansible/development/list
+++ b/ansible/development/list
@@ -41,3 +41,6 @@ vault-dev-b.mobiledgex.net
 
 [console]
 console-dev.mobiledgex.net
+
+[jaeger]
+jaeger-dev.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -32,6 +32,7 @@ vault_artifactory_token_path: "secret/ansible/common/accounts/artifactory"
 vault_ns1_apikey_path: "secret/ansible/common/accounts/ns1"
 vault_influxdb_creds_path: "secret/ansible/internal/accounts/influxdb"
 vault_mex_ca_cert_path: secret/ansible/common/certs/mex-ca
+vault_root_ca_cert_path: secret/certs/root-ca
 mc_creds_vault_path: "secret/ansible/{{ deploy_environ }}/accounts/mc"
 vouch_hostname: vouch.mobiledgex.net
 influxdb_vm_hostname: influxdb.internal.mobiledgex.net

--- a/ansible/internal
+++ b/ansible/internal
@@ -14,12 +14,6 @@ vouch.mobiledgex.net
 [elasticsearch]
 es01.es.mobiledgex.net		cert_wildcard_domain=es.mobiledgex.net es_instance=main
 
-[jaeger]
-jaeger.mobiledgex.net		es_instance=main
-jaeger-dev.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443
-jaeger-qa.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443
-jaeger-stage.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443
-
 [slack]
 infra.internal.mobiledgex.net
 

--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -496,48 +496,6 @@
         status_code: 200
       delegate_to: localhost
 
-- hosts: jaeger
-  vars:
-    vault_mex_ca_cert_path: "secret/certs/mex-ca"
-
-  tasks:
-
-    - import_role:
-        name: telegraf
-      tags:
-        - monitoring
-        - setup
-
-    - import_role:
-        name: docker
-      tags: setup
-
-    - name: Look up CA cert in vault
-      set_fact:
-        vault_lookup: "{{ lookup('vault', vault_mex_ca_cert_path) }}"
-      tags: setup
-    - set_fact:
-        mex_ca_cert: "{{ vault_lookup.mex_ca.data.cert }}"
-      tags: setup
-
-    - name: Copy CA cert
-      copy:
-        dest: "{{ mex_ca_cert_path }}"
-        content: "{{ mex_ca_cert }}"
-      become: yes
-      tags: setup
-
-    - import_role:
-        name: web
-      vars:
-        nginx_config_template: "internal/jaeger/nginx-config.j2"
-        cert_domains: [ "*.{{ cloudflare_zone }}" ]
-        cert_name: "{{ inventory_hostname }}"
-      tags: setup
-
-    - import_role:
-        name: jaeger
-
 - hosts: slack
   vars:
     slack_org_mgmt_image: "registry.mobiledgex.net:5000/mobiledgex/slack-org-mgmt:1.2.2"

--- a/ansible/lookup_plugins/vault_ca_cert.py
+++ b/ansible/lookup_plugins/vault_ca_cert.py
@@ -1,0 +1,73 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+lookup: vault_ca_cert
+short_description: return vault CA cert chain
+description:
+  - return a vault CA cert chain for the list of vault PKI mounts
+options:
+  _terms:
+    description:
+        - list of vault pki mount points
+    required: True
+"""
+
+EXAMPLES="""
+  - set_fact:
+      ca_chain: "{{ query('vault_ca_cert', 'pki-global', 'pki') }}"
+  - debug: var=ca_chain
+"""
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
+
+from OpenSSL import crypto
+
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError as e:
+    HAS_REQUESTS = False
+
+display = Display()
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        if variables is not None:
+            self._templar.available_variables = variables
+        myvars = getattr(self._templar, '_available_variables', {})
+
+        if len(terms) < 1:
+            raise AnsibleError('PKI mounts to look up not provided')
+
+        vault_addr_key = 'vault_address'
+        try:
+            vault_addr = kwargs.get(vault_addr_key, myvars[vault_addr_key])
+        except KeyError:
+            raise AnsibleError("Could not find vault address variable: {0}".format(vault_addr_key))
+
+        ca_chain = []
+        has_root_ca = False
+
+        for pki in terms:
+            url = "{0}/v1/{1}/ca/pem".format(vault_addr, pki)
+            display.vv("CA URL: {0}".format(url))
+            r = requests.get(url)
+            if r.status_code != requests.codes.ok:
+                display.vvv("Request: {0}".format(r.request.__dict__))
+                raise AnsibleError("Vault CA cert lookup return response code: {0}".format(r.status_code))
+            display.vvv("CA cert: {0}".format(r.text))
+            ca_cert = r.text
+            ca_chain.append(ca_cert)
+
+            c = crypto.load_certificate(crypto.FILETYPE_PEM, ca_cert)
+            if c.get_subject() == c.get_issuer():
+                has_root_ca = True
+
+        return ({
+            "ca_chain": ca_chain,
+            "has_root_ca": has_root_ca,
+        })

--- a/ansible/main/list
+++ b/ansible/main/list
@@ -34,3 +34,6 @@ stun.mobiledgex.net
 [vault]
 vault-main-a.mobiledgex.net
 vault-main-b.mobiledgex.net
+
+[jaeger]
+jaeger.mobiledgex.net		es_instance=main

--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -211,3 +211,18 @@
       when:
         - not ansible_check_mode
       tags: notify
+
+- hosts: jaeger
+  tasks:
+    - import_role:
+        name: telegraf
+      tags:
+        - monitoring
+        - setup
+
+    - import_role:
+        name: docker
+      tags: setup
+
+    - import_role:
+        name: jaeger

--- a/ansible/qa/list
+++ b/ansible/qa/list
@@ -48,3 +48,6 @@ vault-qa-b.mobiledgex.net
 
 [artifactory]
 artifactory-qa.mobiledgex.net
+
+[jaeger]
+jaeger-qa.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443

--- a/ansible/roles/jaeger/defaults/main.yml
+++ b/ansible/roles/jaeger/defaults/main.yml
@@ -3,3 +3,4 @@ jaeger_version: 1.14
 jaeger_image: "jaegertracing/all-in-one:{{ jaeger_version }}"
 jaeger_index_cleaner_image: "jaegertracing/jaeger-es-index-cleaner:{{ jaeger_version }}"
 jaeger_index_cleanup_days: 30
+jaeger_local_storage_dir: /var/jaeger

--- a/ansible/roles/jaeger/tasks/main.yml
+++ b/ansible/roles/jaeger/tasks/main.yml
@@ -1,12 +1,52 @@
 ---
+- name: Load CA certs
+  import_role:
+    name: vault
+    tasks_from: ca-certs
+  tags: setup
+
+- name: Copy CA cert
+  copy:
+    dest: "{{ mex_ca_cert_path }}"
+    content: "{{ ca_certs | join('\n') }}"
+    backup: yes
+  become: yes
+  tags: setup
+
+- name: Set up reverse proxy
+  import_role:
+    name: web
+  vars:
+    nginx_config_template: "internal/jaeger/nginx-config.j2"
+    cert_domains: [ "*.{{ cloudflare_zone }}" ]
+    cert_name: "{{ inventory_hostname }}"
+  tags: setup
+
 - name: Deploy all-in-one jaeger
-  docker_container:
-    name: jaeger
-    image: "{{ jaeger_image }}"
-    restart_policy: unless-stopped
-    ports:
-      - 127.0.0.1:24268:14268
-      - 127.0.0.1:26686:16686
+  block:
+
+    - name: Create local storage directory
+      file:
+        path: "{{ jaeger_local_storage_dir }}"
+        state: directory
+      become: yes
+
+    - name: Start all-in-one jaeger
+      docker_container:
+        name: jaeger
+        image: "{{ jaeger_image }}"
+        restart_policy: unless-stopped
+        env:
+          SPAN_STORAGE_TYPE: badger
+          BADGER_EPHEMERAL: "false"
+          BADGER_DIRECTORY_VALUE: /badger/data
+          BADGER_DIRECTORY_KEY: /badger/key
+        volumes:
+          - "{{ jaeger_local_storage_dir }}:/badger"
+        ports:
+          - 127.0.0.1:24268:14268
+          - 127.0.0.1:26686:16686
+
   when:
     - es_instance is not defined
 

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -30,6 +30,7 @@ vault_user_roles:
     - pki-regional-roles.read.v1
     - pki-root-config.read.v1
     - registry.read.v1
+    - root-ca.read.v1
     - sys-auth.read.v1
     - sys-mounts.read.v1
     - sys-policies.read.v1

--- a/ansible/roles/vault/tasks/ca-certs.yml
+++ b/ansible/roles/vault/tasks/ca-certs.yml
@@ -1,0 +1,28 @@
+- import_role:
+    name: vault
+    tasks_from: load-token
+  delegate_to: localhost
+
+- name: Load mex CA cert from vault
+  set_fact:
+    vault_lookup: "{{ lookup('vault', ca_path) }}"
+  vars:
+    ca_path: "{{ vault_mex_ca_cert_path }}:ca"
+
+- set_fact:
+    ca_certs: [ "{{ vault_lookup.ca.data.pem }}" ]
+
+- name: Look up vault PKI CA certs
+  set_fact:
+    vault_ca_lookup: "{{ query('vault_ca_cert', 'pki-regional-cloudlet', 'pki-regional', 'pki-global', 'pki') }}"
+
+- name: Append vault PKI CA certs
+  set_fact:
+    ca_certs: "{{ ca_certs + vault_ca_lookup.ca_chain }}"
+
+- name: Append offline root cert
+  set_fact:
+    ca_certs: "{{ ca_certs + [ offline_root_cert.root_ca.data.cert ] }}"
+  vars:
+    offline_root_cert: "{{ lookup('vault', vault_root_ca_cert_path) }}"
+  when: not vault_ca_lookup.has_root_ca

--- a/ansible/roles/vault/tasks/policies.yml
+++ b/ansible/roles/vault/tasks/policies.yml
@@ -33,6 +33,7 @@
     - policies/pki-regional-roles.read.v1.hcl.j2
     - policies/pki-root-config.read.v1.hcl.j2
     - policies/registry.read.v1.hcl.j2
+    - policies/root-ca.read.v1.hcl.j2
     - policies/sys-auth.read.v1.hcl.j2
     - policies/sys-auth.write.v1.hcl.j2
     - policies/sys-mounts.read.v1.hcl.j2

--- a/ansible/roles/vault/tasks/roles.yml
+++ b/ansible/roles/vault/tasks/roles.yml
@@ -24,6 +24,7 @@
       - pki-regional-roles.read.v1
       - pki-root-config.read.v1
       - registry.read.v1
+      - root-ca.read.v1
       - sys-auth.read.v1
       - sys-mounts.read.v1
       - sys-policies.read.v1

--- a/ansible/roles/vault/templates/policies/root-ca.read.v1.hcl.j2
+++ b/ansible/roles/vault/templates/policies/root-ca.read.v1.hcl.j2
@@ -1,0 +1,3 @@
+path "secret/data/certs/root-ca" {
+  capabilities = [ "read" ]
+}

--- a/ansible/staging/list
+++ b/ansible/staging/list
@@ -44,3 +44,6 @@ console-stage.mobiledgex.net
 [vault]
 vault-stage-a.mobiledgex.net
 vault-stage-b.mobiledgex.net
+
+[jaeger]
+jaeger-stage.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443

--- a/mgmt/vault/root-ca/README.md
+++ b/mgmt/vault/root-ca/README.md
@@ -54,10 +54,16 @@ vault write pki/intermediate/set-signed \
     certificate=@intermediate.cert.pem
 ```
 
-## Store the root CA certificates _very_ securely offline:
+## Store the root CA certificate and key _very_ securely offline:
 
 * `private/ca.key.pem`
 * `certs/ca.cert.pem`
+
+## Store the root CA certificate _only_ in vault
+
+```
+vault kv put secret/certs/root-ca cert=@certs/ca.cert.pem
+```
 
 ## References
 


### PR DESCRIPTION
The in-memory jaeger database in QA/staging/dev would periodically end up using all system memory and bring the box down.

Also fixed the following:
* For some reason, jaeger instances were not associated with individual setups but were instead being deployed together across all setups.
* Add all the vault PKI CA certs (including the offline CA cert, if present) to Jaeger's mTLS CA list