### PR TITLE
Fix jaeger restarts in staging/QA

### DIFF
--- a/ansible/roles/jaeger/tasks/main.yml
+++ b/ansible/roles/jaeger/tasks/main.yml
@@ -41,6 +41,7 @@
           BADGER_EPHEMERAL: "false"
           BADGER_DIRECTORY_VALUE: /badger/data
           BADGER_DIRECTORY_KEY: /badger/key
+          BADGER_TRUNCATE: "true"
         volumes:
           - "{{ jaeger_local_storage_dir }}:/badger"
         ports:


### PR DESCRIPTION
Jaeger staging/QA uses a local file-based database whose white-ahead
log might get corrupted if the container crashes--which stops jaeger
from coming back up.  Adding an option to truncate the WAL during
restart which gets rid of this issue at the expense of some potential
data loss, which should be acceptable for staging/QA jaeger.