### PR TITLE
EDGECLOUD-1740: MC API error message not consistent for 400 and 403 errors

### DIFF
--- a/mc/orm/reply.go
+++ b/mc/orm/reply.go
@@ -72,6 +72,7 @@ func setReply(c echo.Context, err error, data interface{}) error {
 		// If error is HTTPError, pull out the message to prevent redundant status code info
 		if e, ok := err.(*echo.HTTPError); ok {
 			err = fmt.Errorf("%v", e.Message)
+			code = e.Code
 		}
 		return c.JSON(code, MsgErr(err))
 	}


### PR DESCRIPTION
If getControllerAddrForRegion returns a non-nil err, return an echo.HTTPError error that wraps the "bad region" error 