### PR TITLE
add cloudlet secgrp to router

### DIFF
--- a/vmlayer/vmparams.go
+++ b/vmlayer/vmparams.go
@@ -487,11 +487,7 @@ func (v *VMPlatform) getVMGroupOrchestrationParamsFromGroupSpec(ctx context.Cont
 	cloudflareDns := []string{"1.1.1.1", "1.0.0.1"}
 	vmDns := ""
 	subnetDns := []string{}
-	var err error
-	cloudletSecGrpID := ""
-	if !spec.SkipDefaultSecGrp {
-		cloudletSecGrpID, err = v.VMProvider.GetResourceID(ctx, ResourceTypeSecurityGroup, v.VMProperties.GetCloudletSecurityGroupName())
-	}
+	cloudletSecGrpID, err := v.VMProvider.GetResourceID(ctx, ResourceTypeSecurityGroup, v.VMProperties.GetCloudletSecurityGroupName())
 	internalSecgrpID := ""
 	internalSecgrpPreexisting := false
 
@@ -525,11 +521,9 @@ func (v *VMPlatform) getVMGroupOrchestrationParamsFromGroupSpec(ctx context.Cont
 	} else {
 		log.SpanLog(ctx, log.DebugLevelInfra, "External router in use")
 		if spec.NewSubnetName != "" {
-			if !spec.SkipDefaultSecGrp {
-				log.SpanLog(ctx, log.DebugLevelInfra, "SkipDefaultSecGrp flag set")
-				internalSecgrpID = cloudletSecGrpID
-				internalSecgrpPreexisting = true
-			}
+			internalSecgrpID = cloudletSecGrpID
+			internalSecgrpPreexisting = true
+
 			rtrInUse = true
 			routerPortName := spec.NewSubnetName + "-rtr-port"
 			routerPort := PortOrchestrationParams{


### PR DESCRIPTION
To try to prepare for the TELUS upgrade, I did some tests in as similar an environment as possible.  I discovered a potential problem in that the interface we create to the router does not have a security group, as it does with the current ports in Telus.

I'm not 100% sure this will be the last problem with Telus due to the unusual nature of their setup.. but it needs to be fixed prior to trying.