### PR TITLE
EDGECLOUD-2312  EDGECLOUD-2307  App connections metrics is returning the pod field

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -83,7 +83,6 @@ var ClientSelectors = []string{
 var AppFields = []string{
 	"\"app\"",
 	"\"ver\"",
-	"\"pod\"",
 	"\"cluster\"",
 	"\"clusterorg\"",
 	"\"cloudlet\"",


### PR DESCRIPTION
Remove pod selector from general app selectors.
pod field added only for a subset of selectors.