### PR TITLE
EDGECLOUD-2298/3102 - Docker IpAccessShared app instances do not show the containerid for the app

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -645,6 +645,17 @@ func (v *VMPlatform) GetAppInstRuntime(ctx context.Context, clusterInst *edgepro
 		}
 		return k8smgmt.GetAppInstRuntime(ctx, client, names, app, appInst)
 	case cloudcommon.DeploymentTypeDocker:
+		if app.AccessType == edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER {
+			nodeIp, err := v.GetIPFromServerName(ctx, v.VMProperties.GetCloudletMexNetwork(), GetClusterSubnetName(ctx, clusterInst), GetClusterMasterName(ctx, clusterInst))
+			if err != nil {
+				return nil, err
+			}
+			// docker command will run on the docker vm
+			client, err = client.AddHop(nodeIp.ExternalAddr, 22)
+			if err != nil {
+				return nil, err
+			}
+		}
 		return dockermgmt.GetAppInstRuntime(ctx, client, app, appInst)
 	case cloudcommon.DeploymentTypeVM:
 		fallthrough


### PR DESCRIPTION
Fixed two issues:
* EDGECLOUD-3102 - Docker shared app inst shows the containers for all apps on the rootlb
* EDGECLOUD-2298 - Docker IpAccessShared app instances do not show the containerid for the app

For AccessTypeLoadBalancer, we must add hop to access docker VM