### PR TITLE
fix image name in template

### DIFF
--- a/crm-platforms/openstack/openstack-heat.go
+++ b/crm-platforms/openstack/openstack-heat.go
@@ -380,7 +380,11 @@ resources:
         {{- end}}
       {{- end}}
       {{- if not .ExternalVolumeSize}}
+        {{- if .VMAppParams}}
+         image: {{.VMAppParams.ImageName}}
+        {{else}}
          image: {{.ImageName}}
+        {{- end}}
       {{- end}}
          flavor: {{.MasterNodeFlavor}}
          config_drive: true


### PR DESCRIPTION
EDGECLOUD-2604

When a VM App is behind a load balancer, the platform image name is used for the VM app instead of the specified image.

