### PR TITLE
EDGECLOUD-3097 TEF cloudlet unable to download from artifactory

### DIFF
--- a/ansible/templates/nginx-artifactory.j2
+++ b/ansible/templates/nginx-artifactory.j2
@@ -9,6 +9,7 @@ server {
 
 	location / {
 		proxy_read_timeout  900;
+		proxy_max_temp_file_size 20480m;
 		proxy_pass_header   Server;
 		proxy_cookie_path   ~*^/.* /;
 		if ( $request_uri ~ ^/artifactory/(.*)$ ) {


### PR DESCRIPTION
Nginx buffers upstream Artifactory downloads, but if it has a limit of
1G for the temporary buffer file that it creates.  If the download
connection is fast, it will not hit this buffer limit, but with slower
connections, nginx waits for the client and stop downloading from
Artifactory, and Artifactory interprets that as a socket timeout and
tears down the connection.  Once the client downloads 1GB, nginx tries
to resume the download from Artifactory and fails.