### PR TITLE
fix unit test for heat

### DIFF
--- a/crm-platforms/openstack/openstack_heat_test.go
+++ b/crm-platforms/openstack/openstack_heat_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	e2esetup "github.com/mobiledgex/edge-cloud-infra/e2e-tests/e2e-setup"
+	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
 	pf "github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -59,6 +60,7 @@ func TestHeatTemplate(t *testing.T) {
 	log.InitTracer("")
 	defer log.FinishTracer()
 	log.SetDebugLevel(log.DebugLevelInfra)
+	infracommon.SetTestMode(true)
 
 	ctx := log.StartTestSpan(context.Background())
 	vaultServer, vaultConfig := vault.DummyServer()


### PR DESCRIPTION
heat unit test was failing if the MEX_CF_USER and MEX_CF_KEY env var are not set in the local environment.  

Fix is to set test mode to allow this to be ignored