### PR TITLE
backwards compatibility to old port names from R2

### DIFF
--- a/crm-platforms/vsphere/vsphere-cloudlet.go
+++ b/crm-platforms/vsphere/vsphere-cloudlet.go
@@ -82,7 +82,7 @@ func (v *VSpherePlatform) AddCloudletImageIfNotPresent(ctx context.Context, imgP
 			return "", fmt.Errorf("Error in creating baseimage template: %v", err)
 		}
 	}
-	return imgPath, nil
+	return pfImageName, nil
 }
 
 func (v *VSpherePlatform) GetFlavor(ctx context.Context, flavorName string) (*edgeproto.FlavorInfo, error) {


### PR DESCRIPTION
EDGECLOUD-3101

After R2, the port naming convention changed, it now contains both vm name and subnet name rather than just vm name.  This caused a backwards-compatibility issue in TEF when we had clusters created with the R2 load, and then upgraded the CRM to the master.  AppInsts could not be created or deleted on these clusters due to inability to find the server IP.

Fix is to support backwards compatibility by retrying the GetIPFromServerDetails using the old port name if it fails using the current port name.

Unrelated: a fix to vSphere cloudlet image download was returning the full path and not just the image name