### PR TITLE
Support for deployment of production console builds

### DIFF
--- a/ansible/development/list
+++ b/ansible/development/list
@@ -22,6 +22,7 @@ azure_volume_storage_class=default
 influxdb_volume_size=1Gi
 vault_firewall_setup=no
 vault_ha_domain="vault-{{ deploy_environ }}.mobiledgex.net"
+console_prod=no
 
 [notifyroot]
 notifyroot-dev.mobiledgex.net

--- a/ansible/main/list
+++ b/ansible/main/list
@@ -15,6 +15,7 @@ vault_port=443
 vault_firewall_setup=no
 letsencrypt_env=production
 console_vm_hostname=console.mobiledgex.net
+console_prod=yes
 
 [notifyroot]
 notifyroot.mobiledgex.net

--- a/ansible/mexdemo/list
+++ b/ansible/mexdemo/list
@@ -18,6 +18,7 @@ gitlab_email_enabled=false
 gitlab_docker_hostname="docker.mobiledgex.net"
 azure_volume_storage_class=managed-premium
 influxdb_volume_size=5Gi
+console_prod=yes
 
 [platform]
 localhost	ansible_connection=local

--- a/ansible/qa/list
+++ b/ansible/qa/list
@@ -23,6 +23,7 @@ toksrv_url="http://mexdemo.tok.mobiledgex.net:9999/its?followURL=https://dme.mob
 dme_carrier=TDG
 operator_key=TDG
 deploy_target="mexplat-{{ deploy_environ }}"
+console_prod=no
 
 [notifyroot]
 notifyroot-qa.mobiledgex.net

--- a/ansible/roles/console/tasks/main.yml
+++ b/ansible/roles/console/tasks/main.yml
@@ -14,11 +14,10 @@
 - name: Deploy the console
   docker_container:
     name: "console-{{ deploy_environ }}"
-    image: "{{ console_image }}:{{ console_version }}"
+    image: "{% if console_prod|bool %}{{ console_prod_image }}{% else %}{{ console_image }}{% endif %}:{{ console_version }}"
     restart_policy: unless-stopped
     ports:
-      - "127.0.0.1:3000:3000"
-      - "127.0.0.1:13030:3030"
+      - "127.0.0.1:3000:{% if console_prod|bool %}80{% else %}3000{% endif %}"
     env:
       REACT_APP_API_ENDPOINT: "https://{{ inventory_hostname }}"
       REACT_APP_API_VM_ENDPOINT: "https://{{ console_vnc_hostname }}"

--- a/ansible/roles/console/vars/main.yml
+++ b/ansible/roles/console/vars/main.yml
@@ -1,2 +1,3 @@
 console_image: registry.mobiledgex.net:5000/mobiledgex/console
+console_prod_image: "{{ console_image }}-prod"
 slack_channel: "#web-ui"

--- a/ansible/staging/list
+++ b/ansible/staging/list
@@ -22,6 +22,7 @@ gitlab_docker_hostname="docker-{{ deploy_environ }}.mobiledgex.net"
 azure_volume_storage_class=managed-premium
 influxdb_volume_size=5Gi
 letsencrypt_env=production
+console_prod=yes
 
 [notifyroot]
 notifyroot-stage.mobiledgex.net

--- a/ansible/templates/mexplat/console-nginx-config.j2
+++ b/ansible/templates/mexplat/console-nginx-config.j2
@@ -14,7 +14,29 @@ ange';
         add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH';
 
 	location / {
-		proxy_pass https://127.0.0.1:3000;
+
+		{% if console_prod|bool %}
+		gzip on;
+		gzip_disable "msie6";
+
+		gzip_comp_level 6;
+		gzip_min_length 1100;
+		gzip_buffers 16 8k;
+		gzip_proxied any;
+		gzip_types
+				text/plain
+				text/css
+				text/js
+				text/xml
+				text/javascript
+				application/javascript
+				application/json
+				application/xml
+				application/rss+xml
+				image/svg+xml;
+		{% endif %}
+
+		proxy_pass {% if console_prod|bool %}http{% else %}https{% endif %}://127.0.0.1:3000;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "upgrade";


### PR DESCRIPTION
The `console_prod` parameter controls whether the development or
production build of the console gets deployed in a setup.  Currently,
main and staging are configured to have the production version deployed,
and QA and dev will use the development version.

This can be overridden at deployment time by passing the `console_prod`
parameter as an argument to `deploy.sh`. For instance, to deploy the
production version of the console in QA:

```
./deploy.sh -e console_prod=yes qa console
```

The actual builds of the dev and prod images happen in the edge-cloud-ui
repo.