### PR TITLE
Import chef-master into terraform

### DIFF
--- a/terraform/internal/main.tf
+++ b/terraform/internal/main.tf
@@ -37,7 +37,7 @@ module "influxdb" {
   instance_size           = "custom-1-4864"
   zone                    = "${var.gcp_zone}"
   boot_disk_size          = 100
-  tags                    = [ "internal", "influxdb", "http-server", "https-server" ]
+  tags                    = [ "internal", "influxdb", "http-server", "https-server", "mosh-default" ]
   ssh_public_key_file     = "${var.ssh_public_key_file}"
 }
 
@@ -91,23 +91,6 @@ module "kibana_dns" {
   ip                            = "${module.elasticsearch.external_ip}"
 }
 
-module "infra" {
-  source                        = "../modules/vm_gcp"
-
-  instance_name                 = "${var.infra_instance_name}"
-  instance_size                 = "n1-standard-1"
-  zone                          = "${var.gcp_zone}"
-  boot_disk_size                = 20
-  tags                          = [ "mexplat-${var.environ_tag}", "infra" ]
-  ssh_public_key_file           = "${var.ssh_public_key_file}"
-}
-
-module "infra_dns" {
-  source                        = "../modules/cloudflare_record"
-  hostname                      = "${var.infra_domain_name}"
-  ip                            = "${module.infra.external_ip}"
-}
-
 module "apt" {
   source                        = "../modules/vm_gcp"
 
@@ -138,4 +121,22 @@ module "backups_dns" {
   source                        = "../modules/cloudflare_record"
   hostname                      = "${var.backups_domain_name}"
   ip                            = "${module.backups.external_ip}"
+}
+
+module "chef" {
+  source                        = "../modules/vm_gcp"
+
+  instance_name                 = "${var.chef_instance_name}"
+  instance_size                 = "n1-standard-1"
+  zone                          = "${var.chef_zone}"
+  boot_image                    = "ubuntu-1604-xenial-v20200407"
+  boot_disk_size                = 20
+  tags                          = [ "mexplat-${var.environ_tag}", "http-server", "https-server" ]
+  ssh_public_key_file           = "${var.ssh_public_key_file}"
+}
+
+module "chef_dns" {
+  source                        = "../modules/cloudflare_record"
+  hostname                      = "${var.chef_domain_name}"
+  ip                            = "${module.chef.external_ip}"
 }

--- a/terraform/internal/variables.tf
+++ b/terraform/internal/variables.tf
@@ -52,6 +52,7 @@ variable "influxdb_instance_name" {
 variable "influxdb_vm_hostname" {
   description = "InfluxDB VM domain name"
   type        = "string"
+  default     = "influxdb.internal.mobiledgex.net"
 }
 
 variable "vouch_domain_name" {
@@ -108,6 +109,18 @@ variable "backups_domain_name" {
 
 variable "backups_instance_name" {
   default     = "backups"
+}
+
+variable "chef_domain_name" {
+  default     = "chef.mobiledgex.net"
+}
+
+variable "chef_instance_name" {
+  default     = "chef-master"
+}
+
+variable "chef_zone" {
+  default     = "us-central1-a"
 }
 
 variable "ssh_public_key_file" {


### PR DESCRIPTION
This imports the existing manually created chef instance into terraform.  When we need to scale up the chef master as we roll chef out globally, we can update the config in terraform and apply it.

Also cleaned up the stale infra VM.