### PR TITLE
Reliable alerts for CPU/memory/disk usage in infra

### DIFF
--- a/ansible/files/kapacitor/tasks/cpu-usage.tick
+++ b/ansible/files/kapacitor/tasks/cpu-usage.tick
@@ -1,60 +1,68 @@
 dbrp "telegraf"."autogen"
 
-var name = 'CPU Alert Usage'
+var name = 'CPU Usage Alert'
+
 var db = 'telegraf'
+
 var rp = 'autogen'
 
-var info = 30
-var warn = 60
+var info = 70
+
+var warn = 80
+
 var crit = 90
 
-var infoSig = 2.5
-var warnSig = 3
-var critSig = 3.5
+var infoSig = 4
 
-var period = 5m
-var every = 5m
+var warnSig = 5
+
+var critSig = 6
+
+var period = 1h
+
+var every = 1h
 
 var idVar = name + ':{{.Group}}'
+
 var idTag = 'alertID'
+
 var outputDB = 'chronograf'
+
 var outputRP = 'autogen'
+
 var outputMeasurement = 'alerts'
+
 var triggerType = 'threshold'
 
 // Dataframe
-var data = stream
-    |from()
-        .database('telegraf')
-        .retentionPolicy('autogen')
-        .measurement('cpu')
-        .groupBy('host')
-        .where(lambda: "cpu" == 'cpu-total')
-    |eval(lambda: 100.0 - "usage_idle")
-        .as('used')
-    |window()
+var data = batch
+    |query(''' SELECT mean("usage_idle") AS "mean_usage_idle" FROM "telegraf"."autogen"."cpu" ''')
         .period(period)
         .every(every)
+        .groupBy('host')
+    |eval(lambda: 100.0 - "mean_usage_idle")
+        .as('used')
     |mean('used')
         .as('stat')
-    |eval(lambda: floor("used" * 100.0) / 100.0)
-        .as('stat_round')
 
 // Thresholds
 var trigger = data
     |eval(lambda: sigma("stat"))
         .as('sigma')
         .keep()
+    |eval(lambda: floor("stat" * 100.0) / 100.0)
+        .as('stat_round')
+        .keep()
     |alert()
         .id(idVar)
-        .message('{{ .ID }} is {{.Level}}: {{ index .Fields "stat_round" }}')
+        .message(' {{ .ID }} is {{.Level}}: {{ index .Fields "stat_round" }}% mean CPU usage')
         .info(lambda: "stat" > info OR "sigma" > infoSig)
         .warn(lambda: "stat" > warn OR "sigma" > warnSig)
         .crit(lambda: "stat" > crit OR "sigma" > critSig)
         .slack()
 
 trigger
-    |eval(lambda: float("used"))
+    |eval(lambda: float("stat"))
         .as('used')
         .keep()
     |influxDBOut()
@@ -64,6 +72,3 @@ trigger
         .measurement(outputMeasurement)
         .tag('alertName', name)
         .tag('triggerType', triggerType)
-
-trigger
-    |httpOut('output')

--- a/ansible/files/kapacitor/tasks/disk-usage.tick
+++ b/ansible/files/kapacitor/tasks/disk-usage.tick
@@ -1,51 +1,67 @@
 dbrp "telegraf"."autogen"
 
+var name = 'Disk Usage Alert'
+
 var db = 'telegraf'
+
 var rp = 'autogen'
 
-var measurement = 'disk'
-var groupBy = ['host']
-var whereFilter = lambda: ("path" == '/')
-var name = 'Disk Usage Alert'
-var idVar = name + '-{{.Group}}'
-var message = '{{.ID}} is {{.Level}}: usage {{ index .Fields "value" }}%'
+var info = 80
+
+var warn = 85
+
+var crit = 90
+
+var infoSig = 4
+
+var warnSig = 5
+
+var critSig = 6
+
+var period = 1h
+
+var every = 1h
+
+var idVar = name + ':{{.Group}}'
+
 var idTag = 'alertID'
-var levelTag = 'level'
-var messageField = 'message'
-var durationField = 'duration'
 
 var outputDB = 'chronograf'
+
 var outputRP = 'autogen'
+
 var outputMeasurement = 'alerts'
+
 var triggerType = 'threshold'
 
-var crit = 70
+// Dataframe
+var data = batch
+    |query(''' SELECT mean("used_percent") AS "used" FROM "telegraf"."autogen"."disk" ''')
+        .period(period)
+        .every(every)
+        .groupBy('host')
+    |mean('used')
+        .as('stat')
 
