### PR TITLE
EDGECLOUD-3062 better Jaeger span tags

### DIFF
--- a/autoprov/alerthandler.go
+++ b/autoprov/alerthandler.go
@@ -34,6 +34,7 @@ func alertChanged(ctx context.Context, old *edgeproto.Alert, new *edgeproto.Aler
 	alert := alertCopy(new)
 	go func() {
 		cspan := log.StartSpan(log.DebugLevelApi, "auto scale", opentracing.ChildOf(log.SpanFromContext(ctx).Context()))
+		log.SetTags(cspan, alert.GetKey().GetTags())
 		cctx := log.ContextWithSpan(context.Background(), cspan)
 		defer cspan.Finish()
 		err := handler(cctx, name, alert)

--- a/autoprov/autoprov_deploy.go
+++ b/autoprov/autoprov_deploy.go
@@ -17,7 +17,7 @@ var testDialOpt grpc.DialOption
 
 func goAppInstApi(ctx context.Context, inst *edgeproto.AppInst, action cloudcommon.Action, reason, policyName string) error {
 	span := log.StartSpan(log.DebugLevelApi, "auto-prov deploy "+action.String(), opentracing.ChildOf(log.SpanFromContext(ctx).Context()))
-	span.SetTag("AppInst", inst.Key)
+	log.SetTags(span, inst.Key.GetTags())
 	span.SetTag("reason", reason)
 	defer span.Finish()
 	ctx = log.ContextWithSpan(context.Background(), span)

--- a/autoprov/autoprov_test.go
+++ b/autoprov/autoprov_test.go
@@ -72,10 +72,10 @@ func testAutoScale(t *testing.T, ctx context.Context, ds *testutil.DummyServer, 
 
 	// alert labels for ClusterInst
 	keys := make(map[string]string)
-	keys[cloudcommon.AlertLabelClusterOrg] = cinst.Key.Organization
-	keys[cloudcommon.AlertLabelCloudletOrg] = cinst.Key.CloudletKey.Organization
-	keys[cloudcommon.AlertLabelCloudlet] = cinst.Key.CloudletKey.Name
-	keys[cloudcommon.AlertLabelCluster] = cinst.Key.ClusterKey.Name
+	keys[edgeproto.ClusterInstKeyTagOrganization] = cinst.Key.Organization
+	keys[edgeproto.CloudletKeyTagOrganization] = cinst.Key.CloudletKey.Organization
+	keys[edgeproto.CloudletKeyTagName] = cinst.Key.CloudletKey.Name
+	keys[edgeproto.ClusterKeyTagName] = cinst.Key.ClusterKey.Name
 
 	// scale up alert
 	scaleup := edgeproto.Alert{}

--- a/autoprov/autoscale.go
+++ b/autoprov/autoscale.go
@@ -17,10 +17,10 @@ func autoScale(ctx context.Context, name string, alert *edgeproto.Alert) error {
 		return nil
 	}
 	inst := edgeproto.ClusterInst{}
-	inst.Key.Organization = alert.Labels[cloudcommon.AlertLabelClusterOrg]
-	inst.Key.ClusterKey.Name = alert.Labels[cloudcommon.AlertLabelCluster]
-	inst.Key.CloudletKey.Name = alert.Labels[cloudcommon.AlertLabelCloudlet]
-	inst.Key.CloudletKey.Organization = alert.Labels[cloudcommon.AlertLabelCloudletOrg]
+	inst.Key.Organization = alert.Labels[edgeproto.ClusterInstKeyTagOrganization]
+	inst.Key.ClusterKey.Name = alert.Labels[edgeproto.ClusterKeyTagName]
+	inst.Key.CloudletKey.Name = alert.Labels[edgeproto.CloudletKeyTagName]
+	inst.Key.CloudletKey.Organization = alert.Labels[edgeproto.CloudletKeyTagOrganization]
 
 	nodecountStr := alert.Annotations[cloudcommon.AlertKeyNodeCount]
 	nodecount, err := strconv.Atoi(nodecountStr)

--- a/shepherd/appinst-worker.go
+++ b/shepherd/appinst-worker.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mobiledgex/edge-cloud-infra/shepherd/shepherd_common"
 	platform "github.com/mobiledgex/edge-cloud-infra/shepherd/shepherd_platform"
-	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -51,9 +50,7 @@ func (p *AppInstWorker) Stop(ctx context.Context) {
 
 func (p *AppInstWorker) sendMetrics() {
 	span := log.StartSpan(log.DebugLevelSampled, "send-metric")
-	span.SetTag("operator", p.appInstKey.ClusterInstKey.CloudletKey.Organization)
-	span.SetTag("cloudlet", p.appInstKey.ClusterInstKey.CloudletKey.Name)
-	span.SetTag("cluster", cloudcommon.DefaultVMCluster)
+	log.SetTags(span, p.appInstKey.GetTags())
 	ctx := log.ContextWithSpan(context.Background(), span)
 	defer span.Finish()
 	key := shepherd_common.MetricAppInstKey{

--- a/shepherd/cloudlet-prom.go
+++ b/shepherd/cloudlet-prom.go
@@ -29,13 +29,13 @@ var promTargetT = `
 {
 	"targets": ["{{.MetricsProxyAddr}}"],
 	"labels": {
-		"` + cloudcommon.AlertLabelApp + `": "{{.Key.AppKey.Name}}",
-		"` + cloudcommon.AlertLabelAppVer + `": "{{.Key.AppKey.Version}}",
-		"` + cloudcommon.AlertLabelAppOrg + `": "{{.Key.AppKey.Organization}}",
-		"` + cloudcommon.AlertLabelCluster + `": "{{.Key.ClusterInstKey.ClusterKey.Name}}",
-		"` + cloudcommon.AlertLabelClusterOrg + `": "{{.Key.ClusterInstKey.Organization}}",
-		"` + cloudcommon.AlertLabelCloudlet + `": "{{.Key.ClusterInstKey.CloudletKey.Name}}",
-		"` + cloudcommon.AlertLabelCloudletOrg + `": "{{.Key.ClusterInstKey.CloudletKey.Organization}}",
+		"` + edgeproto.AppKeyTagName + `": "{{.Key.AppKey.Name}}",
+		"` + edgeproto.AppKeyTagVersion + `": "{{.Key.AppKey.Version}}",
+		"` + edgeproto.AppKeyTagOrganization + `": "{{.Key.AppKey.Organization}}",
+		"` + edgeproto.ClusterKeyTagName + `": "{{.Key.ClusterInstKey.ClusterKey.Name}}",
+		"` + edgeproto.ClusterInstKeyTagOrganization + `": "{{.Key.ClusterInstKey.Organization}}",
+		"` + edgeproto.CloudletKeyTagName + `": "{{.Key.ClusterInstKey.CloudletKey.Name}}",
+		"` + edgeproto.CloudletKeyTagOrganization + `": "{{.Key.ClusterInstKey.CloudletKey.Organization}}",
 		"__metrics_path__":"{{.EnvoyMetricsPath}}"
 	}
 }`
@@ -57,7 +57,7 @@ var promAutoProvAlertT = `groups:
 - name: ` + cloudcommon.AlertAutoProvDown + `
   rules:
   - alert: ScaleDown
-    expr: envoy_cluster_upstream_cx_active{` + cloudcommon.AlertLabelApp + `="{{.AppKey.Name}}",` + cloudcommon.AlertLabelAppVer + `="{{.AppKey.Version}}",` + cloudcommon.AlertLabelAppOrg + `="{{.AppKey.Organization}}"} == 0
+    expr: envoy_cluster_upstream_cx_active{` + edgeproto.AppKeyTagName + `="{{.AppKey.Name}}",` + edgeproto.AppKeyTagVersion + `="{{.AppKey.Version}}",` + edgeproto.AppKeyTagOrganization + `="{{.AppKey.Organization}}"} == 0
     for: 5m
 `
 

--- a/shepherd/cloudlet-worker.go
+++ b/shepherd/cloudlet-worker.go
@@ -25,8 +25,7 @@ func CloudletScraper() {
 		select {
 		case <-time.After(settings.ShepherdMetricsCollectionInterval.TimeDuration()):
 			span := log.StartSpan(log.DebugLevelSampled, "send-cloudlet-metric")
-			span.SetTag("operator", cloudletKey.Organization)
-			span.SetTag("cloudlet", cloudletKey.Name)
+			log.SetTags(span, cloudletKey.GetTags())
 			ctx := log.ContextWithSpan(context.Background(), span)
 			cloudletStats, err := myPlatform.GetPlatformStats(ctx)
 			if err != nil {
@@ -49,8 +48,7 @@ func CloudletPrometheusScraper() {
 		case <-time.After(settings.ShepherdMetricsCollectionInterval.TimeDuration()):
 			//TODO  - cloudletEnvoyStats, err := getEnvoyStats
 			aspan := log.StartSpan(log.DebugLevelMetrics, "send-cloudlet-alerts")
-			aspan.SetTag("operator", cloudletKey.Organization)
-			aspan.SetTag("cloudlet", cloudletKey.Name)
+			log.SetTags(aspan, cloudletKey.GetTags())
 			actx := log.ContextWithSpan(context.Background(), aspan)
 			// platform client is a local ssh
 			alerts, err := getPromAlerts(actx, CloudletPrometheusAddr, &pc.LocalClient{})

--- a/shepherd/cloudlet-worker_test.go
+++ b/shepherd/cloudlet-worker_test.go
@@ -46,13 +46,13 @@ var failAlerts = `{
 		{
 		  "labels": {
 			"alertname": "AppInstDown",
-			"` + cloudcommon.AlertLabelApp + `": "` + shepherd_test.TestApp.Key.Name + `",
-			"` + cloudcommon.AlertLabelAppOrg + `": "` + shepherd_test.TestApp.Key.Organization + `",
-			"` + cloudcommon.AlertLabelAppVer + `": "` + shepherd_test.TestApp.Key.Version + `",
-			"` + cloudcommon.AlertLabelCloudlet + `": "` + shepherd_test.TestCloudletKey.Name + `",
-			"` + cloudcommon.AlertLabelCloudletOrg + `": "` + shepherd_test.TestCloudletKey.Organization + `",
-			"` + cloudcommon.AlertLabelCluster + `": "` + shepherd_test.TestClusterKey.Name + `",
-			"` + cloudcommon.AlertLabelClusterOrg + `": "` + shepherd_test.TestClusterInstKey.Organization + `",
+			"` + edgeproto.AppKeyTagName + `": "` + shepherd_test.TestApp.Key.Name + `",
+			"` + edgeproto.AppKeyTagOrganization + `": "` + shepherd_test.TestApp.Key.Organization + `",
+			"` + edgeproto.AppKeyTagVersion + `": "` + shepherd_test.TestApp.Key.Version + `",
+			"` + edgeproto.CloudletKeyTagName + `": "` + shepherd_test.TestCloudletKey.Name + `",
+			"` + edgeproto.CloudletKeyTagOrganization + `": "` + shepherd_test.TestCloudletKey.Organization + `",
+			"` + edgeproto.ClusterKeyTagName + `": "` + shepherd_test.TestClusterKey.Name + `",
+			"` + edgeproto.ClusterInstKeyTagOrganization + `": "` + shepherd_test.TestClusterInstKey.Organization + `",
 			"` + cloudcommon.AlertHealthCheckStatus + `": "` + strconv.Itoa(int(edgeproto.HealthCheck_HEALTH_CHECK_FAIL_ROOTLB_OFFLINE)) + `",
 			"instance": "host.docker.internal:9091",
 			"job": "envoy_targets"
@@ -64,13 +64,13 @@ var failAlerts = `{
 		{
 		  "labels": {
 			"alertname": "AppInstDown",
-			"` + cloudcommon.AlertLabelApp + `": "` + shepherd_test.TestApp.Key.Name + `",
-			"` + cloudcommon.AlertLabelAppOrg + `": "` + shepherd_test.TestApp.Key.Organization + `",
-			"` + cloudcommon.AlertLabelAppVer + `": "` + shepherd_test.TestApp.Key.Version + `",
-			"` + cloudcommon.AlertLabelCloudlet + `": "` + shepherd_test.TestCloudletKey.Name + `",
-			"` + cloudcommon.AlertLabelCloudletOrg + `": "` + shepherd_test.TestCloudletKey.Organization + `",
-			"` + cloudcommon.AlertLabelCluster + `": "` + shepherd_test.TestClusterKey.Name + `",
-			"` + cloudcommon.AlertLabelClusterOrg + `": "` + shepherd_test.TestClusterInstKey.Organization + `",
+			"` + edgeproto.AppKeyTagName + `": "` + shepherd_test.TestApp.Key.Name + `",
+			"` + edgeproto.AppKeyTagOrganization + `": "` + shepherd_test.TestApp.Key.Organization + `",
+			"` + edgeproto.AppKeyTagVersion + `": "` + shepherd_test.TestApp.Key.Version + `",
+			"` + edgeproto.CloudletKeyTagName + `": "` + shepherd_test.TestCloudletKey.Name + `",
+			"` + edgeproto.CloudletKeyTagOrganization + `": "` + shepherd_test.TestCloudletKey.Organization + `",
+			"` + edgeproto.ClusterKeyTagName + `": "` + shepherd_test.TestClusterKey.Name + `",
+			"` + edgeproto.ClusterInstKeyTagOrganization + `": "` + shepherd_test.TestClusterInstKey.Organization + `",
 			"` + cloudcommon.AlertHealthCheckStatus + `": "` + strconv.Itoa(int(edgeproto.HealthCheck_HEALTH_CHECK_FAIL_SERVER_FAIL)) + `",
 			"envoy_cluster_name": "backend7777",
 			"instance": "host.docker.internal:9091",
@@ -142,13 +142,13 @@ func TestCCloudletAlerts(t *testing.T) {
 	// check each alert and make sure it has correct data
 	for _, alert := range AlertCache.Objs {
 		assert.Equal(t, cloudcommon.AlertAppInstDown, alert.Obj.Labels["alertname"])
-		assert.Equal(t, shepherd_test.TestApp.Key.Name, alert.Obj.Labels[cloudcommon.AlertLabelApp])
-		assert.Equal(t, shepherd_test.TestApp.Key.Organization, alert.Obj.Labels[cloudcommon.AlertLabelAppOrg])
-		assert.Equal(t, shepherd_test.TestApp.Key.Version, alert.Obj.Labels[cloudcommon.AlertLabelAppVer])
-		assert.Equal(t, shepherd_test.TestCloudletKey.Name, alert.Obj.Labels[cloudcommon.AlertLabelCloudlet])
-		assert.Equal(t, shepherd_test.TestCloudletKey.Organization, alert.Obj.Labels[cloudcommon.AlertLabelCloudletOrg])
-		assert.Equal(t, shepherd_test.TestClusterKey.Name, alert.Obj.Labels[cloudcommon.AlertLabelCluster])
-		assert.Equal(t, shepherd_test.TestClusterInstKey.Organization, alert.Obj.Labels[cloudcommon.AlertLabelClusterOrg])
+		assert.Equal(t, shepherd_test.TestApp.Key.Name, alert.Obj.Labels[edgeproto.AppKeyTagName])
+		assert.Equal(t, shepherd_test.TestApp.Key.Organization, alert.Obj.Labels[edgeproto.AppKeyTagOrganization])
+		assert.Equal(t, shepherd_test.TestApp.Key.Version, alert.Obj.Labels[edgeproto.AppKeyTagVersion])
+		assert.Equal(t, shepherd_test.TestCloudletKey.Name, alert.Obj.Labels[edgeproto.CloudletKeyTagName])
+		assert.Equal(t, shepherd_test.TestCloudletKey.Organization, alert.Obj.Labels[edgeproto.CloudletKeyTagOrganization])
+		assert.Equal(t, shepherd_test.TestClusterKey.Name, alert.Obj.Labels[edgeproto.ClusterKeyTagName])
+		assert.Equal(t, shepherd_test.TestClusterInstKey.Organization, alert.Obj.Labels[edgeproto.ClusterInstKeyTagOrganization])
 		// make sure the alert status is not OK, or UNKNOWN
 		assert.NotEqual(t, strconv.Itoa(int(edgeproto.HealthCheck_HEALTH_CHECK_OK)), alert.Obj.Labels[cloudcommon.AlertHealthCheckStatus])
 		assert.NotEqual(t, strconv.Itoa(int(edgeproto.HealthCheck_HEALTH_CHECK_UNKNOWN)), alert.Obj.Labels[cloudcommon.AlertHealthCheckStatus])

--- a/shepherd/cluster-worker.go
+++ b/shepherd/cluster-worker.go
@@ -91,18 +91,14 @@ func (p *ClusterWorker) RunNotify() {
 		select {
 		case <-time.After(p.interval):
 			span := log.StartSpan(log.DebugLevelSampled, "send-metric")
-			span.SetTag("operator", p.clusterInstKey.CloudletKey.Organization)
-			span.SetTag("cloudlet", p.clusterInstKey.CloudletKey.Name)
-			span.SetTag("cluster", p.clusterInstKey.ClusterKey.Name)
+			log.SetTags(span, p.clusterInstKey.GetTags())
 			ctx := log.ContextWithSpan(context.Background(), span)
 			clusterStats := p.clusterStat.GetClusterStats(ctx)
 			appStatsMap := p.clusterStat.GetAppStats(ctx)
 
 			// create another span for alerts that is always logged
 			aspan := log.StartSpan(log.DebugLevelMetrics, "alerts check")
-			aspan.SetTag("operator", p.clusterInstKey.CloudletKey.Organization)
-			aspan.SetTag("cloudlet", p.clusterInstKey.CloudletKey.Name)
-			aspan.SetTag("cluster", p.clusterInstKey.ClusterKey.Name)
+			log.SetTags(aspan, p.clusterInstKey.GetTags())
 			actx := log.ContextWithSpan(context.Background(), aspan)
 
 			for key, stat := range appStatsMap {

--- a/shepherd/proxy-stats.go
+++ b/shepherd/proxy-stats.go
@@ -176,8 +176,7 @@ func ProxyScraper() {
 			scrapePoints := copyMapValues()
 			for _, v := range scrapePoints {
 				span := log.StartSpan(log.DebugLevelSampled, "send-metric")
-				span.SetTag("operator", cloudletKey.Organization)
-				span.SetTag("cloudlet", cloudletKey.Name)
+				log.SetTags(span, cloudletKey.GetTags())
 				span.SetTag("cluster", v.Cluster)
 				ctx := log.ContextWithSpan(context.Background(), span)
 

--- a/shepherd/shepherd-alerts.go
+++ b/shepherd/shepherd-alerts.go
@@ -11,10 +11,10 @@ import (
 func addClusterDetailsToAlerts(alerts []edgeproto.Alert, clusterInstKey *edgeproto.ClusterInstKey) []edgeproto.Alert {
 	for ii, _ := range alerts {
 		alert := &alerts[ii]
-		alert.Labels[cloudcommon.AlertLabelClusterOrg] = clusterInstKey.Organization
-		alert.Labels[cloudcommon.AlertLabelCloudletOrg] = clusterInstKey.CloudletKey.Organization
-		alert.Labels[cloudcommon.AlertLabelCloudlet] = clusterInstKey.CloudletKey.Name
-		alert.Labels[cloudcommon.AlertLabelCluster] = clusterInstKey.ClusterKey.Name
+		alert.Labels[edgeproto.ClusterInstKeyTagOrganization] = clusterInstKey.Organization
+		alert.Labels[edgeproto.CloudletKeyTagOrganization] = clusterInstKey.CloudletKey.Organization
+		alert.Labels[edgeproto.CloudletKeyTagName] = clusterInstKey.CloudletKey.Name
+		alert.Labels[edgeproto.ClusterKeyTagName] = clusterInstKey.ClusterKey.Name
 	}
 	return alerts
 }
@@ -29,11 +29,11 @@ func pruneClusterForeignAlerts(key interface{}, keys map[edgeproto.AlertKey]stru
 	alertFromKey := edgeproto.Alert{}
 	for key, _ := range keys {
 		edgeproto.AlertKeyStringParse(string(key), &alertFromKey)
-		if _, found := alertFromKey.Labels[cloudcommon.AlertLabelApp]; found ||
-			alertFromKey.Labels[cloudcommon.AlertLabelClusterOrg] != clusterInstKey.Organization ||
-			alertFromKey.Labels[cloudcommon.AlertLabelCloudletOrg] != clusterInstKey.CloudletKey.Organization ||
-			alertFromKey.Labels[cloudcommon.AlertLabelCloudlet] != clusterInstKey.CloudletKey.Name ||
-			alertFromKey.Labels[cloudcommon.AlertLabelCluster] != clusterInstKey.ClusterKey.Name {
+		if _, found := alertFromKey.Labels[edgeproto.AppKeyTagName]; found ||
+			alertFromKey.Labels[edgeproto.ClusterInstKeyTagOrganization] != clusterInstKey.Organization ||
+			alertFromKey.Labels[edgeproto.CloudletKeyTagOrganization] != clusterInstKey.CloudletKey.Organization ||
+			alertFromKey.Labels[edgeproto.CloudletKeyTagName] != clusterInstKey.CloudletKey.Name ||
+			alertFromKey.Labels[edgeproto.ClusterKeyTagName] != clusterInstKey.ClusterKey.Name {
 			delete(keys, key)
 		}
 	}
@@ -107,10 +107,10 @@ func flushAlerts(ctx context.Context, key *edgeproto.ClusterInstKey) {
 	AlertCache.Mux.Lock()
 	for k, data := range AlertCache.Objs {
 		v := data.Obj
-		if v.Labels[cloudcommon.AlertLabelClusterOrg] == key.Organization &&
-			v.Labels[cloudcommon.AlertLabelCloudletOrg] == key.CloudletKey.Organization &&
-			v.Labels[cloudcommon.AlertLabelCloudlet] == key.CloudletKey.Name &&
-			v.Labels[cloudcommon.AlertLabelCluster] == key.ClusterKey.Name {
+		if v.Labels[edgeproto.ClusterInstKeyTagOrganization] == key.Organization &&
+			v.Labels[edgeproto.CloudletKeyTagOrganization] == key.CloudletKey.Organization &&
+			v.Labels[edgeproto.CloudletKeyTagName] == key.CloudletKey.Name &&
+			v.Labels[edgeproto.ClusterKeyTagName] == key.ClusterKey.Name {
 			toflush = append(toflush, k)
 		}
 	}


### PR DESCRIPTION
Infra changes for better Jaeger key tags. No changes in MC really, as any key'd objects will end up as a Controller API call and get tagged there. From the controller API span you can see the parent MC span.