### PR TITLE
fix problem of internal ip used for dns in TEF

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -187,7 +187,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 
 		// set up DNS
 		var rootLBIPaddr *ServerIP
-		rootLBIPaddr, err = v.GetIPFromServerName(ctx, v.VMProperties.GetCloudletExternalNetwork(), GetClusterSubnetName(ctx, clusterInst), rootLBName)
+		rootLBIPaddr, err = v.GetIPFromServerName(ctx, v.VMProperties.GetCloudletExternalNetwork(), "", rootLBName)
 		if err == nil {
 			getDnsAction := func(svc v1.Service) (*infracommon.DnsSvcAction, error) {
 				action := infracommon.DnsSvcAction{}


### PR DESCRIPTION
Today, there were a couple of appinsts noticed in TEF with DNS entries like:

mobiledgexsdkdemo20-tcp.sfdockerdedcatedmadgal.edge1-madrid-spain.telefonica.mobiledgex.net - 10.101.0.1
mobiledgexsdkdemo20-tcp.sfwitredisprivacypolicy.edge1-madrid-spain.telefonica.mobiledgex.net - 10.101.4.1

This is the appinst specific DNS entry with the service prefix.   It is pointing to the private IP of rootLB and not the public one.

I cannot reproduce the problem fully, but I partially can based on the following scenario:

1) CRM is restarted after clusterinst created
2) The name of the external network ("ue" in this case) comes alphabetically after the mex-k8s net

The root cause I believe is that the call to GetIPFromServerName when the DNS is populated is passing both the external network and the internal subnet.  So both can match an IP.  The reason we probably didn't see this in TEF earlier is the clusters were not preexisting before CRM restart.  This is because the first place the code looks for an IP match on the rootLB is the cache of rootlb IPs.  This is cleared after CRM restart.  The reason we never see it in DT is due to the fact that in DT the external network is called "external-network-shared".  This causes the output of "openstack server list" to put the external network first in the DT case, and second in the TEF case.

This is the easy fix for the immediate problem.  The fact that the LB cache is wiped and not refreshed after restart should also be addressed in a future PR.  Also GetIPFromServerName should be modified to ensure only 1 IP is matched, and throw an error otherwise.

