### PR TITLE
EDGECLOUD-321 test docker-based autoprov

### DIFF
--- a/e2e-tests/data/autoprov_appinst.yml
+++ b/e2e-tests/data/autoprov_appinst.yml
@@ -14,3 +14,15 @@ regiondata:
             organization: tmus
             name: tmus-cloud-1
           organization: MobiledgeX
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: autoprovappd
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: ReservableD
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-1
+          organization: MobiledgeX

--- a/e2e-tests/data/autoprov_appinst_show.yml
+++ b/e2e-tests/data/autoprov_appinst_show.yml
@@ -31,3 +31,32 @@ regiondata:
       createdat:
         seconds: 1576628584
         nanos: 73154000
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: autoprovappd
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: ReservableD
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-1
+          organization: MobiledgeX
+      cloudletloc:
+        latitude: 31
+        longitude: -91
+      uri: tmus-cloud-1.tmus.mobiledgex.net
+      liveness: LivenessStatic
+      mappedports:
+      - proto: LProtoTcp
+        internalport: 81
+        publicport: 10000
+      flavor:
+        name: x1.small
+      state: Ready
+      createdat:
+        seconds: 1587747310
+        nanos: 358952000
+      powerstate: PowerOn
+      vmflavor: x1.small

--- a/e2e-tests/data/find_cloudlet_apd.yml
+++ b/e2e-tests/data/find_cloudlet_apd.yml
@@ -1,0 +1,14 @@
+registerclientrequest:
+  orgname: AcmeAppCo
+  appname: autoprovappd
+  appvers: "1.0"
+  cellid: 1234
+findcloudletrequest:
+  carriername: tmus
+  gpslocation:
+    latitude: 36.00
+    longitude: -96.00
+  cellid: 1234
+repeat: 3
+runatintervalsec: 1
+runatoffsetsec: 0.6

--- a/e2e-tests/data/mc_admin_reservable.yml
+++ b/e2e-tests/data/mc_admin_reservable.yml
@@ -18,3 +18,18 @@ regiondata:
       nummasters: 1
       numnodes: 1
       reservable: true
+    - key:
+        clusterkey:
+          name: ReservableD
+        cloudletkey:
+          organization: tmus
+          name: tmus-cloud-1
+        organization: MobiledgeX
+      flavor:
+        name: x1.small
+      deployment: docker
+      liveness: LivenessStatic
+      ipaccess: IpAccessShared
+      nodeflavor: x1.small
+      masterflavor: x1.small
+      reservable: true

--- a/e2e-tests/data/mc_user2_data.yml
+++ b/e2e-tests/data/mc_user2_data.yml
@@ -74,6 +74,17 @@ regiondata:
       accessports: "tcp:81"
       autoprovpolicy: autoprov1
     - key:
+        organization: AcmeAppCo
+        name: autoprovappd
+        version: "1.0"
+      imagepath: registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0
+      imagetype: ImageTypeDocker
+      deployment: docker
+      defaultflavor:
+        name: x1.small
+      accessports: "tcp:81"
+      autoprovpolicy: autoprov1
+    - key:
         organization: Samsung
         name: SamsungEnablingLayer
         version: "1.0"

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -299,6 +299,18 @@ regiondata:
       deploymentgenerator: kubernetes-basic
       autoprovpolicy: autoprov1
     - key:
+        organization: AcmeAppCo
+        name: autoprovappd
+        version: "1.0"
+      imagepath: registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0
+      imagetype: ImageTypeDocker
+      accessports: tcp:81
+      defaultflavor:
+        name: x1.small
+      deployment: docker
+      autoprovpolicy: autoprov1
+      accesstype: AccessTypeLoadBalancer
+    - key:
         organization: Samsung
         name: SamsungEnablingLayer
         version: "1.0"

--- a/e2e-tests/testfiles/autoprov.yml
+++ b/e2e-tests/testfiles/autoprov.yml
@@ -11,9 +11,20 @@ tests:
   - name: find cloudlet for auto-prov app (3 of 3)
     apifile: "{{datadir2}}/find_cloudlet_ap.yml"
     actions: [dmeapi-findcloudlet]
+
+  - name: find cloudlet for auto-prov docker app (1 of 3)
+    apifile: "{{datadir2}}/find_cloudlet_apd.yml"
+    actions: [dmeapi-findcloudlet]
+  - name: find cloudlet for auto-prov docker app (2 of 3)
+    apifile: "{{datadir2}}/find_cloudlet_apd.yml"
+    actions: [dmeapi-findcloudlet]
+  - name: find cloudlet for auto-prov docker app (3 of 3)
+    apifile: "{{datadir2}}/find_cloudlet_apd.yml"
+    actions: [dmeapi-findcloudlet]
+
   - name: sleep, allow extra time for auto-prov to create AppInst
     actions: [sleep=1]
-  - name: check that AppInst was auto-provisioned
+  - name: check that AppInsts were auto-provisioned
     actions: [mcapi-showfiltered]
     apifile: '{{datadir2}}/autoprov_appinst.yml'
     curuserfile: '{{datadir2}}/mc_user2.yml'
@@ -21,7 +32,7 @@ tests:
       yaml1: '{{outputdir}}/show-commands.yml'
       yaml2: '{{datadir2}}/autoprov_appinst_show.yml'
       filetype: mcdata
-  - name: delete auto-provisioned AppInst
+  - name: delete auto-provisioned AppInsts
     actions: [mcapi-delete]
     apifile: '{{datadir2}}/autoprov_appinst.yml'
     curuserfile: '{{datadir2}}/mc_user2.yml'

--- a/e2e-tests/testfiles/mc_add_delete.yml
+++ b/e2e-tests/testfiles/mc_add_delete.yml
@@ -103,6 +103,7 @@ tests:
     filetype: orgdata
 
 - includefile: autoprov.yml
+  loops: 2
 
 - includefile: mc_debugtest.yml
 


### PR DESCRIPTION
Adds e2e tests for testing auto-provisioning of a docker-based app and reservable ClusterInst, in addition to the existing kubernetes-based tests. Also loops it to test reuse of the reservable ClusterInsts.

No code change is needed as it already works, just adding regression tests.