### PR TITLE
Allow upgrades to target only the MC or the console

### DIFF
--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -13,42 +13,45 @@
     - console
   gather_facts: no
   tasks:
-    - set_fact:
-        github_user: "{{ lookup('env', 'GITHUB_USER') }}"
-      when: github_user is not defined or not github_user
+    - block:
+      - set_fact:
+          github_user: "{{ lookup('env', 'GITHUB_USER') }}"
+        when: github_user is not defined or not github_user
 
-    - set_fact:
-        github_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
-      when: github_token is not defined or not github_token
+      - set_fact:
+          github_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
+        when: github_token is not defined or not github_token
 
-    - set_fact:
-        console_version_not_provided: true
-      when: console_version is not defined
+      - set_fact:
+          console_version_not_provided: true
+        when: console_version is not defined
 
-    - name: Get latest edge-cloud-ui release from Github
-      uri:
-        url: https://api.github.com/repos/mobiledgex/edge-cloud-ui/releases/latest
-        user: "{{ github_user }}"
-        password: "{{ github_token }}"
-        force_basic_auth: yes
-        return_content: yes
-      register: console_tags
-      check_mode: false
-      when: console_version_not_provided | default(false)
+      - name: Get latest edge-cloud-ui release from Github
+        uri:
+          url: https://api.github.com/repos/mobiledgex/edge-cloud-ui/releases/latest
+          user: "{{ github_user }}"
+          password: "{{ github_token }}"
+          force_basic_auth: yes
+          return_content: yes
+        register: console_tags
+        check_mode: false
+        when: console_version_not_provided | default(false)
 
-    - name: Pick tag for latest release
-      set_fact:
-        console_version: "{{ console_tags.json.tag_name }}"
-      when: console_version_not_provided | default(false)
+      - name: Pick tag for latest release
+        set_fact:
+          console_version: "{{ console_tags.json.tag_name }}"
+        when: console_version_not_provided | default(false)
 
-    - assert:
-        that:
-          - console_version is defined
+      - assert:
+          that:
+            - console_version is defined
 
-    - pause:
-        prompt: "Installing the latest console release: {{ console_version }}"
-        seconds: 30
-      when: console_version_not_provided | default(false)
+      - pause:
+          prompt: "Installing the latest console release: {{ console_version }}"
+          seconds: 30
+        when: console_version_not_provided | default(false)
+
+      tags: console
 
 - name: Set up vault auth, policies, and roles
   import_playbook: vault-setup.yml
@@ -177,6 +180,7 @@
       tags: setup
     - import_role:
         name: console
+      tags: console
     - import_role:
         name: mc
       tags: mc


### PR DESCRIPTION
As console and MC are co-hosted on the same VM, ansible deployments typically update both. QA especially need a way to update just the console and skip the MC. With this change, it is possible to deploy either just the MC or the console.
```
./deploy -s mc staging console         # Deploy console only (skip MC)
./deploy -s console staging console    # Deploy MC only (skip console)
```
(Console changes are mainly whitespace. Only change is the moving of all tasks into a block which has a "console" tag at the end.)