### PR TITLE
EDGECLOUD-2550 MC in staging/QA not showing audit events more than a few seconds old

### DIFF
--- a/ansible/roles/jaeger/defaults/main.yml
+++ b/ansible/roles/jaeger/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-jaeger_version: 1.14
+jaeger_version: 1.17.1
 jaeger_image: "jaegertracing/all-in-one:{{ jaeger_version }}"
 jaeger_index_cleaner_image: "jaegertracing/jaeger-es-index-cleaner:{{ jaeger_version }}"
 jaeger_index_cleanup_days: 30


### PR DESCRIPTION
Upgrading Jaeger to the latest stable version.
There are no specific bugs relating to this issue in their changelog, but the latest version has been running in staging for a couple of days and this issue does not appear to be happening any more.