### PR TITLE
EDGECLOUD-2658 clear org deleteInProgress flag

### DIFF
--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -147,6 +147,10 @@ func DeleteOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.Organizat
 	// delete org
 	err = db.Delete(&org).Error
 	if err != nil {
+		undoerr := markOrgForDelete(db, org.Name, !doMark)
+		if undoerr != nil {
+			log.SpanLog(ctx, log.DebugLevelApi, "undo mark org for delete", "undoerr", undoerr)
+		}
 		if strings.Contains(err.Error(), "violates foreign key constraint \"org_cloudlet_pools_org_fkey\"") {
 			return fmt.Errorf("Cannot delete organization because it is referenced by an OrgCloudletPool")
 		}


### PR DESCRIPTION
One error case in org delete failed to undo the deleteInProgress flag, making it stuck on the org and subsequently unable to create or delete anything that references the org. This particular error case is somewhat unlikely to hit, though.