### PR TITLE
EDGECLOUD-3132: Fixes issues with VM deployment of AccessTypeLoadBalancer

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -490,6 +490,7 @@ func (v *VMPlatform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.C
 			if err != nil {
 				log.SpanLog(ctx, log.DebugLevelInfra, "failed to delete client from Chef Server", "clientName", clientName, "err", err)
 			}
+			DeleteRootLB(lbName)
 		}
 		imgName, err := cloudcommon.GetFileName(app.ImagePath)
 		if err != nil {


### PR DESCRIPTION
Fixes bunch of issues here:
* subnet name was empty, because we were reading it from uninitialised variable
* similarly lbName was uninitialised
* Changed LBName to be a proper FQDN with AppDNSRoot set