### PR TITLE
EDGECLOUD-3036 deepcopy, lookup cache, keyworkers

### DIFF
--- a/autoprov/autoprov.go
+++ b/autoprov/autoprov.go
@@ -83,10 +83,9 @@ func start() error {
 	cacheData.init()
 	autoProvAggr = NewAutoProvAggr(settings.AutoDeployIntervalSec, settings.AutoDeployOffsetSec, &cacheData)
 	minMaxChecker = newMinMaxChecker(&cacheData)
-	cacheData.alertCache.SetUpdatedCb(alertChanged)
+	cacheData.alertCache.AddUpdatedCb(alertChanged)
 
 	autoProvAggr.Start()
-	minMaxChecker.Start()
 
 	addrs := strings.Split(*notifyAddrs, ",")
 	notifyClient = notify.NewClient(addrs, dialOpts)
@@ -99,9 +98,6 @@ func start() error {
 }
 
 func stop() {
-	if minMaxChecker != nil {
-		minMaxChecker.Stop()
-	}
 	if autoProvAggr != nil {
 		autoProvAggr.Stop()
 	}

--- a/autoprov/autoprov_aggr.go
+++ b/autoprov/autoprov_aggr.go
@@ -61,9 +61,9 @@ func NewAutoProvAggr(intervalSec, offsetSec float64, caches *CacheData) *AutoPro
 	s.offsetSec = offsetSec
 	s.caches = caches
 	// set callbacks to respond to changes
-	caches.appCache.SetUpdatedKeyCb(s.UpdateApp)
-	caches.appCache.SetDeletedKeyCb(s.DeleteApp)
-	caches.autoProvPolicyCache.SetUpdatedKeyCb(s.UpdatePolicy)
+	caches.appCache.AddUpdatedKeyCb(s.UpdateApp)
+	caches.appCache.AddDeletedKeyCb(s.DeleteApp)
+	caches.autoProvPolicyCache.AddUpdatedKeyCb(s.UpdatePolicy)
 	return &s
 }
 

--- a/autoprov/autoprov_deploy_test.go
+++ b/autoprov/autoprov_deploy_test.go
@@ -38,15 +38,15 @@ func TestDeploy(t *testing.T) {
 	inst2.Key.AppKey.Name = "foo2"
 	go goAppInstApi(ctx, &inst2, cloudcommon.Create, "test", "")
 
-	err := dc.waitForAppInsts(2)
+	err := dc.waitForAppInsts(ctx, 2)
 	require.Nil(t, err)
 
 	go goAppInstApi(ctx, &inst2, cloudcommon.Delete, "test", "")
-	err = dc.waitForAppInsts(1)
+	err = dc.waitForAppInsts(ctx, 1)
 	require.Nil(t, err)
 
 	go goAppInstApi(ctx, &inst, cloudcommon.Delete, "test", "")
-	err = dc.waitForAppInsts(0)
+	err = dc.waitForAppInsts(ctx, 0)
 	require.Nil(t, err)
 }
 
@@ -89,14 +89,15 @@ func (s *DummyController) getBufDialer() func(context.Context, string) (net.Conn
 	}
 }
 
-func (s *DummyController) waitForAppInsts(count int) error {
+func (s *DummyController) waitForAppInsts(ctx context.Context, count int) error {
 	for i := 0; i < 50; i++ {
 		if s.appInstCache.GetCount() == count {
+			log.SpanLog(ctx, log.DebugLevelInfo, "waitForAppInsts: count matched", "count", count)
 			return nil
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	log.DebugLog(log.DebugLevelInfo, "Timed out waiting for cache")
+	log.SpanLog(ctx, log.DebugLevelInfo, "Timed out waiting for cache")
 	return fmt.Errorf("Timed out waiting for %d AppInsts, have %d instead", count, s.appInstCache.GetCount())
 }
 

--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -307,6 +307,6 @@ var AppAutoProvPolicyComments = map[string]string{
 	"appkey.organization": "App developer organization",
 	"appkey.name":         "App name",
 	"appkey.version":      "App version",
-	"autoprovpolicy":      "Auto Provisioning Policy name",
+	"autoprovpolicy":      "Auto provisioning policy name",
 }
 var AppAutoProvPolicySpecialArgs = map[string]string{}

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -184,7 +184,7 @@ func RunServer(config *ServerConfig) (*Server, error) {
 		if config.InitLocal || os.IsNotExist(err) {
 			sql.InitDataDir()
 		}
-		err = sql.StartLocal("")
+		err = sql.StartLocal("", process.WithCleanStartup())
 		if err != nil {
 			return nil, fmt.Errorf("local sql start failed, %s",
 				err.Error())


### PR DESCRIPTION
This leverages much of the changes from https://github.com/mobiledgex/edge-cloud/pull/996

Most of the changes are in autoprov_minmax.go.
- hand-written look up caches are replaced by auto-generated ones.
- use keyworkers to manage worker threads instead of a custom worker thread

Functionally there are two changes:
- instead of a single worker thread for all apps, each app will get its own worker thread. This should improve response times at scale.
- because of the above, I had to rework the way failover requests (cloudlet maintenance) were handled. Gets a little tricking having to wait for other threads to finish.
