### PR TITLE
EDGECLOUD-3214/3021: Fixes for failure in chef client creation

### DIFF
--- a/vmlayer/cluster.go
+++ b/vmlayer/cluster.go
@@ -133,12 +133,13 @@ func (v *VMPlatform) updateClusterInternal(ctx context.Context, client ssh.Clien
 				continue
 			}
 			numNodes++
+			nodeName := GetClusterNodeName(ctx, clusterInst, num)
 			// heat will remove the higher-numbered nodes
 			if num > clusterInst.NumNodes {
 				toRemove = append(toRemove, n)
-				chefUpdateInfo[n] = ActionRemove
+				chefUpdateInfo[nodeName] = ActionRemove
 			} else {
-				chefUpdateInfo[n] = ActionNone
+				chefUpdateInfo[nodeName] = ActionNone
 			}
 		}
 		if len(toRemove) > 0 {


### PR DESCRIPTION
**Fixes:**
* EDGECLOUD-3124: Creation of AppInst with VM deployment and AccessTypeLoadBalancer fails
  - Deletion of LB client was not present. Have added it.
* EDGECLOUD-3021: Chef doesn't handle UpdateClusterInst
  - kubectl strips node name to be of length 64 chars. Hence, store names from our functions rather than using kubectl's list of node names