### PR TITLE
Add geo-coordinates to QA clusters

### DIFF
--- a/ansible/qa/group_vars/all
+++ b/ansible/qa/group_vars/all
@@ -10,6 +10,8 @@ vault_ha_zones:
 vault_github_users:
   - userid: andya072071
     role: admin
+  - userid: angshuman2508
+    role: editor
   - userid: venkytv
     role: admin
 

--- a/ansible/qa/group_vars/platform.yml
+++ b/ansible/qa/group_vars/platform.yml
@@ -2,8 +2,13 @@ regions:
   - name: mexplat-qa-us
     location: southcentralus
     region: US
+    latitude: 29.4167
+    longitude: -98.5
     kubernetes_version: 1.13.11
+
   - name: mexplat-qa-eu
     location: southcentralus
     region: EU
+    latitude: 52.3667
+    longitude: 4.9
     kubernetes_version: 1.13.11


### PR DESCRIPTION
Even though QA is not configured with a geo DNS "wifi" entry, we still
need lat-long included in the k8s clusters list.

Also adding Angshuman to the QA vault auth list.