### PR TITLE
fix heat unit test

### DIFF
--- a/crm-platforms/openstack/openstack_heat_test.go
+++ b/crm-platforms/openstack/openstack_heat_test.go
@@ -67,7 +67,12 @@ func TestHeatTemplate(t *testing.T) {
 	vaultServer, vaultConfig := vault.DummyServer()
 	defer vaultServer.Close()
 
+	ckey := edgeproto.CloudletKey{
+		Organization: "MobiledgeX",
+		Name:         "unit-test",
+	}
 	pc := pf.PlatformConfig{}
+	pc.CloudletKey = &ckey
 
 	op := OpenstackPlatform{TestMode: true}
 	var vmp = vmlayer.VMPlatform{


### PR DESCRIPTION
EDGECLOUD-3165

Infra unit-test for TestHeatTemplate fails due crash when looking for shared rootLB because the cloudlet key is nil.