-var data = stream
-    |from()
-        .database(db)
-        .retentionPolicy(rp)
-        .measurement(measurement)
-        .groupBy(groupBy)
-        .where(whereFilter)
-    |eval(lambda: floor("used_percent" * 100.0) / 100.0)
-        .as('value')
-
+// Thresholds
 var trigger = data
+    |eval(lambda: sigma("stat"))
+        .as('sigma')
+        .keep()
+    |eval(lambda: floor("stat" * 100.0) / 100.0)
+        .as('stat_round')
+        .keep()
     |alert()
-        .crit(lambda: "value" > crit)
-        .stateChangesOnly(30m)
-        .message(message)
         .id(idVar)
-        .idTag(idTag)
-        .levelTag(levelTag)
-        .messageField(messageField)
-        .durationField(durationField)
+        .message(' {{ .ID }} is {{.Level}}: {{ index .Fields "stat_round" }}% disk usage')
+        .info(lambda: "stat" > info OR "sigma" > infoSig)
+        .warn(lambda: "stat" > warn OR "sigma" > warnSig)
+        .crit(lambda: "stat" > crit OR "sigma" > critSig)
         .slack()
 
 trigger
-    |eval(lambda: float("value"))
-        .as('value')
+    |eval(lambda: float("stat"))
+        .as('used')
         .keep()
     |influxDBOut()
         .create()
@@ -54,6 +70,3 @@ trigger
         .measurement(outputMeasurement)
         .tag('alertName', name)
         .tag('triggerType', triggerType)
-
-trigger
-    |httpOut('output')

--- a/ansible/files/kapacitor/tasks/memory-usage.tick
+++ b/ansible/files/kapacitor/tasks/memory-usage.tick
@@ -1,50 +1,67 @@
 dbrp "telegraf"."autogen"
 
+var name = 'Memory Usage Alert'
+
 var db = 'telegraf'
+
 var rp = 'autogen'
 
-var measurement = 'mem'
-var groupBy = ['host']
-var whereFilter = lambda: TRUE
-var name = 'Memory Usage Alert'
-var idVar = name + '-{{.Group}}'
-var message = ' {{.ID}} is {{.Level}}: usage {{ index .Fields "value" }}%'
+var info = 80
+
+var warn = 85
+
+var crit = 90
+
+var infoSig = 4
+
+var warnSig = 5
+
+var critSig = 6
+
+var period = 1h
+
+var every = 1h
+
+var idVar = name + ':{{.Group}}'
+
 var idTag = 'alertID'
-var levelTag = 'level'
-var messageField = 'message'
-var durationField = 'duration'
 
 var outputDB = 'chronograf'
+
 var outputRP = 'autogen'
+
 var outputMeasurement = 'alerts'
+
 var triggerType = 'threshold'
 
-var crit = 70
+// Dataframe
+var data = batch
+    |query('''SELECT mean("used_percent") AS "used" FROM "telegraf"."autogen"."mem" ''')
+        .period(period)
+        .every(every)
+        .groupBy('host')
+    |mean('used')
+        .as('stat')
 
-var data = stream
-    |from()
-        .database(db)
-        .retentionPolicy(rp)
-        .measurement(measurement)
-        .groupBy(groupBy)
-        .where(whereFilter)
-    |eval(lambda: "")
-        .as('value')
-
+// Thresholds
 var trigger = data
+    |eval(lambda: sigma("stat"))
+        .as('sigma')
+        .keep()
+    |eval(lambda: floor("stat" * 100.0) / 100.0)
+        .as('stat_round')
+        .keep()
     |alert()
-        .crit(lambda: "value" > crit)
-        .message(message)
         .id(idVar)
-        .idTag(idTag)
-        .levelTag(levelTag)
-        .messageField(messageField)
-        .durationField(durationField)
+        .message(' {{ .ID }} is {{.Level}}: {{ index .Fields "stat_round" }}% mean memory usage')
+        .info(lambda: "stat" > info OR "sigma" > infoSig)
+        .warn(lambda: "stat" > warn OR "sigma" > warnSig)
+        .crit(lambda: "stat" > crit OR "sigma" > critSig)
         .slack()
 
 trigger
-    |eval(lambda: float("value"))
-        .as('value')
+    |eval(lambda: float("stat"))
+        .as('used')
         .keep()
     |influxDBOut()
         .create()
@@ -53,6 +70,3 @@ trigger
         .measurement(outputMeasurement)
         .tag('alertName', name)
         .tag('triggerType', triggerType)
-
-trigger
-    |httpOut('output')


### PR DESCRIPTION
Switching to batch mode queries which seem to be more reliable than
streaming data alerts.