### PR TITLE
EDGECLOUD-2875: controller crash when doing DeleteCloudlet

### DIFF
--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -474,6 +474,16 @@ func (v *VMPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 		return nil
 	}
 
+	pc := pf.PlatformConfig{
+		CloudletKey: &cloudlet.Key,
+		AppDNSRoot:  pfConfig.AppDnsRoot,
+	}
+
+	err = v.InitProps(ctx, &pc, vaultConfig)
+	if err != nil {
+		return err
+	}
+
 	platformVMName := v.GetPlatformVMName(&cloudlet.Key)
 	updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Deleting PlatformVM %s", platformVMName))
 	err = v.VMProvider.DeleteVMs(ctx, platformVMName)


### PR DESCRIPTION
```
func (v *VMPlatform) GetRootLBName(key *edgeproto.CloudletKey) string {
        name := cloudcommon.GetRootLBFQDN(key, v.VMProperties.CommonPf.PlatformConfig.AppDNSRoot)
        return v.VMProvider.NameSanitize(name)
}
```
PlatformConfig was missing from commonPf. Fixed it.