### PR TITLE
Baseimage 3.1.1: Fix SSH issues

### DIFF
--- a/mexos/cloudletinfra.go
+++ b/mexos/cloudletinfra.go
@@ -44,7 +44,7 @@ type CommonPlatform struct {
 	mappedExternalIPs map[string]string
 }
 
-var MEXInfraVersion = "3.1.0"
+var MEXInfraVersion = "3.1.1"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 var ImageFormatQcow2 = "qcow2"

--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 3.1.0
+VERSION = 3.1.1
 DISTRIBUTION = stratus
 COMPONENT = main
 


### PR DESCRIPTION
Disable the systemd config option which would prevent ssh restart if
process dies with a 255 exit code.

```
# diff /lib/systemd/system/ssh.service /etc/systemd/system/ssh.service
14d13
< RestartPreventExitStatus=255
```

Also install cronjob to clean up stale SSH session files which can clog
up /run.