### PR TITLE
init debug commands

### DIFF
--- a/crm-platforms/openstack/openstack.go
+++ b/crm-platforms/openstack/openstack.go
@@ -25,6 +25,7 @@ func (o *OpenstackPlatform) SetVMProperties(vmProperties *vmlayer.VMProperties) 
 }
 
 func (o *OpenstackPlatform) InitProvider(ctx context.Context) error {
+	o.initDebug(o.vmProperties.CommonPf.PlatformConfig.NodeMgr)
 	return o.PrepNetwork(ctx)
 }
 


### PR DESCRIPTION
EDGECLOUD-2787 

After CRM refactor, the initDebug for OpenStack was no longer getting called because I missed it during merge.

