### PR TITLE
Fix scope of props map, add to uint-test for GetFlavorInfo

### DIFF
--- a/crm-platforms/openstack/openstack-cmd.go
+++ b/crm-platforms/openstack/openstack-cmd.go
@@ -926,8 +926,6 @@ func (s *OpenstackPlatform) OSGetAllLimits(ctx context.Context) ([]OSLimit, erro
 
 func (s *OpenstackPlatform) GetFlavorInfo(ctx context.Context) ([]*edgeproto.FlavorInfo, []OSAZone, []OSImage, error) {
 
-	var props map[string]string
-
 	osflavors, err := s.ListFlavors(ctx)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get flavors, %v", err.Error())
@@ -937,6 +935,7 @@ func (s *OpenstackPlatform) GetFlavorInfo(ctx context.Context) ([]*edgeproto.Fla
 	}
 	var finfo []*edgeproto.FlavorInfo
 	for _, f := range osflavors {
+		var props map[string]string
 		if f.Properties != "" {
 			props = ParseFlavorProperties(f)
 		}


### PR DESCRIPTION
The props var needs to be scoped to a single flavor's props in GetFlavorInfo. Also added to the cloudlet_test.go for exercising flavor props parsing.