### PR TITLE
fix floating ip

### DIFF
--- a/crm-platforms/openstack/openstack-server.go
+++ b/crm-platforms/openstack/openstack-server.go
@@ -63,6 +63,7 @@ func (o *OpenstackPlatform) UpdateServerIPs(ctx context.Context, addresses strin
 					serverIP.InternalAddr = strings.TrimSpace(addrs[0])
 					serverIP.ExternalAddr = strings.TrimSpace(addrs[1])
 					serverIP.ExternalAddrIsFloating = true
+					serverDetail.Addresses = append(serverDetail.Addresses, serverIP)
 				} else {
 					return fmt.Errorf("GetServerExternalIPFromAddr: Unable to parse '%s'", addr)
 				}


### PR DESCRIPTION
EDGECLOUD-3166.  Floating IPs not working properly post R2.

Thanks for researching this @ashxjain !   Fix was tried in WWT gsplab.