### PR TITLE
EDGECLOUD-3043 AutoProv not deploying when MaxInstances=0

### DIFF
--- a/autoprov/autoprov_minmax.go
+++ b/autoprov/autoprov_minmax.go
@@ -492,7 +492,7 @@ func (s *AppChecker) checkPolicy(ctx context.Context, pname string, prevPolicyCl
 		go goAppInstApi(ctx, &inst, cloudcommon.Delete, cloudcommon.AutoProvReasonMinMax, pname)
 	}
 
-	if totalCount >= int(policy.MaxInstances) {
+	if totalCount >= int(policy.MaxInstances) && policy.MaxInstances != 0 {
 		// don't bother with min because we're already at max
 		return
 	}

--- a/autoprov/autoprov_minmax_test.go
+++ b/autoprov/autoprov_minmax_test.go
@@ -227,6 +227,29 @@ func TestAppChecker(t *testing.T) {
 	err = dc.waitForAppInsts(0)
 	require.Nil(t, err)
 
+	// Check it works the same with MaxInstances=0
+	pt1.policy.MinActiveInstances = 2
+	pt1.policy.MaxInstances = 0
+	pt1.updatePolicy(ctx)
+	pt2.policy.MinActiveInstances = 3
+	pt2.policy.MaxInstances = 0
+	pt2.updatePolicy(ctx)
+	minmax.runIter(ctx)
+	countMin = int(pt1.policy.MinActiveInstances + pt2.policy.MinActiveInstances)
+	err = dc.waitForAppInsts(countMin)
+	require.Nil(t, err)
+
+	// set min/max to 0 to clean up everything
+	pt1.policy.MinActiveInstances = 0
+	pt1.policy.MaxInstances = 0
+	pt1.updatePolicy(ctx)
+	pt2.policy.MinActiveInstances = 0
+	pt2.policy.MaxInstances = 0
+	pt2.updatePolicy(ctx)
+	minmax.runIter(ctx)
+	err = dc.waitForAppInsts(0)
+	require.Nil(t, err)
+
 	// go back to reasonable settings (only using one policy from now)
 	pt1.policy.MinActiveInstances = 2
 	pt1.policy.MaxInstances = 3


### PR DESCRIPTION
Small fix to allow the AutoProv service to deploy to meet min when max is set to 0 (unlimited).