### PR TITLE
EDGECLOUD-2952 CRM crash during deleteappinst after a failed create

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -426,6 +426,7 @@ func (v *VMPlatform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.C
 				v.DeleteProxySecurityGroupRules(ctx, client, dockermgmt.GetContainerName(&app.Key), secGrp, appInst.MappedPorts, app, rootLBName)
 				return nil
 			}
+			return err
 		}
 		// Add crm local replace variables
 		deploymentVars := crmutil.DeploymentReplaceVars{


### PR DESCRIPTION
We were not handling the error properly. Have fixed it now.