### PR TITLE
WWT fixes

### DIFF
--- a/crm-platforms/openstack/openstack-heat.go
+++ b/crm-platforms/openstack/openstack-heat.go
@@ -188,8 +188,8 @@ func reindent16(str string) string {
 	return reindent(str, 16)
 }
 
-func (o *OpenstackPlatform) getFreeFloatingIpid(ctx context.Context) (string, error) {
-	fips, err := o.ListFloatingIPs(ctx)
+func (o *OpenstackPlatform) getFreeFloatingIpid(ctx context.Context, extNet string) (string, error) {
+	fips, err := o.ListFloatingIPs(ctx, extNet)
 	if err != nil {
 		return "", fmt.Errorf("Unable to list floating IPs %v", err)
 	}
@@ -336,9 +336,9 @@ func (o *OpenstackPlatform) populateParams(ctx context.Context, VMGroupOrchestra
 		var sns []OSSubnet
 		var snserr error
 		if action != heatTest {
-			sns, snserr = o.ListSubnets(ctx, VMGroupOrchestrationParams.Netspec.Name)
+			sns, snserr = o.ListSubnets(ctx, o.VMProperties.GetCloudletMexNetwork())
 			if snserr != nil {
-				return fmt.Errorf("can't get list of subnets for %s, %v", VMGroupOrchestrationParams.Netspec.Name, snserr)
+				return fmt.Errorf("can't get list of subnets for %s, %v", o.VMProperties.GetCloudletMexNetwork(), snserr)
 			}
 			for _, s := range sns {
 				usedCidrs[s.Subnet] = s.Name
@@ -408,7 +408,7 @@ func (o *OpenstackPlatform) populateParams(ctx context.Context, VMGroupOrchestra
 			if action == heatTest {
 				fipid = "test-fip-id"
 			} else {
-				fipid, err = o.getFreeFloatingIpid(ctx)
+				fipid, err = o.getFreeFloatingIpid(ctx, VMGroupOrchestrationParams.Netspec.FloatingIPExternalNet)
 				if err != nil {
 					return err
 				}

--- a/crm-platforms/openstack/openstack-network.go
+++ b/crm-platforms/openstack/openstack-network.go
@@ -159,7 +159,7 @@ func (o *OpenstackPlatform) PrepNetwork(ctx context.Context) error {
 			return err
 		}
 		// We need at least one network for `mex` clusters
-		err = o.CreateNetwork(ctx, o.VMProperties.GetCloudletMexNetwork(), ni.NetworkType)
+		err = o.CreateNetwork(ctx, o.VMProperties.GetCloudletMexNetwork(), ni.NetworkType, o.VMProperties.GetCloudletNetworkAvailabilityZone())
 		if err != nil {
 			return fmt.Errorf("cannot create mex network %s, %v", o.VMProperties.GetCloudletMexNetwork(), err)
 		}

--- a/vmlayer/ip.go
+++ b/vmlayer/ip.go
@@ -32,17 +32,18 @@ type RouterDetail struct {
 }
 
 type NetSpecInfo struct {
-	Name, CIDR        string
-	NetworkType       string
-	NetworkAddress    string
-	NetmaskBits       string
-	Octets            []string
-	MasterIPLastOctet string
-	DelimiterOctet    int // this is the X
-	FloatingIPNet     string
-	FloatingIPSubnet  string
-	VnicType          string
-	RouterGatewayIP   string
+	CIDR                  string
+	NetworkType           string
+	NetworkAddress        string
+	NetmaskBits           string
+	Octets                []string
+	MasterIPLastOctet     string
+	DelimiterOctet        int // this is the X
+	FloatingIPNet         string
+	FloatingIPSubnet      string
+	FloatingIPExternalNet string
+	VnicType              string
+	RouterGatewayIP       string
 }
 
 //ParseNetSpec decodes netspec string
@@ -64,13 +65,15 @@ func ParseNetSpec(ctx context.Context, netSpec string) (*NetSpecInfo, error) {
 
 		switch k {
 		case "name":
-			ni.Name = v
+			log.SpanLog(ctx, log.DebugLevelInfra, "netspec name obsolete")
 		case "cidr":
 			ni.CIDR = v
 		case "floatingipnet":
 			ni.FloatingIPNet = v
 		case "floatingipsubnet":
 			ni.FloatingIPSubnet = v
+		case "floatingipextnet":
+			ni.FloatingIPExternalNet = v
 		case "vnictype":
 			ni.VnicType = v
 		case "routergateway":
@@ -80,9 +83,6 @@ func ParseNetSpec(ctx context.Context, netSpec string) (*NetSpecInfo, error) {
 		default:
 			return nil, fmt.Errorf("unknown netspec item key: %s", k)
 		}
-	}
-	if ni.Name == "" {
-		return nil, fmt.Errorf("Missing name=(value) in netspec")
 	}
 	if ni.CIDR == "" {
 		return nil, fmt.Errorf("Missing cidr=(value) in netspec")

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -48,41 +48,42 @@ var DefaultCloudletVMImagePath = "https://artifactory.mobiledgex.net/artifactory
 var VMProviderProps = map[string]*infracommon.PropertyInfo{
 	// Property: Default-Value
 
-	"MEX_EXT_NETWORK": &infracommon.PropertyInfo{
+	"MEX_EXT_NETWORK": {
 		Value: "external-network-shared",
 	},
-	"MEX_NETWORK": &infracommon.PropertyInfo{
+	"MEX_NETWORK": {
 		Value: "mex-k8s-net-1",
 	},
 	// note OS_IMAGE refers to Operating System
-	"MEX_OS_IMAGE": &infracommon.PropertyInfo{
+	"MEX_OS_IMAGE": {
 		Value: DefaultOSImageName,
 	},
-	"MEX_SECURITY_GROUP": &infracommon.PropertyInfo{
+	"MEX_SECURITY_GROUP": {
 		Value: "default",
 	},
-	"MEX_SHARED_ROOTLB_RAM": &infracommon.PropertyInfo{
+	"MEX_SHARED_ROOTLB_RAM": {
 		Value: "4096",
 	},
-	"MEX_SHARED_ROOTLB_VCPUS": &infracommon.PropertyInfo{
+	"MEX_SHARED_ROOTLB_VCPUS": {
 		Value: "2",
 	},
-	"MEX_SHARED_ROOTLB_DISK": &infracommon.PropertyInfo{
+	"MEX_SHARED_ROOTLB_DISK": {
 		Value: "40",
 	},
-	"MEX_NETWORK_SCHEME": &infracommon.PropertyInfo{
-		Value: "name=mex-k8s-net-1,cidr=10.101.X.0/24",
+	"MEX_NETWORK_SCHEME": {
+		Value: "cidr=10.101.X.0/24",
 	},
-	"MEX_COMPUTE_AVAILABILITY_ZONE": &infracommon.PropertyInfo{},
-	"MEX_VOLUME_AVAILABILITY_ZONE":  &infracommon.PropertyInfo{},
-	"MEX_IMAGE_DISK_FORMAT": &infracommon.PropertyInfo{
+	"MEX_COMPUTE_AVAILABILITY_ZONE": {},
+	"MEX_NETWORK_AVAILABILITY_ZONE": {},
+	"MEX_VOLUME_AVAILABILITY_ZONE":  {},
+	"MEX_IMAGE_DISK_FORMAT": {
 		Value: ImageFormatQcow2,
 	},
-	"MEX_ROUTER": &infracommon.PropertyInfo{
+	"MEX_ROUTER": {
 		Value: NoExternalRouter,
 	},
-	"MEX_CRM_GATEWAY_ADDR": &infracommon.PropertyInfo{},
-	"MEX_SUBNET_DNS":       &infracommon.PropertyInfo{},
+	"MEX_CRM_GATEWAY_ADDR": {},
+	"MEX_SUBNET_DNS":       {},
 }
 
 func GetVaultCloudletCommonPath(filePath string) string {
@@ -173,6 +174,10 @@ func (vp *VMProperties) GetCloudletVolumeAvailabilityZone() string {
 
 func (vp *VMProperties) GetCloudletComputeAvailabilityZone() string {
 	return vp.CommonPf.Properties["MEX_COMPUTE_AVAILABILITY_ZONE"].Value
+}
+
+func (vp *VMProperties) GetCloudletNetworkAvailabilityZone() string {
+	return vp.CommonPf.Properties["MEX_NETWORK_AVAILABILITY_ZONE"].Value
 }
 
 func (vp *VMProperties) GetCloudletImageDiskFormat() string {


### PR DESCRIPTION
Two issues for WWT:

1) WWT's new centralized control plane lab requires yet another type of availability zone, this time for networks.

Allow the AZ to be optionally specified when creating the internal network

2) In the centralized environment there are multiple external networks to be used as floating networks.  The code currently just assumes one external network for this.   Add an additional netspec param to deal with this, "FloatingIPExternalNet".  

Also, removing the "Name" from netspec because there are 2 separate places where we configure the mex internal network, via netspec and via MEX_NETWORK. They have the same defaults and mean the same thing but a couple places in the code reference netspec.Name and the rest refer to MEX_NETWORK.  Consolidate this