### PR TITLE
EDGECLOUD-2932: CRM crashed while parsing k8s manifest

### DIFF
--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -179,6 +179,7 @@ var AppOptionalArgs = []string{
 	"accesstype",
 	"defaultprivacypolicy",
 	"autoprovpolicies",
+	"templatedelimiter",
 }
 var AppAliasArgs = []string{
 	"fields=app.fields",
@@ -210,6 +211,7 @@ var AppAliasArgs = []string{
 	"defaultprivacypolicy=app.defaultprivacypolicy",
 	"deleteprepare=app.deleteprepare",
 	"autoprovpolicies=app.autoprovpolicies",
+	"templatedelimiter=app.templatedelimiter",
 }
 var AppComments = map[string]string{
 	"fields":                  "Fields are used for the Update API to specify which fields to apply",
@@ -241,6 +243,7 @@ var AppComments = map[string]string{
 	"defaultprivacypolicy":    "Privacy policy when creating auto cluster",
 	"deleteprepare":           "Preparing to be deleted",
 	"autoprovpolicies":        "Auto provisioning policy names",
+	"templatedelimiter":       "Delimiter to be used for template parsing, defaults to [[ ]]",
 }
 var AppSpecialArgs = map[string]string{
 	"app.autoprovpolicies": "StringArray",

--- a/mc/orm/alert.mc2.go
+++ b/mc/orm/alert.mc2.go
@@ -808,6 +808,7 @@ func addControllerApis(method string, group *echo.Group) {
 	// DefaultPrivacyPolicy: 30
 	// DeletePrepare: 31
 	// AutoProvPolicies: 32
+	// TemplateDelimiter: 33
 	// ```
 	// Security:
 	//   Bearer:

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -284,7 +284,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		if appInst.Uri != "" && ip.ExternalAddr != "" {
 			fqdn := appInst.Uri
 			configs := append(app.Configs, appInst.Configs...)
-			aac, err := access.GetAppAccessConfig(ctx, configs)
+			aac, err := access.GetAppAccessConfig(ctx, configs, app.TemplateDelimiter)
 			if err != nil {
 				return err
 			}
@@ -448,7 +448,7 @@ func (v *VMPlatform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.C
 		if !app.InternalPorts {
 			// Clean up DNS entries
 			configs := append(app.Configs, appInst.Configs...)
-			aac, err := access.GetAppAccessConfig(ctx, configs)
+			aac, err := access.GetAppAccessConfig(ctx, configs, app.TemplateDelimiter)
 			if err != nil {
 				return err
 			}
@@ -481,7 +481,7 @@ func (v *VMPlatform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.C
 		if appInst.Uri != "" {
 			fqdn := appInst.Uri
 			configs := append(app.Configs, appInst.Configs...)
-			aac, err := access.GetAppAccessConfig(ctx, configs)
+			aac, err := access.GetAppAccessConfig(ctx, configs, app.TemplateDelimiter)
 			if err != nil {
 				return err
 			}

--- a/vmlayer/security.go
+++ b/vmlayer/security.go
@@ -31,7 +31,7 @@ func (v *VMPlatform) AddProxySecurityRulesAndPatchDNS(ctx context.Context, clien
 		return nil
 	}
 	configs := append(app.Configs, appInst.Configs...)
-	aac, err := access.GetAppAccessConfig(ctx, configs)
+	aac, err := access.GetAppAccessConfig(ctx, configs, app.TemplateDelimiter)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Corresponding changes for edge-cloud PR: https://github.com/mobiledgex/edge-cloud/pull/950