### PR TITLE
Add qemu-utils to docker base image

### DIFF
--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -33,7 +33,8 @@ RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" >/etc/apt/sourc
 RUN apt-get update && apt-get install -y \
 	azure-cli=2.0.75-1~bionic \
 	google-cloud-sdk=267.0.0-0 \
-	kubectl=1.16.2-00
+	kubectl=1.16.2-00 \
+	qemu-utils=1:2.11+dfsg-1ubuntu7.26
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Package differences after this change:
```
< ii  ca-certificate 20180409     all          Common CA certificates
---
> ii  ca-certificate 20190110~18. all          Common CA certificates
```

New packages:
```
ii  ibverbs-provid 17.1-1ubuntu amd64        User space provider drivers for l
ii  libaio1:amd64  0.3.110-5ubu amd64        Linux kernel AIO access library -
ii  libcurl3-gnutl 7.58.0-2ubun amd64        easy-to-use client-side URL trans
ii  libibverbs1:am 17.1-1ubuntu amd64        Library for direct userspace use
ii  libiscsi7:amd6 1.17.0-1.1   amd64        iSCSI client shared library
ii  libnl-3-200:am 3.2.29-0ubun amd64        library for dealing with netlink
ii  libnl-route-3- 3.2.29-0ubun amd64        library for dealing with netlink
ii  libnspr4:amd64 2:4.18-1ubun amd64        NetScape Portable Runtime Library
ii  libnss3:amd64  2:3.35-2ubun amd64        Network Security Service librarie
ii  librados2      12.2.12-0ubu amd64        RADOS distributed object store cl
ii  librbd1        12.2.12-0ubu amd64        RADOS block device client library
ii  qemu-block-ext 1:2.11+dfsg- amd64        extra block backend modules for q
ii  qemu-utils     1:2.11+dfsg- amd64        QEMU utilities
ii  sharutils      1:4.15.2-3   amd64        shar, unshar, uuencode, uudecode
```

No changes in python package list