### PR TITLE
Bump up Jaeger's span age to one month

### DIFF
--- a/ansible/roles/jaeger/tasks/main.yml
+++ b/ansible/roles/jaeger/tasks/main.yml
@@ -79,6 +79,7 @@
           ES_INDEX_PREFIX: "{{ es_index_prefix | default('main') }}"
           ES_USERNAME: "{{ jaeger_es_user }}"
           ES_PASSWORD: "{{ jaeger_es_pass }}"
+          ES_MAX_SPAN_AGE: "720h"
 
     - name: Deploy jaeger query
       docker_container:
@@ -93,6 +94,7 @@
           ES_INDEX_PREFIX: "{{ es_index_prefix | default('main') }}"
           ES_USERNAME: "{{ jaeger_es_user }}"
           ES_PASSWORD: "{{ jaeger_es_pass }}"
+          ES_MAX_SPAN_AGE: "720h"
 
     - name: Install dependencies
       apt:


### PR DESCRIPTION
By default, Jaeger with an Elasticsearch backend only looks for spans
which are less than 72 hours old.