### PR TITLE
Bring back Slack channel automation

### DIFF
--- a/ansible/internal
+++ b/ansible/internal
@@ -15,7 +15,7 @@ vouch.mobiledgex.net
 es01.es.mobiledgex.net		cert_wildcard_domain=es.mobiledgex.net es_instance=main
 
 [slack]
-infra.internal.mobiledgex.net
+spook.mobiledgex.net
 
 [apt]
 apt.mobiledgex.net

--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -502,7 +502,6 @@
     slack_org_mgmt_log: slack-org-mgmt.log
     skipped_channel_file: "{{ ansible_env.HOME }}/skipped-channels.txt"
     support_users:
-      - michal.skiba@mobiledgex.com
       - thomas.vits@mobiledgex.com
       - wonho.park@mobiledgex.com
 


### PR DESCRIPTION
During our GCP spring cleaning, the VM that used to run the Slack
channel automation was destroyed.  Moving to another machine.