### PR TITLE
EDGECLOUD-3239 AutoProv AppInst deleted when MaxInstance=0

### DIFF
--- a/autoprov/autoprov_minmax_test.go
+++ b/autoprov/autoprov_minmax_test.go
@@ -223,9 +223,12 @@ func TestAppChecker(t *testing.T) {
 	pt1.policy.MinActiveInstances = 0
 	pt1.policy.MaxInstances = 0
 	pt1.updatePolicy(ctx)
+	pt1.deleteAppInsts(ctx, dc, &app.Key)
 	pt2.policy.MinActiveInstances = 0
 	pt2.policy.MaxInstances = 0
 	pt2.updatePolicy(ctx)
+	pt2.deleteAppInsts(ctx, dc, &app.Key)
+
 	minmax.CheckApp(ctx, app.Key)
 	err = dc.waitForAppInsts(ctx, 0)
 	require.Nil(t, err)
@@ -246,9 +249,11 @@ func TestAppChecker(t *testing.T) {
 	pt1.policy.MinActiveInstances = 0
 	pt1.policy.MaxInstances = 0
 	pt1.updatePolicy(ctx)
+	pt1.deleteAppInsts(ctx, dc, &app.Key)
 	pt2.policy.MinActiveInstances = 0
 	pt2.policy.MaxInstances = 0
 	pt2.updatePolicy(ctx)
+	pt2.deleteAppInsts(ctx, dc, &app.Key)
 	minmax.CheckApp(ctx, app.Key)
 	err = dc.waitForAppInsts(ctx, 0)
 	require.Nil(t, err)
@@ -296,6 +301,7 @@ func TestAppChecker(t *testing.T) {
 	pt1.policy.MinActiveInstances = 0
 	pt1.policy.MaxInstances = 0
 	pt1.updatePolicy(ctx)
+	pt1.deleteAppInsts(ctx, dc, &app.Key)
 	minmax.CheckApp(ctx, app.Key)
 	err = dc.waitForAppInsts(ctx, 0)
 	require.Nil(t, err)
@@ -338,6 +344,7 @@ func TestAppChecker(t *testing.T) {
 	pt1.policy.MinActiveInstances = 0
 	pt1.policy.MaxInstances = 0
 	pt1.updatePolicy(ctx)
+	pt1.deleteAppInsts(ctx, dc, &app.Key)
 	minmax.CheckApp(ctx, app.Key)
 	err = dc.waitForAppInsts(ctx, 0)
 	require.Nil(t, err)
@@ -425,6 +432,7 @@ func TestAppChecker(t *testing.T) {
 	pt1.policy.MinActiveInstances = 0
 	pt1.policy.MaxInstances = 0
 	pt1.updatePolicy(ctx)
+	pt1.deleteAppInsts(ctx, dc, &app.Key)
 	minmax.CheckApp(ctx, app.Key)
 	err = dc.waitForAppInsts(ctx, 0)
 	require.Nil(t, err)
@@ -548,4 +556,10 @@ func (s *policyTest) getAppInsts(key *edgeproto.AppKey) []edgeproto.AppInst {
 		insts = append(insts, inst)
 	}
 	return insts
+}
+
+func (s *policyTest) deleteAppInsts(ctx context.Context, dc *DummyController, key *edgeproto.AppKey) {
+	for _, inst := range s.getAppInsts(key) {
+		dc.deleteAppInst(ctx, &inst)
+	}
 }

--- a/e2e-tests/data/mc_showaudit_user2.yml
+++ b/e2e-tests/data/mc_showaudit_user2.yml
@@ -23,7 +23,7 @@
   starttime: "2020-03-18T14:06:20.216288-07:00"
   duration: 671µs
   request: '{"Region":"locala","Settings":{}}'
-  response: '{"message"="Forbidden"}'
+  response: '{"message":"Forbidden"}'
   traceid: 33f2e0e8baa458b5
 - operationname: /api/v1/auth/ctrl/ShowSettings
   username: user2
@@ -32,7 +32,7 @@
   starttime: "2020-01-16T16:24:05.019808-08:00"
   duration: 578µs
   request: '{"Region":"local","Settings":{}}'
-  response: '{"message"="Forbidden"}'
+  response: '{"message":"Forbidden"}'
   traceid: 6d8e25359c7c2d2d
 - operationname: /api/v1/login
   username: user2


### PR DESCRIPTION
Fix for AutoProv deleting AppInsts when MaxInstance = 0. A check was missing to avoid trying to delete instances if MaxInstances was 0. Needed to tweak my unit-tests as a result. The other change to e2e-test data is from someone else's change.