### PR TITLE
EDGECLOUD-2551 audit ShowLogs

### DIFF
--- a/mc/orm/auditlog.go
+++ b/mc/orm/auditlog.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/middleware"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
+	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/tls"
 )
@@ -26,8 +27,10 @@ func logger(next echo.HandlerFunc) echo.HandlerFunc {
 
 		lvl := log.DebugLevelApi
 
+		path := strings.Split(req.RequestURI, "/")
+		method := path[len(path)-1]
 		if strings.Contains(req.RequestURI, "show") ||
-			strings.Contains(req.RequestURI, "Show") ||
+			edgeproto.IsShow(method) ||
 			strings.Contains(req.RequestURI, "/auth/user/current") ||
 			strings.Contains(req.RequestURI, "/metrics/") ||
 			strings.Contains(req.RequestURI, "/ctrl/Stream") ||


### PR DESCRIPTION
Take into account any non-standard-show commands when determining if something is a "show" or not for audit logging. See edge-cloud PR https://github.com/mobiledgex/edge-cloud/pull/919