### PR TITLE
use MEX_OS_IMAGE if specified

### DIFF
--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -68,6 +68,19 @@ func (v *VMPlatform) GetPlatformNodes(cloudlet *edgeproto.Cloudlet) []string {
 	return nodes
 }
 
+// GetCloudletImageToUse decides what image to use based on
+// 1) if MEX_OS_IMAGE is specified in properties and not default, use that
+// 2) Use image specified on startup based on cloudlet config
+func (v *VMPlatform) GetCloudletImageToUse(ctx context.Context, updateCallback edgeproto.CacheUpdateCallback) (string, error) {
+	imgFromProps := v.VMProperties.GetCloudletOSImage()
+	if imgFromProps != DefaultOSImageName {
+		log.SpanLog(ctx, log.DebugLevelInfra, "using image from MEX_OS_IMAGE property", "imgFromProps", imgFromProps)
+		return imgFromProps, nil
+	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "Getting cloudlet image from platform config", "CloudletVMImagePath", v.VMProperties.CommonPf.PlatformConfig.CloudletVMImagePath, "version", v.VMProperties.CommonPf.PlatformConfig.VMImageVersion)
+	return v.VMProvider.AddCloudletImageIfNotPresent(ctx, v.VMProperties.CommonPf.PlatformConfig.CloudletVMImagePath, v.VMProperties.CommonPf.PlatformConfig.VMImageVersion, updateCallback)
+}
+
 // setupPlatformVM:
 //   * Downloads Cloudlet VM base image (if not-present)
 //   * Brings up Platform VM (using vm provider stack)
@@ -77,7 +90,7 @@ func (v *VMPlatform) SetupPlatformVM(ctx context.Context, vaultConfig *vault.Con
 	log.SpanLog(ctx, log.DebugLevelInfra, "SetupPlatformVM", "cloudlet", cloudlet)
 
 	platformVmName := v.GetPlatformVMName(&cloudlet.Key)
-	_, err := v.VMProvider.AddCloudletImageIfNotPresent(ctx, pfConfig.CloudletVmImagePath, cloudlet.VmImageVersion, updateCallback)
+	_, err := v.GetCloudletImageToUse(ctx, updateCallback)
 	if err != nil {
 		return err
 	}

--- a/vmlayer/cluster.go
+++ b/vmlayer/cluster.go
@@ -93,8 +93,8 @@ func (v *VMPlatform) UpdateClusterInst(ctx context.Context, clusterInst *edgepro
 		return err
 	}
 
-	log.SpanLog(ctx, log.DebugLevelInfra, "verify if cloudlet base image exists")
-	imgName, err := v.VMProvider.AddCloudletImageIfNotPresent(ctx, v.VMProperties.CommonPf.PlatformConfig.CloudletVMImagePath, v.VMProperties.CommonPf.PlatformConfig.VMImageVersion, updateCallback)
+	log.SpanLog(ctx, log.DebugLevelInfra, "get cloudlet base image")
+	imgName, err := v.GetCloudletImageToUse(ctx, updateCallback)
 	if err != nil {
 		log.InfoLog("error with cloudlet base image", "imgName", imgName, "error", err)
 		return err
@@ -270,7 +270,7 @@ func (v *VMPlatform) CreateClusterInst(ctx context.Context, clusterInst *edgepro
 	timeout -= time.Minute
 
 	log.SpanLog(ctx, log.DebugLevelInfra, "verify if cloudlet base image exists")
-	imgName, err := v.VMProvider.AddCloudletImageIfNotPresent(ctx, v.VMProperties.CommonPf.PlatformConfig.CloudletVMImagePath, v.VMProperties.CommonPf.PlatformConfig.VMImageVersion, updateCallback)
+	imgName, err := v.GetCloudletImageToUse(ctx, updateCallback)
 	if err != nil {
 		log.InfoLog("error with cloudlet base image", "imgName", imgName, "error", err)
 		return err
@@ -581,7 +581,7 @@ func (v *VMPlatform) getVMRequestSpecForDockerCluster(ctx context.Context, imgNa
 
 func (v *VMPlatform) syncClusterInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, privacyPolicy *edgeproto.PrivacyPolicy, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "syncClusterInst", "clusterInst", clusterInst)
-	imgName, err := v.VMProvider.AddCloudletImageIfNotPresent(ctx, v.VMProperties.CommonPf.PlatformConfig.CloudletVMImagePath, v.VMProperties.CommonPf.PlatformConfig.VMImageVersion, updateCallback)
+	imgName, err := v.GetCloudletImageToUse(ctx, updateCallback)
 	if err != nil {
 		log.InfoLog("error with cloudlet base image", "imgName", imgName, "error", err)
 		return err

--- a/vmlayer/lb.go
+++ b/vmlayer/lb.go
@@ -390,9 +390,7 @@ func (v *VMPlatform) GetVMSpecForRootLB(ctx context.Context, rootLbName string, 
 	if az == "" {
 		az = v.VMProperties.GetCloudletComputeAvailabilityZone()
 	}
-	imgPath := v.VMProperties.CommonPf.PlatformConfig.CloudletVMImagePath
-	imgVersion := v.VMProperties.CommonPf.PlatformConfig.VMImageVersion
-	imageName, err := v.VMProvider.AddCloudletImageIfNotPresent(ctx, imgPath, imgVersion, updateCallback)
+	imageName, err := v.GetCloudletImageToUse(ctx, updateCallback)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
EDGECLOUD-3022

For certain environments, we want to be able to continue to use MEX_OS_IMAGE to override the base image CRM uses.  For example this is useful when experimenting with a patch.  

Create a new function GetCloudletImageToUse which uses MEX_OS_IMAGE if it is not the default value, otherwise pull from the vault as usual.

