### PR TITLE
Jenkins job to update staging console

### DIFF
--- a/jenkins/console-deploy.Jenkinsfile
+++ b/jenkins/console-deploy.Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
             steps {
                 dir(path: 'ansible') {
                     ansiColor('xterm') {
-                        sh label: 'Run ansible playbook', script: '''$!/bin/bash
+                        sh label: 'Run ansible playbook', script: '''#!/bin/bash
 export ANSIBLE_FORCE_COLOR=true
 export GITHUB_USER="${GITHUB_CREDS_USR}"
 export GITHUB_TOKEN="${GITHUB_CREDS_PSW}"


### PR DESCRIPTION
Fix the jenkins job to trigger console updates in staging. This will be used from within a Github action from the UI repo so that staging console upgrades are automatic decoupled from the daily platform upgrade.