### PR TITLE
quick fix for EDGECLOUD-2572

### DIFF
--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -147,8 +147,12 @@ func (c *CommonPlatform) InitInfraCommon(ctx context.Context, vaultConfig *vault
 		if _, ok := c.envVars[envData.Name]; ok {
 			c.envVars[envData.Name].Value = envData.Value
 		} else {
+			// quick fix for EDGECLOUD-2572.  Assume the mexenv.json item is secret if we have
+			// not defined it one way or another in code, of if the props that defines it is not
+			// run (e.g. an Azure property defined in mexenv.json when we are running openstack)
 			c.envVars[envData.Name] = &PropertyInfo{
-				Value: envData.Value,
+				Value:  envData.Value,
+				Secret: true,
 			}
 		}
 	}


### PR DESCRIPTION
EDGECLOUD-2572: properties defined in mexenv.json which are not specifically defined
in the code are assumed to be non-secret.   This changes unknown entries to be assumed secret.

This is a quick fix for R2.  Longer term we need to split out mexenv.json processing so only relevant properties are loaded for each platform type.  

