### PR TITLE
EDGECLOUD-3053 AutoProv fix incorrect deletes

### DIFF
--- a/autoprov/autoprov_deploy.go
+++ b/autoprov/autoprov_deploy.go
@@ -59,6 +59,7 @@ func runAppInstApi(ctx context.Context, inst *edgeproto.AppInst, action cloudcom
 	var stream edgeproto.AppInstApi_CreateAppInstClient
 	switch action {
 	case cloudcommon.Create:
+		inst.Liveness = edgeproto.Liveness_LIVENESS_AUTOPROV
 		stream, err = client.CreateAppInst(ctx, inst)
 	case cloudcommon.Delete:
 		stream, err = client.DeleteAppInst(ctx, inst)

--- a/autoprov/autoprov_minmax_test.go
+++ b/autoprov/autoprov_minmax_test.go
@@ -427,6 +427,31 @@ func TestAppChecker(t *testing.T) {
 	minmax.runIter(ctx)
 	err = dc.waitForAppInsts(0)
 	require.Nil(t, err)
+
+	// create App with MobiledgeX org, no policies
+	// make sure they don't get deleted (edgecloud-3053)
+	app2 := edgeproto.App{}
+	app2.Key.Name = "app2"
+	app2.Key.Organization = cloudcommon.OrganizationMobiledgeX
+	cacheData.appCache.Update(ctx, &app2, 0)
+
+	refs2 := edgeproto.AppInstRefs{}
+	refs2.Key = app2.Key
+	refs2.Insts = make(map[string]uint32)
+	cacheData.appInstRefsCache.Update(ctx, &refs2, 0)
+
+	insts = pt1.getAppInsts(&app2.Key)
+	for _, inst := range insts {
+		inst.Key.ClusterInstKey.Organization = cloudcommon.OrganizationMobiledgeX
+		dc.updateAppInst(ctx, &inst)
+	}
+	minmax.runIter(ctx)
+	err = dc.waitForAppInsts(len(insts))
+	require.Nil(t, err)
+	// clean up
+	for _, inst := range insts {
+		dc.deleteAppInst(ctx, &inst)
+	}
 }
 
 type policyTest struct {

--- a/e2e-tests/data/autoprov_appinst_show.yml
+++ b/e2e-tests/data/autoprov_appinst_show.yml
@@ -18,7 +18,7 @@ regiondata:
         latitude: 35
         longitude: -95
       uri: tmus-cloud-2.tmus.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 81
@@ -48,7 +48,7 @@ regiondata:
         latitude: 31
         longitude: -91
       uri: tmus-cloud-1.tmus.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 81

--- a/e2e-tests/data/autoprov_ha_appinst_failedover.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_failedover.yml
@@ -18,7 +18,7 @@ regiondata:
         latitude: 31
         longitude: -91
       uri: tmus-cloud-1.tmus.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
@@ -48,7 +48,7 @@ regiondata:
         latitude: 32
         longitude: -91
       uri: acmeappcoautoprovha10.reservable3.azure-cloud-4.azure.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
@@ -78,7 +78,7 @@ regiondata:
         latitude: 36
         longitude: -95
       uri: acmeappcoautoprovha10.reservable4.gcp-cloud-5.gcp.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82

--- a/e2e-tests/data/autoprov_ha_appinst_maintenance.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_maintenance.yml
@@ -18,7 +18,7 @@ regiondata:
         latitude: 31
         longitude: -91
       uri: tmus-cloud-1.tmus.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
@@ -48,7 +48,7 @@ regiondata:
         latitude: 35
         longitude: -95
       uri: tmus-cloud-2.tmus.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
@@ -78,7 +78,7 @@ regiondata:
         latitude: 32
         longitude: -91
       uri: acmeappcoautoprovha10.reservable3.azure-cloud-4.azure.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82

--- a/e2e-tests/data/autoprov_ha_appinst_show.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_show.yml
@@ -18,7 +18,7 @@ regiondata:
         latitude: 31
         longitude: -91
       uri: tmus-cloud-1.tmus.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
@@ -48,7 +48,7 @@ regiondata:
         latitude: 35
         longitude: -95
       uri: tmus-cloud-2.tmus.mobiledgex.net
-      liveness: LivenessDynamic
+      liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82

--- a/e2e-tests/data/mc_orgsinuse_error.yml
+++ b/e2e-tests/data/mc_orgsinuse_error.yml
@@ -13,10 +13,10 @@ errors:
   err: 'Organization MobiledgeX in use or check failed: region local: in use by some App, AppInst, ClusterInst; region locala: in use by some App, AppInst'
 - desc: DeleteOrg[4]
   status: 400
-  err: 'Organization azure in use or check failed: region local: in use by some Cloudlet, ClusterInst'
+  err: 'Organization azure in use or check failed: region local: in use by some AppInst, Cloudlet, ClusterInst'
 - desc: DeleteOrg[5]
   status: 400
-  err: 'Organization gcp in use or check failed: region local: in use by some Cloudlet, ClusterInst'
+  err: 'Organization gcp in use or check failed: region local: in use by some AppInst, Cloudlet, ClusterInst'
 - desc: DeleteOrg[6]
   status: 400
   err: 'Organization Samsung in use or check failed: region local: in use by some App; region locala: in use by some App'

--- a/mc/mcctl/ormctl/appinst.mc2.go
+++ b/mc/mcctl/ormctl/appinst.mc2.go
@@ -396,7 +396,7 @@ var AppInstComments = map[string]string{
 	"cloudletloc.course":             "course (IOS) / bearing (Android) (degrees east relative to true north)",
 	"cloudletloc.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
 	"uri":                            "Base FQDN (not really URI) for the App. See Service FQDN for endpoint access.",
-	"liveness":                       "Liveness of instance (see Liveness), one of LivenessUnknown, LivenessStatic, LivenessDynamic",
+	"liveness":                       "Liveness of instance (see Liveness), one of LivenessUnknown, LivenessStatic, LivenessDynamic, LivenessAutoprov",
 	"mappedports:#.proto":            "TCP (L4), UDP (L4), or HTTP (L7) protocol, one of LProtoUnknown, LProtoTcp, LProtoUdp, LProtoHttp",
 	"mappedports:#.internalport":     "Container port",
 	"mappedports:#.publicport":       "Public facing port for TCP/UDP (may be mapped on shared LB reverse proxy)",

--- a/mc/mcctl/ormctl/clusterinst.mc2.go
+++ b/mc/mcctl/ormctl/clusterinst.mc2.go
@@ -187,7 +187,7 @@ var ClusterInstComments = map[string]string{
 	"cloudlet":           "Name of the cloudlet",
 	"cluster-org":        "Name of Developer organization that this cluster belongs to",
 	"flavor":             "Flavor name",
-	"liveness":           "Liveness of instance (see Liveness), one of LivenessUnknown, LivenessStatic, LivenessDynamic",
+	"liveness":           "Liveness of instance (see Liveness), one of LivenessUnknown, LivenessStatic, LivenessDynamic, LivenessAutoprov",
 	"auto":               "Auto is set to true when automatically created by back-end (internal use only)",
 	"state":              "State of the cluster instance, one of TrackedStateUnknown, NotPresent, CreateRequested, Creating, CreateError, Ready, UpdateRequested, Updating, UpdateError, DeleteRequested, Deleting, DeleteError, DeletePrepare, CrmInitok, CreatingDependencies",
 	"errors":             "Any errors trying to create, update, or delete the ClusterInst on the Cloudlet.",


### PR DESCRIPTION
This fixes two issues in the AutoProv service.

The first issue is that the AutoProv service was evaluating Apps it didn't need to, because they didn't have any policies associated with them. I've added some checks in the update calls to ignore such Apps.

The second issue is that the way the AutoProv service was identifying automatically provisioned AppInsts was by their organization being the special MobiledgeX org. Unfortunately, this is the org Andy was using when running his tests. That, combined with the above issue, was causing the AutoProv code to think his AppInsts were orphaned, and deleting them. This isn't something a normal user would hit because they wouldn't be able to use the MobiledgeX org to deploy AppInsts. However, another side effect of these two issues is that the Prometheus AppInsts for cluster metrics were getting erroneously deleted.

The fix for the second issue is to use a new Liveness value on the AppInst to mark it as created by the AutoProv service. This is an explicit marking as opposed to the implicit method used before. In this way, even if we erroneously process an App without a policy, we won't mistakenly delete the AppInsts for it, regardless of the org being MobiledgeX or not.