### PR TITLE
Add retry for ssh reachable before configuring internal interface

### DIFF
--- a/crm-platforms/openstack/openstack-lb.go
+++ b/crm-platforms/openstack/openstack-lb.go
@@ -238,12 +238,18 @@ func setupForwardingIptables(ctx context.Context, client ssh.Client, externalIfn
 func (s *Platform) configureInternalInterfaceAndExternalForwarding(ctx context.Context, client ssh.Client, externalIPAddr, internalPortName, internalIPAddr string, action string) error {
 
 	log.SpanLog(ctx, log.DebugLevelMexos, "configureInternalInterfaceAndExternalForwarding", "externalIPAddr", externalIPAddr, "internalPortName", internalPortName, "internalIPAddr", internalIPAddr)
-
 	// list the ports so we can find the internal and external port macs
 	ports, err := s.ListPorts(ctx)
 	if err != nil {
 		return err
 	}
+
+	err = WaitServerSSHReachable(ctx, client, externalIPAddr, time.Minute*1)
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelMexos, "server not reachable", "err", err)
+		return err
+	}
+
 	internalPortMac := ""
 	externalPortMac := ""
 	for _, p := range ports {


### PR DESCRIPTION
EDGECLOUD-2592

There is a timing issue when setting up the LB for VM Apps.  Sometimes it works consistently and sometimes it fails a lot.   

The issue is that we are trying to SSH to the LB to configure the new internal interface but the LB is not yet fully booted.

Fix is to add a timeout/retry.  There are several other places that do something similar so I create a new func to do this, although to limit the number of changes I am only calling this new func in this specific scenario