### PR TITLE
EDGECLOUD-3033 AutoScaling thresholds below 10% fix

### DIFF
--- a/plugin/common/cluster-svc-plugin.go
+++ b/plugin/common/cluster-svc-plugin.go
@@ -34,9 +34,9 @@ var MEXPrometheusAutoScaleT = `additionalPrometheusRules:
         * on (namespace, pod) group_left(node)
           node_namespace_pod:kube_pod_info:)
       record: node:node_cpu_utilisation:avg1m
-    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"[[.NodePrefix]].*"} > bool .[[.ScaleUpCpuThresh]])
+    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"[[.NodePrefix]].*"} > bool [[printf "%.2f" .ScaleUpCpuThreshF]])
       record: 'node_cpu_high_count'
-    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"[[.NodePrefix]].*"} < bool .[[.ScaleDownCpuThresh]])
+    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"[[.NodePrefix]].*"} < bool [[printf "%.2f" .ScaleDownCpuThreshF]])
       record: 'node_cpu_low_count'
     - expr: count(kube_node_info) - count(kube_node_spec_taint)
       record: 'node_count'
@@ -66,6 +66,8 @@ type AutoScaleArgs struct {
 	AutoScaleDownName   string
 	ScaleUpCpuThresh    uint32
 	ScaleDownCpuThresh  uint32
+	ScaleUpCpuThreshF   float32
+	ScaleDownCpuThreshF float32
 	TriggerTimeSec      uint32
 	MaxNodes            int
 	MinNodes            int
@@ -87,6 +89,8 @@ func (s *ClusterSvc) GetAppInstConfigs(ctx context.Context, clusterInst *edgepro
 		AutoScaleDownName:   cloudcommon.AlertAutoScaleDown,
 		ScaleUpCpuThresh:    policy.ScaleUpCpuThresh,
 		ScaleDownCpuThresh:  policy.ScaleDownCpuThresh,
+		ScaleUpCpuThreshF:   float32(policy.ScaleUpCpuThresh) / 100.0,
+		ScaleDownCpuThreshF: float32(policy.ScaleDownCpuThresh) / 100.0,
 		TriggerTimeSec:      policy.TriggerTimeSec,
 		MaxNodes:            int(policy.MaxNodes),
 		MinNodes:            int(policy.MinNodes),

--- a/plugin/common/cluster-svc-plugin_test.go
+++ b/plugin/common/cluster-svc-plugin_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -30,10 +31,100 @@ func TestAutoScaleT(t *testing.T) {
 
 	clusterInst.AutoScalePolicy = policy.Key.Name
 
+	configExpected := `additionalPrometheusRules:
+- name: autoscalepolicy
+  groups:
+  - name: autoscale.rules
+    rules:
+    - expr: 1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
+      record: :node_cpu_utilisation:avg1m
+    - expr: |-
+        1 - avg by (node) (
+          rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
+        * on (namespace, pod) group_left(node)
+          node_namespace_pod:kube_pod_info:)
+      record: node:node_cpu_utilisation:avg1m
+    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"mex-k8s-node-.*"} > bool 0.80)
+      record: 'node_cpu_high_count'
+    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"mex-k8s-node-.*"} < bool 0.20)
+      record: 'node_cpu_low_count'
+    - expr: count(kube_node_info) - count(kube_node_spec_taint)
+      record: 'node_count'
+    - alert: AutoScaleUp
+      expr: node_cpu_high_count == node_count and node_count < 5
+      for: 60s
+      labels:
+        severity: none
+      annotations:
+        message: High cpu greater than 80% for all nodes
+        nodecount: '{{ with query "node_count" }}{{ . | first | value | humanize }}{{ end }}'
+    - alert: AutoScaleDown
+      expr: node_cpu_low_count > 0 and node_count > 1
+      for: 60s
+      labels:
+        severity: none
+      annotations:
+        message: Low cpu less than 20% for some nodes
+        lowcpunodecount: '{{ $value }}'
+        nodecount: '{{ with query "node_count" }}{{ . | first | value | humanize }}{{ end }}'
+        minnodes: '1'
+`
+	testAutoScaleT(t, ctx, &clusterInst, &policy, configExpected)
+
+	policy.MinNodes = 5
+	policy.MaxNodes = 7
+	policy.ScaleUpCpuThresh = 5
+	policy.ScaleDownCpuThresh = 1
+
+	configExpected = `additionalPrometheusRules:
+- name: autoscalepolicy
+  groups:
+  - name: autoscale.rules
+    rules:
+    - expr: 1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
+      record: :node_cpu_utilisation:avg1m
+    - expr: |-
+        1 - avg by (node) (
+          rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
+        * on (namespace, pod) group_left(node)
+          node_namespace_pod:kube_pod_info:)
+      record: node:node_cpu_utilisation:avg1m
+    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"mex-k8s-node-.*"} > bool 0.05)
+      record: 'node_cpu_high_count'
+    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"mex-k8s-node-.*"} < bool 0.01)
+      record: 'node_cpu_low_count'
+    - expr: count(kube_node_info) - count(kube_node_spec_taint)
+      record: 'node_count'
+    - alert: AutoScaleUp
+      expr: node_cpu_high_count == node_count and node_count < 7
+      for: 60s
+      labels:
+        severity: none
+      annotations:
+        message: High cpu greater than 5% for all nodes
+        nodecount: '{{ with query "node_count" }}{{ . | first | value | humanize }}{{ end }}'
+    - alert: AutoScaleDown
+      expr: node_cpu_low_count > 0 and node_count > 5
+      for: 60s
+      labels:
+        severity: none
+      annotations:
+        message: Low cpu less than 1% for some nodes
+        lowcpunodecount: '{{ $value }}'
+        nodecount: '{{ with query "node_count" }}{{ . | first | value | humanize }}{{ end }}'
+        minnodes: '5'
+`
+	testAutoScaleT(t, ctx, &clusterInst, &policy, configExpected)
+}
+
+func testAutoScaleT(t *testing.T, ctx context.Context, clusterInst *edgeproto.ClusterInst, policy *edgeproto.AutoScalePolicy, expected string) {
 	clusterSvc := ClusterSvc{}
 	appInst := edgeproto.AppInst{}
 
-	configs, err := clusterSvc.GetAppInstConfigs(ctx, &clusterInst, &appInst, &policy)
+	configs, err := clusterSvc.GetAppInstConfigs(ctx, clusterInst, &appInst, policy)
 	require.Nil(t, err)
 	require.Equal(t, 1, len(configs))
+	ioutil.WriteFile("foo", []byte(configs[0].Config), 0644)
+
+	require.Equal(t, expected, configs[0].Config)
 }


### PR DESCRIPTION
This fixes an issue where thresholds less than 10 were generating incorrect measurements. For 5 (5%), should have been 0.05, but was 0.5 because I wasn't using proper utils for generating the float.