### PR TITLE
EDGECLOUD-1825 AutoProv Undeploy

### DIFF
--- a/autoprov/autorules/autoprovrules.go
+++ b/autoprov/autorules/autoprovrules.go
@@ -1,0 +1,32 @@
+package autorules
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/prommgmt"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/prometheus/common/model"
+)
+
+func GetAutoUndeployRules(ctx context.Context, settings edgeproto.Settings, appKey *edgeproto.AppKey, policy *edgeproto.AutoProvPolicy) *prommgmt.RuleGroup {
+	if policy.UndeployClientCount == 0 {
+		return nil
+	}
+	grp := prommgmt.NewRuleGroup("autoprov-feature", policy.Key.Organization)
+
+	rule := prommgmt.Rule{}
+	rule.Alert = cloudcommon.AlertAutoUndeploy
+	rule.Expr = `envoy_cluster_upstream_cx_active{` +
+		edgeproto.AppKeyTagName + `="` + appKey.Name + `",` +
+		edgeproto.AppKeyTagVersion + `="` + appKey.Version + `",` +
+		edgeproto.AppKeyTagOrganization + `="` + appKey.Organization +
+		`"} <= ` + fmt.Sprintf("%d", policy.UndeployClientCount)
+	forSec := int64(policy.UndeployIntervalCount) * int64(settings.AutoDeployIntervalSec)
+	rule.For = model.Duration(time.Second * time.Duration(forSec))
+	grp.Rules = append(grp.Rules, rule)
+
+	return grp
+}

--- a/autoprov/autorules/autoscalerules.go
+++ b/autoprov/autorules/autoscalerules.go
@@ -1,0 +1,102 @@
+package autorules
+
+import (
+	"bytes"
+	"context"
+	"text/template"
+
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+)
+
+// If an auto-scale profile is set, we add two measurements and two alerts.
+// The measurements count the number of nodes that are above the high cpu
+// threshold and below the low cpu threshold. These measurements assume
+// the master node is not schedulable and other nodes are schedulable, which
+// may not be true if custom taints are used.
+// The scale up alert fires when all nodes are above the high cpu threshold,
+// and there are less than the max number of nodes.
+// The scale down alert files when any node is below the low cpu threshold,
+// and there are more than the min number of nodes.
+var MEXPrometheusAutoScaleT = `additionalPrometheusRules:
+- name: autoscalepolicy
+  groups:
+  - name: autoscale.rules
+    rules:
+    - expr: 1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
+      record: :node_cpu_utilisation:avg1m
+    - expr: |-
+        1 - avg by (node) (
+          rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
+        * on (namespace, pod) group_left(node)
+          node_namespace_pod:kube_pod_info:)
+      record: node:node_cpu_utilisation:avg1m
+    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"[[.NodePrefix]].*"} > bool [[printf "%.2f" .ScaleUpCpuThreshF]])
+      record: 'node_cpu_high_count'
+    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"[[.NodePrefix]].*"} < bool [[printf "%.2f" .ScaleDownCpuThreshF]])
+      record: 'node_cpu_low_count'
+    - expr: count(kube_node_info) - count(kube_node_spec_taint)
+      record: 'node_count'
+    - alert: [[.AutoScaleUpName]]
+      expr: node_cpu_high_count == node_count and node_count < [[.MaxNodes]]
+      for: [[.TriggerTimeSec]]s
+      labels:
+        severity: none
+      annotations:
+        message: High cpu greater than [[.ScaleUpCpuThresh]]% for all nodes
+        [[.NodeCountName]]: '{{ with query "node_count" }}{{ . | first | value | humanize }}{{ end }}'
+    - alert: [[.AutoScaleDownName]]
+      expr: node_cpu_low_count > 0 and node_count > [[.MinNodes]]
+      for: [[.TriggerTimeSec]]s
+      labels:
+        severity: none
+      annotations:
+        message: Low cpu less than [[.ScaleDownCpuThresh]]% for some nodes
+        [[.LowCpuNodeCountName]]: '{{ $value }}'
+        [[.NodeCountName]]: '{{ with query "node_count" }}{{ . | first | value | humanize }}{{ end }}'
+        [[.MinNodesName]]: '[[.MinNodes]]'
+`
+
+type AutoScaleArgs struct {
+	AutoScalePolicy     string
+	AutoScaleUpName     string
+	AutoScaleDownName   string
+	ScaleUpCpuThresh    uint32
+	ScaleDownCpuThresh  uint32
+	ScaleUpCpuThreshF   float32
+	ScaleDownCpuThreshF float32
+	TriggerTimeSec      uint32
+	MaxNodes            int
+	MinNodes            int
+	NodeCountName       string
+	LowCpuNodeCountName string
+	MinNodesName        string
+	NodePrefix          string // master node must have different prefix
+}
+
+func GetAutoScaleRules(ctx context.Context, policy *edgeproto.AutoScalePolicy) (string, error) {
+	// change delims because Prometheus triggers off of golang delims
+	t := template.Must(template.New("policy").Delims("[[", "]]").Parse(MEXPrometheusAutoScaleT))
+	args := AutoScaleArgs{
+		AutoScalePolicy:     policy.Key.Name,
+		AutoScaleUpName:     cloudcommon.AlertAutoScaleUp,
+		AutoScaleDownName:   cloudcommon.AlertAutoScaleDown,
+		ScaleUpCpuThresh:    policy.ScaleUpCpuThresh,
+		ScaleDownCpuThresh:  policy.ScaleDownCpuThresh,
+		ScaleUpCpuThreshF:   float32(policy.ScaleUpCpuThresh) / 100.0,
+		ScaleDownCpuThreshF: float32(policy.ScaleDownCpuThresh) / 100.0,
+		TriggerTimeSec:      policy.TriggerTimeSec,
+		MaxNodes:            int(policy.MaxNodes),
+		MinNodes:            int(policy.MinNodes),
+		NodeCountName:       cloudcommon.AlertKeyNodeCount,
+		LowCpuNodeCountName: cloudcommon.AlertKeyLowCpuNodeCount,
+		MinNodesName:        cloudcommon.AlertKeyMinNodes,
+		NodePrefix:          cloudcommon.MexNodePrefix,
+	}
+	buf := bytes.Buffer{}
+	err := t.Execute(&buf, &args)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/crm-platforms/edgebox/edgebox-cloudlet.go
+++ b/crm-platforms/edgebox/edgebox-cloudlet.go
@@ -20,7 +20,7 @@ func (e *EdgeboxPlatform) CreateCloudlet(ctx context.Context, cloudlet *edgeprot
 		return err
 	}
 
-	return fakeinfra.CloudletPrometheusStartup(ctx, cloudlet, pfConfig, updateCallback)
+	return fakeinfra.CloudletPrometheusStartup(ctx, cloudlet, pfConfig, caches, updateCallback)
 }
 
 func (e *EdgeboxPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, updateCallback edgeproto.CacheUpdateCallback) error {
@@ -30,7 +30,7 @@ func (e *EdgeboxPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeprot
 		return err
 	}
 	updateCallback(edgeproto.UpdateTask, "Stopping Cloudlet Monitoring")
-	intprocess.StartCloudletPrometheus(ctx, cloudlet)
+	intprocess.StartCloudletPrometheus(ctx, cloudlet, edgeproto.GetDefaultSettings())
 	updateCallback(edgeproto.UpdateTask, "Stopping Shepherd")
 	return intprocess.StopShepherdService(ctx, cloudlet)
 }

--- a/crm-platforms/fakeinfra/fakeinfra.go
+++ b/crm-platforms/fakeinfra/fakeinfra.go
@@ -4,17 +4,34 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
+	"sync"
 	"time"
 
 	intprocess "github.com/mobiledgex/edge-cloud-infra/e2e-tests/int-process"
+	"github.com/mobiledgex/edge-cloud-infra/shepherd/shepherd_common"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
 	pf "github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/fake"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/integration/process"
+	"github.com/mobiledgex/edge-cloud/log"
 )
 
 type Platform struct {
 	fake.Platform
+	envoys map[edgeproto.AppInstKey]*exec.Cmd
+	mux    sync.Mutex
+}
+
+func (s *Platform) GetType() string {
+	return "fakeinfra"
+}
+
+func (s *Platform) Init(ctx context.Context, platformConfig *platform.PlatformConfig, caches *platform.Caches, updateCallback edgeproto.CacheUpdateCallback) error {
+	s.envoys = make(map[edgeproto.AppInstKey]*exec.Cmd)
+	return s.Platform.Init(ctx, platformConfig, caches, updateCallback)
 }
 
 func (s *Platform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, flavor *edgeproto.Flavor, caches *pf.Caches, updateCallback edgeproto.CacheUpdateCallback) error {
@@ -25,7 +42,7 @@ func (s *Platform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 	if err = ShepherdStartup(ctx, cloudlet, pfConfig, updateCallback); err != nil {
 		return err
 	}
-	return CloudletPrometheusStartup(ctx, cloudlet, pfConfig, updateCallback)
+	return CloudletPrometheusStartup(ctx, cloudlet, pfConfig, caches, updateCallback)
 }
 
 func (s *Platform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, updateCallback edgeproto.CacheUpdateCallback) error {
@@ -38,7 +55,7 @@ func (s *Platform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Cloud
 }
 
 // Start prometheus container
-func CloudletPrometheusStartup(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, updateCallback edgeproto.CacheUpdateCallback) error {
+func CloudletPrometheusStartup(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, caches *pf.Caches, updateCallback edgeproto.CacheUpdateCallback) error {
 	// for fakeinfra we only start the first cloudlet prometheus, since it's going to run on the same port as
 	// other cloudlet prometheus
 	if intprocess.CloudletPrometheusExists(ctx) {
@@ -47,7 +64,7 @@ func CloudletPrometheusStartup(ctx context.Context, cloudlet *edgeproto.Cloudlet
 	}
 
 	updateCallback(edgeproto.UpdateTask, "Starting Cloudlet Monitoring")
-	return intprocess.StartCloudletPrometheus(ctx, cloudlet)
+	return intprocess.StartCloudletPrometheus(ctx, cloudlet, caches.SettingsCache.Singular())
 }
 
 func ShepherdStartup(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, updateCallback edgeproto.CacheUpdateCallback) error {
@@ -76,4 +93,42 @@ func ShepherdStartup(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig
 		// Small timeout should be enough for Shepherd to connect to CRM as both will be present locally
 		return nil
 	}
+}
+
+func (s *Platform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, flavor *edgeproto.Flavor, privacyPolicy *edgeproto.PrivacyPolicy, updateCallback edgeproto.CacheUpdateCallback) error {
+	updateCallback(edgeproto.UpdateTask, "Creating App Inst")
+	if shepherd_common.ShouldRunEnvoy(app, appInst) {
+		name := shepherd_common.GetProxyKey(&appInst.Key)
+		envoySock := "/tmp/envoy_" + name + ".sock"
+		envoyLog := "/tmp/envoy_" + name + ".log"
+
+		args := []string{
+			"--sockfile", envoySock,
+			"--cluster", clusterInst.Key.ClusterKey.Name,
+		}
+		log.SpanLog(ctx, log.DebugLevelInfra, "start fake_envoy_exporter", "AppInst", appInst.Key)
+		cmd, err := process.StartLocal(name, "fake_envoy_exporter", args, nil, envoyLog)
+		if err != nil {
+			return err
+		}
+		s.mux.Lock()
+		s.envoys[appInst.Key] = cmd
+		s.mux.Unlock()
+	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "fake AppInst ready")
+	return nil
+}
+
+func (s *Platform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) error {
+	s.mux.Lock()
+	cmd, ok := s.envoys[appInst.Key]
+	delete(s.envoys, appInst.Key)
+	s.mux.Unlock()
+
+	if ok {
+		cmd.Process.Kill()
+		cmd.Process.Wait()
+	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "fake AppInst deleted")
+	return nil
 }

--- a/e2e-tests/data/autoprov_appinst_empty.yml
+++ b/e2e-tests/data/autoprov_appinst_empty.yml
@@ -1,0 +1,3 @@
+regiondata:
+- region: local
+  appdata:

--- a/e2e-tests/data/autoprov_appinst_fake.yml
+++ b/e2e-tests/data/autoprov_appinst_fake.yml
@@ -1,0 +1,16 @@
+regiondata:
+- region: local
+  appdata:
+    appinstances:
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: autoprovapp
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: Reservable2
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-2
+          organization: MobiledgeX

--- a/e2e-tests/data/autoprov_clearactive
+++ b/e2e-tests/data/autoprov_clearactive
@@ -1,0 +1,1 @@
+curl --unix-socket /tmp/envoy_autoprovappd-ReservableD-AcmeAppCo-1.0.sock --data-urlencode 'measure=envoy_cluster_upstream_cx_active{envoy_cluster_name="ReservableD"}' --data-urlencode 'val=0' http:/sock/setval

--- a/e2e-tests/data/mc_admin_data.yml
+++ b/e2e-tests/data/mc_admin_data.yml
@@ -37,6 +37,7 @@ regiondata:
   appdata:
     settings:
       shepherdmetricscollectioninterval: 1s
+      shepherdalertevaluationinterval: 1s
       shepherdhealthcheckretries: 3
       shepherdhealthcheckinterval: 5s
       autodeployintervalsec: 1
@@ -118,6 +119,7 @@ regiondata:
   appdata:
     settings:
       shepherdmetricscollectioninterval: 1s
+      shepherdalertevaluationinterval: 1s
       shepherdhealthcheckretries: 3
       shepherdhealthcheckinterval: 5s
       autodeployintervalsec: 1

--- a/e2e-tests/data/mc_admin_show.yml
+++ b/e2e-tests/data/mc_admin_show.yml
@@ -74,6 +74,7 @@ regiondata:
   appdata:
     settings:
       shepherdmetricscollectioninterval: 1s
+      shepherdalertevaluationinterval: 1s
       shepherdhealthcheckretries: 3
       shepherdhealthcheckinterval: 5s
       autodeployintervalsec: 1

--- a/e2e-tests/data/mc_enabledebug_output.yml
+++ b/e2e-tests/data/mc_enabledebug_output.yml
@@ -139,10 +139,3 @@ requests:
         name: tmus-cloud-1
       region: local
     output: api,notify,infra,metrics,info,sampled
-  - node:
-      type: shepherd
-      cloudletkey:
-        organization: tmus
-        name: tmus-cloud-3
-      region: locala
-    output: api,notify,infra,metrics,info,sampled

--- a/e2e-tests/data/mc_showaudit_org.yml
+++ b/e2e-tests/data/mc_showaudit_org.yml
@@ -14,7 +14,7 @@
   status: 200
   starttime: "2019-12-18T13:36:59.484291-08:00"
   duration: 18.885ms
-  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}]}}'
+  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 7d0896601b1411aa
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy
@@ -108,6 +108,6 @@
   status: 200
   starttime: "2020-03-18T11:41:44.411308-07:00"
   duration: 14.622ms
-  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}]}}'
+  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 73cbbf9e2299ef79

--- a/e2e-tests/data/mc_showaudit_user2.yml
+++ b/e2e-tests/data/mc_showaudit_user2.yml
@@ -69,7 +69,7 @@
   status: 200
   starttime: "2019-12-18T13:42:42.48365-08:00"
   duration: 18.759ms
-  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}]}}'
+  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 7af113ec2d0b698c
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy

--- a/e2e-tests/data/mc_showaudit_user2org.yml
+++ b/e2e-tests/data/mc_showaudit_user2org.yml
@@ -14,7 +14,7 @@
   status: 200
   starttime: "2019-12-18T13:44:44.543446-08:00"
   duration: 16.81ms
-  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}]}}'
+  request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 1b1f287407047931
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy
@@ -108,6 +108,6 @@
   status: 200
   starttime: "2020-03-18T14:19:48.41892-07:00"
   duration: 13.994ms
-  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}]}}'
+  request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 1bf7b6b1f18e9fe3

--- a/e2e-tests/data/mc_showdebug_output.yml
+++ b/e2e-tests/data/mc_showdebug_output.yml
@@ -139,10 +139,3 @@ requests:
         name: tmus-cloud-1
       region: local
     output: api,notify,infra,metrics
-  - node:
-      type: shepherd
-      cloudletkey:
-        organization: tmus
-        name: tmus-cloud-3
-      region: locala
-    output: api,notify,infra,metrics

--- a/e2e-tests/data/mc_user1_data.yml
+++ b/e2e-tests/data/mc_user1_data.yml
@@ -80,7 +80,7 @@ regiondata:
         longitude: -92
       ipsupport: IpSupportDynamic
       numdynamicips: 254
-      platformtype: PlatformTypeFakeinfra
+      platformtype: PlatformTypeFake
       notifysrvaddr: 127.0.0.1:51017
     - key:
         organization: tmus

--- a/e2e-tests/data/mc_user1_data_show.yml
+++ b/e2e-tests/data/mc_user1_data_show.yml
@@ -209,7 +209,7 @@ regiondata:
       ipsupport: IpSupportDynamic
       numdynamicips: 254
       state: Ready
-      platformtype: PlatformTypeFakeinfra
+      platformtype: PlatformTypeFake
       notifysrvaddr: 127.0.0.1:51017
       flavor:
         name: DefaultPlatformFlavor

--- a/e2e-tests/data/mc_user2_data.yml
+++ b/e2e-tests/data/mc_user2_data.yml
@@ -151,6 +151,8 @@ regiondata:
         organization: AcmeAppCo
       deployclientcount: 3
       deployintervalcount: 3
+      undeployclientcount: 1
+      undeployintervalcount: 3
       cloudlets:
       - key:
           organization: tmus
@@ -288,6 +290,8 @@ regiondata:
         organization: AcmeAppCo
       deployclientcount: 3
       deployintervalcount: 3
+      undeployclientcount: 1
+      undeployintervalcount: 3
       cloudlets:
       - key:
           organization: tmus

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -441,6 +441,8 @@ regiondata:
         organization: AcmeAppCo
       deployclientcount: 3
       deployintervalcount: 3
+      undeployclientcount: 1
+      undeployintervalcount: 3
       cloudlets:
       - key:
           organization: tmus
@@ -504,7 +506,7 @@ regiondata:
       ipsupport: IpSupportDynamic
       numdynamicips: 254
       state: Ready
-      platformtype: PlatformTypeFakeinfra
+      platformtype: PlatformTypeFake
       notifysrvaddr: 127.0.0.1:51017
       flavor:
         name: DefaultPlatformFlavor
@@ -530,6 +532,8 @@ regiondata:
         name: autoprov1
       deployclientcount: 3
       deployintervalcount: 3
+      undeployclientcount: 1
+      undeployintervalcount: 3
       cloudlets:
       - key:
           organization: tmus

--- a/e2e-tests/data/mc_user3_data_show.yml
+++ b/e2e-tests/data/mc_user3_data_show.yml
@@ -236,7 +236,7 @@ regiondata:
       ipsupport: IpSupportDynamic
       numdynamicips: 254
       state: Ready
-      platformtype: PlatformTypeFakeinfra
+      platformtype: PlatformTypeFake
       notifysrvaddr: 127.0.0.1:51017
       flavor:
         name: DefaultPlatformFlavor

--- a/e2e-tests/data/mc_user3_empty_show.yml
+++ b/e2e-tests/data/mc_user3_empty_show.yml
@@ -108,7 +108,7 @@ regiondata:
       ipsupport: IpSupportDynamic
       numdynamicips: 254
       state: Ready
-      platformtype: PlatformTypeFakeinfra
+      platformtype: PlatformTypeFake
       notifysrvaddr: 127.0.0.1:51017
       flavor:
         name: DefaultPlatformFlavor

--- a/e2e-tests/data/show_local_region.yml
+++ b/e2e-tests/data/show_local_region.yml
@@ -1,0 +1,1 @@
+region: local

--- a/e2e-tests/data/undeploy_alerts_show.yml
+++ b/e2e-tests/data/undeploy_alerts_show.yml
@@ -1,0 +1,18 @@
+- labels:
+    alertname: AutoProvUndeploy
+    app: autoprovappd
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-1
+    cloudletorg: tmus
+    cluster: ReservableD
+    clusterorg: MobiledgeX
+    envoy_cluster_name: ReservableD
+    instance: host.docker.internal:9091
+    job: envoy_targets
+  state: pending
+  activeat:
+    seconds: 1594945144
+    nanos: 494892341
+  notifyid: 2
+  controller: Jon-Mex@127.0.0.1:55001

--- a/e2e-tests/e2e-setup/cmp.go
+++ b/e2e-tests/e2e-setup/cmp.go
@@ -134,6 +134,23 @@ func CompareYamlFiles(firstYamlFile string, secondYamlFile string, fileType stri
 		}
 		y1 = a1
 		y2 = a2
+	} else if fileType == "mcalerts" {
+		// sort alerts
+		var a1 []edgeproto.Alert
+		var a2 []edgeproto.Alert
+
+		err1 = util.ReadYamlFile(firstYamlFile, &a1)
+		err2 = util.ReadYamlFile(secondYamlFile, &a2)
+
+		copts = []cmp.Option{
+			cmpopts.IgnoreTypes(time.Time{}, dmeproto.Timestamp{}),
+			cmpopts.SortSlices(func(a edgeproto.Alert, b edgeproto.Alert) bool {
+				return a.GetKey().GetKeyString() < b.GetKey().GetKeyString()
+			}),
+		}
+		copts = append(copts, edgeproto.IgnoreAlertFields("nocmp"))
+		y1 = a1
+		y2 = a2
 	} else if fileType == "mcaudit" {
 		var a1 []ormapi.AuditResponse
 		var a2 []ormapi.AuditResponse

--- a/e2e-tests/e2e-setup/e2e-setup.go
+++ b/e2e-tests/e2e-setup/e2e-setup.go
@@ -9,9 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"strconv"
 	"strings"
-	"time"
 
 	intprocess "github.com/mobiledgex/edge-cloud-infra/e2e-tests/int-process"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -398,6 +396,10 @@ func RunAction(ctx context.Context, actionSpec, outputDir string, config *e2eapi
 		if err != nil {
 			errors = append(errors, err.Error())
 		}
+		err = intprocess.StopFakeEnvoyExporters(ctx)
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
 		err = setupmex.Cleanup(ctx)
 		if err != nil {
 			errors = append(errors, err.Error())
@@ -405,13 +407,6 @@ func RunAction(ctx context.Context, actionSpec, outputDir string, config *e2eapi
 	case "fetchlogs":
 		if !FetchRemoteLogs(outputDir) {
 			errors = append(errors, "fetch failed")
-		}
-	case "sleep":
-		t, err := strconv.ParseUint(actionParam, 10, 32)
-		if err == nil {
-			time.Sleep(time.Second * time.Duration(t))
-		} else {
-			errors = append(errors, "Error in parsing sleeptime")
 		}
 	case "runchefclient":
 		err := RunChefClient(spec.ApiFile, vars)

--- a/e2e-tests/e2e-setup/testspec.go
+++ b/e2e-tests/e2e-setup/testspec.go
@@ -1,11 +1,13 @@
 package e2esetup
 
 type TestSpec struct {
-	ApiType     string      `json:"api" yaml:"api"`
-	ApiFile     string      `json:"apifile" yaml:"apifile"`
-	Actions     []string    `json:"actions" yaml:"actions"`
-	CurUserFile string      `json:"curuserfile" yaml:"curuserfile"`
-	CompareYaml CompareYaml `json:"compareyaml" yaml:"compareyaml"`
+	ApiType          string      `json:"api" yaml:"api"`
+	ApiFile          string      `json:"apifile" yaml:"apifile"`
+	Actions          []string    `json:"actions" yaml:"actions"`
+	RetryCount       int         `json:"retrycount" yaml:"retrycount"`
+	RetryIntervalSec float64     `json:"retryintervalsec" yaml:"retryintervalsec"`
+	CurUserFile      string      `json:"curuserfile" yaml:"curuserfile"`
+	CompareYaml      CompareYaml `json:"compareyaml" yaml:"compareyaml"`
 }
 
 type CompareYaml struct {

--- a/e2e-tests/testfiles/autoprov.yml
+++ b/e2e-tests/testfiles/autoprov.yml
@@ -32,10 +32,41 @@ tests:
       yaml1: '{{outputdir}}/show-commands.yml'
       yaml2: '{{datadir2}}/autoprov_appinst_show.yml'
       filetype: mcdata
-  - name: delete auto-provisioned AppInsts
+
+  - name: set active connections to 0 to trigger undeploy on autoprovappd
+    actions: [cmds]
+    apifile: "{{datadir2}}/autoprov_clearactive"
+
+  - name: sleep, allow undeploy alert to be visible as pending
+    actions: [sleep=3]
+
+  - name: check undeploy alerts
+    actions: [mcapi-showalerts]
+    apifile: '{{datadir2}}/show_local_region.yml'
+    curuserfile: '{{datadir2}}/mc_admin.yml'
+    retrycount: 10
+    retryintervalsec: 0.5
+    compareyaml:
+      yaml1: '{{outputdir}}/show-commands.yml'
+      yaml2: '{{datadir2}}/undeploy_alerts_show.yml'
+      filetype: mcalerts
+
+  - name: sleep, allow alerts to go active and delete autoprovappd
+    actions: [sleep=3]
+
+  - name: delete autoprovapp, which will not auto-undeploy because its on non-fakeinfra cloudlet
     actions: [mcapi-delete]
+    apifile: '{{datadir2}}/autoprov_appinst_fake.yml'
+    curuserfile: '{{datadir2}}/mc_user2.yml'
+
+  - name: check that both auto-prov insts are gone
+    actions: [mcapi-showfiltered]
     apifile: '{{datadir2}}/autoprov_appinst.yml'
     curuserfile: '{{datadir2}}/mc_user2.yml'
+    compareyaml:
+      yaml1: '{{outputdir}}/show-commands.yml'
+      yaml2: '{{datadir2}}/autoprov_appinst_empty.yml'
+      filetype: mcdata
 
   - name: create auto-prov HA app and policy, will trigger auto-deployment
     actions: [mcapi-create]

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/pion/webrtc/v2 v2.0.24
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
+	github.com/prometheus/common v0.0.0-20181218105931-67670fe90761
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.4

--- a/mc/mcctl/cliwrapper/alert.mc2.go
+++ b/mc/mcctl/cliwrapper/alert.mc2.go
@@ -46,6 +46,7 @@ It has these top-level messages:
 	AppInstRuntime
 	AppInstInfo
 	AppInstMetrics
+	AppInstLookup
 	AppInstClientKey
 	AppInstClient
 	AutoProvPolicy

--- a/mc/mcctl/ormctl/alert.mc2.go
+++ b/mc/mcctl/ormctl/alert.mc2.go
@@ -46,6 +46,7 @@ It has these top-level messages:
 	AppInstRuntime
 	AppInstInfo
 	AppInstMetrics
+	AppInstLookup
 	AppInstClientKey
 	AppInstClient
 	AutoProvPolicy

--- a/mc/mcctl/ormctl/appinst.mc2.go
+++ b/mc/mcctl/ormctl/appinst.mc2.go
@@ -434,3 +434,39 @@ var AppInstMetricsComments = map[string]string{
 	"something": "what goes here? Note that metrics for grpc calls can be done by a prometheus interceptor in grpc, so adding call metrics here may be redundant unless theyre needed for billing.",
 }
 var AppInstMetricsSpecialArgs = map[string]string{}
+var AppInstLookupRequiredArgs = []string{
+	"key.appkey.organization",
+	"key.appkey.name",
+	"key.appkey.version",
+	"key.clusterinstkey.clusterkey.name",
+	"key.clusterinstkey.cloudletkey.organization",
+	"key.clusterinstkey.cloudletkey.name",
+	"key.clusterinstkey.organization",
+}
+var AppInstLookupOptionalArgs = []string{
+	"policykey.organization",
+	"policykey.name",
+}
+var AppInstLookupAliasArgs = []string{
+	"key.appkey.organization=appinstlookup.key.appkey.organization",
+	"key.appkey.name=appinstlookup.key.appkey.name",
+	"key.appkey.version=appinstlookup.key.appkey.version",
+	"key.clusterinstkey.clusterkey.name=appinstlookup.key.clusterinstkey.clusterkey.name",
+	"key.clusterinstkey.cloudletkey.organization=appinstlookup.key.clusterinstkey.cloudletkey.organization",
+	"key.clusterinstkey.cloudletkey.name=appinstlookup.key.clusterinstkey.cloudletkey.name",
+	"key.clusterinstkey.organization=appinstlookup.key.clusterinstkey.organization",
+	"policykey.organization=appinstlookup.policykey.organization",
+	"policykey.name=appinstlookup.policykey.name",
+}
+var AppInstLookupComments = map[string]string{
+	"key.appkey.organization":                     "App developer organization",
+	"key.appkey.name":                             "App name",
+	"key.appkey.version":                          "App version",
+	"key.clusterinstkey.clusterkey.name":          "Cluster name",
+	"key.clusterinstkey.cloudletkey.organization": "Organization of the cloudlet site",
+	"key.clusterinstkey.cloudletkey.name":         "Name of the cloudlet",
+	"key.clusterinstkey.organization":             "Name of Developer organization that this cluster belongs to",
+	"policykey.organization":                      "Name of the organization for the cluster that this policy will apply to",
+	"policykey.name":                              "Policy name",
+}
+var AppInstLookupSpecialArgs = map[string]string{}

--- a/mc/mcctl/ormctl/autoprovpolicy.mc2.go
+++ b/mc/mcctl/ormctl/autoprovpolicy.mc2.go
@@ -147,6 +147,8 @@ var CreateAutoProvPolicyOptionalArgs = []string{
 	"cloudlets:#.loc.timestamp.nanos",
 	"minactiveinstances",
 	"maxinstances",
+	"undeployclientcount",
+	"undeployintervalcount",
 }
 var AutoProvPolicyRequiredArgs = []string{
 	"app-org",
@@ -168,6 +170,8 @@ var AutoProvPolicyOptionalArgs = []string{
 	"cloudlets:#.loc.timestamp.nanos",
 	"minactiveinstances",
 	"maxinstances",
+	"undeployclientcount",
+	"undeployintervalcount",
 }
 var AutoProvPolicyAliasArgs = []string{
 	"fields=autoprovpolicy.fields",
@@ -188,6 +192,8 @@ var AutoProvPolicyAliasArgs = []string{
 	"cloudlets:#.loc.timestamp.nanos=autoprovpolicy.cloudlets:#.loc.timestamp.nanos",
 	"minactiveinstances=autoprovpolicy.minactiveinstances",
 	"maxinstances=autoprovpolicy.maxinstances",
+	"undeployclientcount=autoprovpolicy.undeployclientcount",
+	"undeployintervalcount=autoprovpolicy.undeployintervalcount",
 }
 var AutoProvPolicyComments = map[string]string{
 	"fields":                             "Fields are used for the Update API to specify which fields to apply",
@@ -206,6 +212,8 @@ var AutoProvPolicyComments = map[string]string{
 	"cloudlets:#.loc.speed":              "speed (IOS) / velocity (Android) (meters/sec)",
 	"minactiveinstances":                 "Minimum number of active instances for High-Availability",
 	"maxinstances":                       "Maximum number of instances (active or not)",
+	"undeployclientcount":                "Number of active clients for the undeploy interval below which trigers undeployment, 0 (default) disables auto undeploy",
+	"undeployintervalcount":              "Number of intervals to check before triggering undeployment",
 }
 var AutoProvPolicySpecialArgs = map[string]string{
 	"autoprovpolicy.fields": "StringArray",

--- a/mc/mcctl/ormctl/settings.mc2.go
+++ b/mc/mcctl/ormctl/settings.mc2.go
@@ -88,6 +88,7 @@ var SettingsApiCmds = []*cli.Command{
 var SettingsRequiredArgs = []string{}
 var SettingsOptionalArgs = []string{
 	"shepherdmetricscollectioninterval",
+	"shepherdalertevaluationinterval",
 	"shepherdhealthcheckretries",
 	"shepherdhealthcheckinterval",
 	"autodeployintervalsec",
@@ -109,6 +110,7 @@ var SettingsOptionalArgs = []string{
 var SettingsAliasArgs = []string{
 	"fields=settings.fields",
 	"shepherdmetricscollectioninterval=settings.shepherdmetricscollectioninterval",
+	"shepherdalertevaluationinterval=settings.shepherdalertevaluationinterval",
 	"shepherdhealthcheckretries=settings.shepherdhealthcheckretries",
 	"shepherdhealthcheckinterval=settings.shepherdhealthcheckinterval",
 	"autodeployintervalsec=settings.autodeployintervalsec",
@@ -130,6 +132,7 @@ var SettingsAliasArgs = []string{
 var SettingsComments = map[string]string{
 	"fields":                            "Fields are used for the Update API to specify which fields to apply",
 	"shepherdmetricscollectioninterval": "Shepherd metrics collection interval for k8s and docker appInstances (duration)",
+	"shepherdalertevaluationinterval":   "Shepherd alert evaluation interval for k8s and docker appInstances (duration)",
 	"shepherdhealthcheckretries":        "Number of times Shepherd Health Check fails before we mark appInst down",
 	"shepherdhealthcheckinterval":       "Health Checking probing frequency (duration)",
 	"autodeployintervalsec":             "Auto Provisioning Stats push and analysis interval (seconds)",

--- a/mc/orm/alert.mc2.go
+++ b/mc/orm/alert.mc2.go
@@ -46,6 +46,7 @@ It has these top-level messages:
 	AppInstRuntime
 	AppInstInfo
 	AppInstMetrics
+	AppInstLookup
 	AppInstClientKey
 	AppInstClient
 	AutoProvPolicy
@@ -237,6 +238,7 @@ func addControllerApis(method string, group *echo.Group) {
 	// The following values should be added to `Settings.fields` field array to specify which fields will be updated.
 	// ```
 	// ShepherdMetricsCollectionInterval: 2
+	// ShepherdAlertEvaluationInterval: 20
 	// ShepherdHealthCheckRetries: 3
 	// ShepherdHealthCheckInterval: 4
 	// AutoDeployIntervalSec: 5
@@ -1029,6 +1031,8 @@ func addControllerApis(method string, group *echo.Group) {
 	// CloudletsLocTimestampNanos: 5.2.8.2
 	// MinActiveInstances: 6
 	// MaxInstances: 7
+	// UndeployClientCount: 8
+	// UndeployIntervalCount: 9
 	// ```
 	// Security:
 	//   Bearer:

--- a/mc/orm/alert_mc2_test.go
+++ b/mc/orm/alert_mc2_test.go
@@ -46,6 +46,7 @@ It has these top-level messages:
 	AppInstRuntime
 	AppInstInfo
 	AppInstMetrics
+	AppInstLookup
 	AppInstClientKey
 	AppInstClient
 	AutoProvPolicy

--- a/mc/orm/testutil/alert_mc2_testutil.go
+++ b/mc/orm/testutil/alert_mc2_testutil.go
@@ -46,6 +46,7 @@ It has these top-level messages:
 	AppInstRuntime
 	AppInstInfo
 	AppInstMetrics
+	AppInstLookup
 	AppInstClientKey
 	AppInstClient
 	AutoProvPolicy

--- a/mc/ormapi/alert.mc2.go
+++ b/mc/ormapi/alert.mc2.go
@@ -46,6 +46,7 @@ It has these top-level messages:
 	AppInstRuntime
 	AppInstInfo
 	AppInstMetrics
+	AppInstLookup
 	AppInstClientKey
 	AppInstClient
 	AutoProvPolicy

--- a/mc/ormclient/alert_client.go
+++ b/mc/ormclient/alert_client.go
@@ -46,6 +46,7 @@ It has these top-level messages:
 	AppInstRuntime
 	AppInstInfo
 	AppInstMetrics
+	AppInstLookup
 	AppInstClientKey
 	AppInstClient
 	AutoProvPolicy

--- a/plugin/common/cluster-svc-plugin.go
+++ b/plugin/common/cluster-svc-plugin.go
@@ -1,111 +1,26 @@
 package common
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"text/template"
-	"github.com/mobiledgex/edge-cloud/cloudcommon"
+
+	"github.com/mobiledgex/edge-cloud-infra/autoprov/autorules"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
 
 type ClusterSvc struct{}
 
-// If an auto-scale profile is set, we add two measurements and two alerts.
-// The measurements count the number of nodes that are above the high cpu
-// threshold and below the low cpu threshold. These measurements assume
-// the master node is not schedulable and other nodes are schedulable, which
-// may not be true if custom taints are used.
-// The scale up alert fires when all nodes are above the high cpu threshold,
-// and there are less than the max number of nodes.
-// The scale down alert files when any node is below the low cpu threshold,
-// and there are more than the min number of nodes.
-var MEXPrometheusAutoScaleT = `additionalPrometheusRules:
-- name: autoscalepolicy
-  groups:
-  - name: autoscale.rules
-    rules:
-    - expr: 1 - avg(rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m]))
-      record: :node_cpu_utilisation:avg1m
-    - expr: |-
-        1 - avg by (node) (
-          rate(node_cpu_seconds_total{job="node-exporter",mode="idle"}[1m])
-        * on (namespace, pod) group_left(node)
-          node_namespace_pod:kube_pod_info:)
-      record: node:node_cpu_utilisation:avg1m
-    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"[[.NodePrefix]].*"} > bool [[printf "%.2f" .ScaleUpCpuThreshF]])
-      record: 'node_cpu_high_count'
-    - expr: sum(node:node_cpu_utilisation:avg1m{node=~"[[.NodePrefix]].*"} < bool [[printf "%.2f" .ScaleDownCpuThreshF]])
-      record: 'node_cpu_low_count'
-    - expr: count(kube_node_info) - count(kube_node_spec_taint)
-      record: 'node_count'
-    - alert: [[.AutoScaleUpName]]
-      expr: node_cpu_high_count == node_count and node_count < [[.MaxNodes]]
-      for: [[.TriggerTimeSec]]s
-      labels:
-        severity: none
-      annotations:
-        message: High cpu greater than [[.ScaleUpCpuThresh]]% for all nodes
-        [[.NodeCountName]]: '{{ with query "node_count" }}{{ . | first | value | humanize }}{{ end }}'
-    - alert: [[.AutoScaleDownName]]
-      expr: node_cpu_low_count > 0 and node_count > [[.MinNodes]]
-      for: [[.TriggerTimeSec]]s
-      labels:
-        severity: none
-      annotations:
-        message: Low cpu less than [[.ScaleDownCpuThresh]]% for some nodes
-        [[.LowCpuNodeCountName]]: '{{ $value }}'
-        [[.NodeCountName]]: '{{ with query "node_count" }}{{ . | first | value | humanize }}{{ end }}'
-        [[.MinNodesName]]: '[[.MinNodes]]'
-`
-
-type AutoScaleArgs struct {
-	AutoScalePolicy     string
-	AutoScaleUpName     string
-	AutoScaleDownName   string
-	ScaleUpCpuThresh    uint32
-	ScaleDownCpuThresh  uint32
-	ScaleUpCpuThreshF   float32
-	ScaleDownCpuThreshF float32
-	TriggerTimeSec      uint32
-	MaxNodes            int
-	MinNodes            int
-	NodeCountName       string
-	LowCpuNodeCountName string
-	MinNodesName        string
-	NodePrefix          string // master node must have different prefix
-}
-
 func (s *ClusterSvc) GetAppInstConfigs(ctx context.Context, clusterInst *edgeproto.ClusterInst, appInst *edgeproto.AppInst, policy *edgeproto.AutoScalePolicy) ([]*edgeproto.ConfigFile, error) {
 	if policy == nil {
 		return nil, fmt.Errorf("no auto-scale policy specified for GetAppInstConfigs")
 	}
-	// change delims because Prometheus triggers off of golang delims
-	t := template.Must(template.New("policy").Delims("[[", "]]").Parse(MEXPrometheusAutoScaleT))
-	args := AutoScaleArgs{
-		AutoScalePolicy:     policy.Key.Name,
-		AutoScaleUpName:     cloudcommon.AlertAutoScaleUp,
-		AutoScaleDownName:   cloudcommon.AlertAutoScaleDown,
-		ScaleUpCpuThresh:    policy.ScaleUpCpuThresh,
-		ScaleDownCpuThresh:  policy.ScaleDownCpuThresh,
-		ScaleUpCpuThreshF:   float32(policy.ScaleUpCpuThresh) / 100.0,
-		ScaleDownCpuThreshF: float32(policy.ScaleDownCpuThresh) / 100.0,
-		TriggerTimeSec:      policy.TriggerTimeSec,
-		MaxNodes:            int(policy.MaxNodes),
-		MinNodes:            int(policy.MinNodes),
-		NodeCountName:       cloudcommon.AlertKeyNodeCount,
-		LowCpuNodeCountName: cloudcommon.AlertKeyLowCpuNodeCount,
-		MinNodesName:        cloudcommon.AlertKeyMinNodes,
-		NodePrefix:          cloudcommon.MexNodePrefix,
-	}
-	buf := bytes.Buffer{}
-	err := t.Execute(&buf, &args)
+	file, err := autorules.GetAutoScaleRules(ctx, policy)
 	if err != nil {
 		return nil, err
 	}
 	policyConfig := &edgeproto.ConfigFile{
 		Kind:   edgeproto.AppConfigHelmYaml,
-		Config: buf.String(),
+		Config: file,
 	}
 	configs := []*edgeproto.ConfigFile{policyConfig}
 	return configs, nil

--- a/shepherd/fake_envoy_exporter/envoy_prom_out.go
+++ b/shepherd/fake_envoy_exporter/envoy_prom_out.go
@@ -1,0 +1,656 @@
+package main
+
+// This is the output from querying
+// curl -s -S http://envoy-ip:envoy-port/stats/prometheus
+// The fake envoy exporter parses this to figure out what
+// measurements to deliver. It replaces the cluster param but
+// leaves other params alone.
+// If the types of measurements that envoy exports changes, we
+// can just recopy the output here.
+var sampleOutput = `
+# TYPE envoy_server_static_unknown_fields counter
+envoy_server_static_unknown_fields{} 0
+# TYPE envoy_cluster_manager_update_out_of_merge_window counter
+envoy_cluster_manager_update_out_of_merge_window{} 0
+# TYPE envoy_http_rq_direct_response counter
+envoy_http_rq_direct_response{envoy_http_conn_manager_prefix="async-client"} 0
+# TYPE envoy_http_downstream_cx_upgrades_total counter
+envoy_http_downstream_cx_upgrades_total{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_rq_rx_reset counter
+envoy_http_downstream_rq_rx_reset{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_ssl_total counter
+envoy_http_downstream_cx_ssl_total{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_rs_too_large counter
+envoy_http_rs_too_large{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_rq_total counter
+envoy_http_rq_total{envoy_http_conn_manager_prefix="async-client"} 0
+# TYPE envoy_server_main_thread_watchdog_mega_miss counter
+envoy_server_main_thread_watchdog_mega_miss{} 4
+# TYPE envoy_server_watchdog_mega_miss counter
+envoy_server_watchdog_mega_miss{} 12
+# TYPE envoy_http_downstream_rq_overload_close counter
+envoy_http_downstream_rq_overload_close{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_rq_xx counter
+envoy_http_downstream_rq_xx{envoy_response_code_class="1",envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_destroy counter
+envoy_http_downstream_cx_destroy{envoy_http_conn_manager_prefix="admin"} 4079
+# TYPE envoy_runtime_override_dir_exists counter
+envoy_runtime_override_dir_exists{} 0
+# TYPE envoy_http_downstream_cx_protocol_error counter
+envoy_http_downstream_cx_protocol_error{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_filesystem_reopen_failed counter
+envoy_filesystem_reopen_failed{} 0
+# TYPE envoy_http_downstream_cx_http3_total counter
+envoy_http_downstream_cx_http3_total{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_flow_control_resumed_reading_total counter
+envoy_http_downstream_flow_control_resumed_reading_total{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_rq_reset_after_downstream_response_started counter
+envoy_http_rq_reset_after_downstream_response_started{envoy_http_conn_manager_prefix="async-client"} 0
+# TYPE envoy_runtime_override_dir_not_exists counter
+envoy_runtime_override_dir_not_exists{} 1
+# TYPE envoy_server_watchdog_miss counter
+envoy_server_watchdog_miss{} 20
+# TYPE envoy_server_debug_assertion_failures counter
+envoy_server_debug_assertion_failures{} 0
+# TYPE envoy_cluster_manager_cluster_added counter
+envoy_cluster_manager_cluster_added{} 1
+# TYPE envoy_server_worker_0_watchdog_miss counter
+envoy_server_worker_0_watchdog_miss{} 6
+# TYPE envoy_server_worker_0_watchdog_mega_miss counter
+envoy_server_worker_0_watchdog_mega_miss{} 5
+# TYPE envoy_http_downstream_rq_too_large counter
+envoy_http_downstream_rq_too_large{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_no_route counter
+envoy_http_no_route{envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="4",envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_tx_bytes_total counter
+envoy_http_downstream_cx_tx_bytes_total{envoy_http_conn_manager_prefix="admin"} 119457069
+# TYPE envoy_http_downstream_cx_destroy_local_active_rq counter
+envoy_http_downstream_cx_destroy_local_active_rq{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_filesystem_write_failed counter
+envoy_filesystem_write_failed{} 0
+# TYPE envoy_http_downstream_cx_overload_disable_keepalive counter
+envoy_http_downstream_cx_overload_disable_keepalive{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_rq_http2_total counter
+envoy_http_downstream_rq_http2_total{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_max_duration_reached counter
+envoy_http_downstream_cx_max_duration_reached{envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="5",envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_filesystem_flushed_by_timer counter
+envoy_filesystem_flushed_by_timer{} 1125
+# TYPE envoy_http_downstream_cx_destroy_active_rq counter
+envoy_http_downstream_cx_destroy_active_rq{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_cluster_manager_cluster_updated counter
+envoy_cluster_manager_cluster_updated{} 0
+# TYPE envoy_http_downstream_cx_http1_total counter
+envoy_http_downstream_cx_http1_total{envoy_http_conn_manager_prefix="admin"} 4080
+# TYPE envoy_http_downstream_cx_destroy_remote_active_rq counter
+envoy_http_downstream_cx_destroy_remote_active_rq{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_rq_total counter
+envoy_http_downstream_rq_total{envoy_http_conn_manager_prefix="admin"} 4080
+# TYPE envoy_filesystem_write_completed counter
+envoy_filesystem_write_completed{} 1126
+# TYPE envoy_server_dynamic_unknown_fields counter
+envoy_server_dynamic_unknown_fields{} 0
+# TYPE envoy_http_downstream_cx_rx_bytes_total counter
+envoy_http_downstream_cx_rx_bytes_total{envoy_http_conn_manager_prefix="admin"} 367602
+# TYPE envoy_http1_metadata_not_supported_error counter
+envoy_http1_metadata_not_supported_error{} 0
+# TYPE envoy_filesystem_write_buffered counter
+envoy_filesystem_write_buffered{} 4079
+# TYPE envoy_http_downstream_rq_timeout counter
+envoy_http_downstream_rq_timeout{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_idle_timeout counter
+envoy_http_downstream_cx_idle_timeout{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_drain_close counter
+envoy_http_downstream_cx_drain_close{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_cluster_manager_cluster_removed counter
+envoy_cluster_manager_cluster_removed{} 0
+# TYPE envoy_cluster_manager_cluster_modified counter
+envoy_cluster_manager_cluster_modified{} 0
+# TYPE envoy_http_downstream_rq_ws_on_non_ws_route counter
+envoy_http_downstream_rq_ws_on_non_ws_route{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_cluster_manager_cluster_updated_via_merge counter
+envoy_cluster_manager_cluster_updated_via_merge{} 0
+# TYPE envoy_runtime_deprecated_feature_use counter
+envoy_runtime_deprecated_feature_use{} 1
+# TYPE envoy_http_downstream_rq_http3_total counter
+envoy_http_downstream_rq_http3_total{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_destroy_remote counter
+envoy_http_downstream_cx_destroy_remote{envoy_http_conn_manager_prefix="admin"} 4079
+# TYPE envoy_http_downstream_rq_non_relative_path counter
+envoy_http_downstream_rq_non_relative_path{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_total counter
+envoy_http_downstream_cx_total{envoy_http_conn_manager_prefix="admin"} 4080
+# TYPE envoy_http_downstream_rq_tx_reset counter
+envoy_http_downstream_rq_tx_reset{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_http2_total counter
+envoy_http_downstream_cx_http2_total{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_server_worker_1_watchdog_miss counter
+envoy_server_worker_1_watchdog_miss{} 5
+# TYPE envoy_runtime_load_error counter
+envoy_runtime_load_error{} 0
+# TYPE envoy_http_downstream_rq_response_before_rq_complete counter
+envoy_http_downstream_rq_response_before_rq_complete{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_no_cluster counter
+envoy_http_no_cluster{envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="3",envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_rq_completed counter
+envoy_http_downstream_rq_completed{envoy_http_conn_manager_prefix="admin"} 4079
+# TYPE envoy_http_rq_redirect counter
+envoy_http_rq_redirect{envoy_http_conn_manager_prefix="async-client"} 0
+# TYPE envoy_cluster_manager_update_merge_cancelled counter
+envoy_cluster_manager_update_merge_cancelled{} 0
+# TYPE envoy_http_downstream_rq_idle_timeout counter
+envoy_http_downstream_rq_idle_timeout{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_server_main_thread_watchdog_miss counter
+envoy_server_main_thread_watchdog_miss{} 9
+# TYPE envoy_server_worker_1_watchdog_mega_miss counter
+envoy_server_worker_1_watchdog_mega_miss{} 3
+# TYPE envoy_http_downstream_rq_http1_total counter
+envoy_http_downstream_rq_http1_total{envoy_http_conn_manager_prefix="admin"} 4080
+# TYPE envoy_http_downstream_cx_delayed_close_timeout counter
+envoy_http_downstream_cx_delayed_close_timeout{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_rq_retry_skipped_request_not_complete counter
+envoy_http_rq_retry_skipped_request_not_complete{envoy_http_conn_manager_prefix="async-client"} 0
+# TYPE envoy_http_downstream_flow_control_paused_reading_total counter
+envoy_http_downstream_flow_control_paused_reading_total{envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="2",envoy_http_conn_manager_prefix="admin"} 4079
+# TYPE envoy_runtime_load_success counter
+envoy_runtime_load_success{} 1
+# TYPE envoy_http_downstream_cx_destroy_local counter
+envoy_http_downstream_cx_destroy_local{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_listener_no_filter_chain_match counter
+envoy_listener_no_filter_chain_match{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_worker_0_downstream_cx_total counter
+envoy_listener_worker_0_downstream_cx_total{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_downstream_cx_destroy counter
+envoy_listener_downstream_cx_destroy{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_downstream_pre_cx_timeout counter
+envoy_listener_downstream_pre_cx_timeout{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_worker_1_downstream_cx_total counter
+envoy_listener_worker_1_downstream_cx_total{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_downstream_cx_total counter
+envoy_listener_downstream_cx_total{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_manager_listener_added counter
+envoy_listener_manager_listener_added{} 1
+# TYPE envoy_listener_manager_listener_create_failure counter
+envoy_listener_manager_listener_create_failure{} 0
+# TYPE envoy_listener_manager_listener_modified counter
+envoy_listener_manager_listener_modified{} 0
+# TYPE envoy_listener_manager_listener_create_success counter
+envoy_listener_manager_listener_create_success{} 2
+# TYPE envoy_listener_manager_listener_removed counter
+envoy_listener_manager_listener_removed{} 0
+# TYPE envoy_listener_manager_listener_stopped counter
+envoy_listener_manager_listener_stopped{} 0
+# TYPE envoy_listener_admin_http_downstream_rq_xx counter
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="2",envoy_http_conn_manager_prefix="admin"} 4079
+# TYPE envoy_listener_admin_downstream_cx_destroy counter
+envoy_listener_admin_downstream_cx_destroy{} 4079
+# TYPE envoy_listener_admin_http_downstream_rq_completed counter
+envoy_listener_admin_http_downstream_rq_completed{envoy_http_conn_manager_prefix="admin"} 4079
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="3",envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_listener_admin_downstream_pre_cx_timeout counter
+envoy_listener_admin_downstream_pre_cx_timeout{} 0
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="5",envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_listener_admin_downstream_cx_total counter
+envoy_listener_admin_downstream_cx_total{} 4080
+# TYPE envoy_listener_admin_no_filter_chain_match counter
+envoy_listener_admin_no_filter_chain_match{} 0
+# TYPE envoy_listener_admin_main_thread_downstream_cx_total counter
+envoy_listener_admin_main_thread_downstream_cx_total{} 4080
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="4",envoy_http_conn_manager_prefix="admin"} 0
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="1",envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_tcp_downstream_cx_total counter
+envoy_tcp_downstream_cx_total{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_downstream_cx_tx_bytes_total counter
+envoy_tcp_downstream_cx_tx_bytes_total{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_downstream_cx_rx_bytes_total counter
+envoy_tcp_downstream_cx_rx_bytes_total{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_downstream_cx_no_route counter
+envoy_tcp_downstream_cx_no_route{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_upstream_flush_total counter
+envoy_tcp_upstream_flush_total{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_downstream_flow_control_paused_reading_total counter
+envoy_tcp_downstream_flow_control_paused_reading_total{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_downstream_flow_control_resumed_reading_total counter
+envoy_tcp_downstream_flow_control_resumed_reading_total{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_idle_timeout counter
+envoy_tcp_idle_timeout{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_cluster_upstream_rq_tx_reset counter
+envoy_cluster_upstream_rq_tx_reset{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_with_active_rq counter
+envoy_cluster_upstream_cx_destroy_with_active_rq{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_pool_overflow counter
+envoy_cluster_upstream_cx_pool_overflow{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_rx_bytes_total counter
+envoy_cluster_upstream_cx_rx_bytes_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_update_failure counter
+envoy_cluster_update_failure{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_remote counter
+envoy_cluster_upstream_cx_destroy_remote{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_zone_cluster_too_small counter
+envoy_cluster_lb_zone_cluster_too_small{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_recalculate_zone_structures counter
+envoy_cluster_lb_recalculate_zone_structures{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_overflow counter
+envoy_cluster_upstream_cx_overflow{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_flow_control_drained_total counter
+envoy_cluster_upstream_flow_control_drained_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_maintenance_mode counter
+envoy_cluster_upstream_rq_maintenance_mode{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_zone_routing_all_directly counter
+envoy_cluster_lb_zone_routing_all_directly{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_subsets_selected counter
+envoy_cluster_lb_subsets_selected{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_health_check_failure counter
+envoy_cluster_health_check_failure{envoy_cluster_name="backend2015"} 2048
+# TYPE envoy_cluster_lb_subsets_created counter
+envoy_cluster_lb_subsets_created{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_retry_or_shadow_abandoned counter
+envoy_cluster_retry_or_shadow_abandoned{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_per_try_timeout counter
+envoy_cluster_upstream_rq_per_try_timeout{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_health_check_success counter
+envoy_cluster_health_check_success{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_health_check_passive_failure counter
+envoy_cluster_health_check_passive_failure{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_completed counter
+envoy_cluster_upstream_rq_completed{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_zone_number_differs counter
+envoy_cluster_lb_zone_number_differs{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_update_no_rebuild counter
+envoy_cluster_update_no_rebuild{envoy_cluster_name="backend2015"} 2251
+# TYPE envoy_cluster_upstream_cx_http2_total counter
+envoy_cluster_upstream_cx_http2_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_subsets_fallback_panic counter
+envoy_cluster_lb_subsets_fallback_panic{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_total counter
+envoy_cluster_upstream_cx_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_timeout counter
+envoy_cluster_upstream_rq_timeout{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_internal_redirect_succeeded_total counter
+envoy_cluster_upstream_internal_redirect_succeeded_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_close_notify counter
+envoy_cluster_upstream_cx_close_notify{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_flow_control_resumed_reading_total counter
+envoy_cluster_upstream_flow_control_resumed_reading_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_assignment_timeout_received counter
+envoy_cluster_assignment_timeout_received{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_pending_total counter
+envoy_cluster_upstream_rq_pending_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_zone_routing_cross_zone counter
+envoy_cluster_lb_zone_routing_cross_zone{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_internal_redirect_failed_total counter
+envoy_cluster_upstream_internal_redirect_failed_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_destroy counter
+envoy_cluster_upstream_cx_destroy{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_local_cluster_not_ok counter
+envoy_cluster_lb_local_cluster_not_ok{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_health_check_attempt counter
+envoy_cluster_health_check_attempt{envoy_cluster_name="backend2015"} 2048
+# TYPE envoy_cluster_upstream_cx_none_healthy counter
+envoy_cluster_upstream_cx_none_healthy{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_zone_no_capacity_left counter
+envoy_cluster_lb_zone_no_capacity_left{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_flow_control_backed_up_total counter
+envoy_cluster_upstream_flow_control_backed_up_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_subsets_removed counter
+envoy_cluster_lb_subsets_removed{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_pending_overflow counter
+envoy_cluster_upstream_rq_pending_overflow{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_zone_routing_sampled counter
+envoy_cluster_lb_zone_routing_sampled{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_health_check_network_failure counter
+envoy_cluster_health_check_network_failure{envoy_cluster_name="backend2015"} 2048
+# TYPE envoy_cluster_membership_change counter
+envoy_cluster_membership_change{envoy_cluster_name="backend2015"} 1
+# TYPE envoy_cluster_original_dst_host_invalid counter
+envoy_cluster_original_dst_host_invalid{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_idle_timeout counter
+envoy_cluster_upstream_cx_idle_timeout{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_total counter
+envoy_cluster_upstream_rq_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_remote_with_active_rq counter
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_pending_failure_eject counter
+envoy_cluster_upstream_rq_pending_failure_eject{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_bind_errors counter
+envoy_cluster_bind_errors{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_update_success counter
+envoy_cluster_update_success{envoy_cluster_name="backend2015"} 2252
+# TYPE envoy_cluster_upstream_cx_connect_timeout counter
+envoy_cluster_upstream_cx_connect_timeout{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_tx_bytes_total counter
+envoy_cluster_upstream_cx_tx_bytes_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_update_empty counter
+envoy_cluster_update_empty{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_protocol_error counter
+envoy_cluster_upstream_cx_protocol_error{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_update_attempt counter
+envoy_cluster_update_attempt{envoy_cluster_name="backend2015"} 2252
+# TYPE envoy_cluster_upstream_rq_rx_reset counter
+envoy_cluster_upstream_rq_rx_reset{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_local_with_active_rq counter
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_http1_total counter
+envoy_cluster_upstream_cx_http1_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_cancelled counter
+envoy_cluster_upstream_rq_cancelled{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_local counter
+envoy_cluster_upstream_cx_destroy_local{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_retry_overflow counter
+envoy_cluster_upstream_rq_retry_overflow{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_connect_attempts_exceeded counter
+envoy_cluster_upstream_cx_connect_attempts_exceeded{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_assignment_stale counter
+envoy_cluster_assignment_stale{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_connect_fail counter
+envoy_cluster_upstream_cx_connect_fail{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_retry counter
+envoy_cluster_upstream_rq_retry{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_health_check_verify_cluster counter
+envoy_cluster_health_check_verify_cluster{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_retry_success counter
+envoy_cluster_upstream_rq_retry_success{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_subsets_fallback counter
+envoy_cluster_lb_subsets_fallback{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_max_requests counter
+envoy_cluster_upstream_cx_max_requests{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_flow_control_paused_reading_total counter
+envoy_cluster_upstream_flow_control_paused_reading_total{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_default_total_match_count counter
+envoy_cluster_default_total_match_count{envoy_cluster_name="backend2015"} 2252
+# TYPE envoy_cluster_lb_healthy_panic counter
+envoy_cluster_lb_healthy_panic{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_server_parent_connections gauge
+envoy_server_parent_connections{} 0
+# TYPE envoy_http_downstream_cx_http1_active gauge
+envoy_http_downstream_cx_http1_active{envoy_http_conn_manager_prefix="admin"} 1
+# TYPE envoy_cluster_manager_warming_clusters gauge
+envoy_cluster_manager_warming_clusters{} 0
+# TYPE envoy_server_days_until_first_cert_expiring gauge
+envoy_server_days_until_first_cert_expiring{} 2147483647
+# TYPE envoy_filesystem_write_total_buffered gauge
+envoy_filesystem_write_total_buffered{} 251
+# TYPE envoy_server_stats_recent_lookups gauge
+envoy_server_stats_recent_lookups{} 0
+# TYPE envoy_http_downstream_cx_active gauge
+envoy_http_downstream_cx_active{envoy_http_conn_manager_prefix="admin"} 1
+# TYPE envoy_server_memory_allocated gauge
+envoy_server_memory_allocated{} 3818776
+# TYPE envoy_server_state gauge
+envoy_server_state{} 0
+# TYPE envoy_server_memory_heap_size gauge
+envoy_server_memory_heap_size{} 5242880
+# TYPE envoy_http_downstream_cx_http2_active gauge
+envoy_http_downstream_cx_http2_active{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_server_concurrency gauge
+envoy_server_concurrency{} 2
+# TYPE envoy_server_version gauge
+envoy_server_version{} 11219146
+# TYPE envoy_http_downstream_cx_http3_active gauge
+envoy_http_downstream_cx_http3_active{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_server_live gauge
+envoy_server_live{} 1
+# TYPE envoy_http_downstream_cx_rx_bytes_buffered gauge
+envoy_http_downstream_cx_rx_bytes_buffered{envoy_http_conn_manager_prefix="admin"} 95
+# TYPE envoy_http_downstream_cx_ssl_active gauge
+envoy_http_downstream_cx_ssl_active{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_server_uptime gauge
+envoy_server_uptime{} 11258
+# TYPE envoy_server_total_connections gauge
+envoy_server_total_connections{} 0
+# TYPE envoy_http_downstream_cx_tx_bytes_buffered gauge
+envoy_http_downstream_cx_tx_bytes_buffered{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_cx_upgrades_active gauge
+envoy_http_downstream_cx_upgrades_active{envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_http_downstream_rq_active gauge
+envoy_http_downstream_rq_active{envoy_http_conn_manager_prefix="admin"} 1
+# TYPE envoy_server_hot_restart_epoch gauge
+envoy_server_hot_restart_epoch{} 0
+# TYPE envoy_runtime_num_keys gauge
+envoy_runtime_num_keys{} 0
+# TYPE envoy_runtime_admin_overrides_active gauge
+envoy_runtime_admin_overrides_active{} 0
+# TYPE envoy_runtime_num_layers gauge
+envoy_runtime_num_layers{} 2
+# TYPE envoy_cluster_manager_active_clusters gauge
+envoy_cluster_manager_active_clusters{} 1
+# TYPE envoy_listener_downstream_pre_cx_active gauge
+envoy_listener_downstream_pre_cx_active{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_worker_1_downstream_cx_active gauge
+envoy_listener_worker_1_downstream_cx_active{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_downstream_cx_active gauge
+envoy_listener_downstream_cx_active{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_worker_0_downstream_cx_active gauge
+envoy_listener_worker_0_downstream_cx_active{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_manager_total_listeners_active gauge
+envoy_listener_manager_total_listeners_active{} 1
+# TYPE envoy_listener_manager_total_listeners_draining gauge
+envoy_listener_manager_total_listeners_draining{} 0
+# TYPE envoy_listener_manager_total_listeners_warming gauge
+envoy_listener_manager_total_listeners_warming{} 0
+# TYPE envoy_listener_admin_downstream_pre_cx_active gauge
+envoy_listener_admin_downstream_pre_cx_active{} 0
+# TYPE envoy_listener_admin_main_thread_downstream_cx_active gauge
+envoy_listener_admin_main_thread_downstream_cx_active{} 1
+# TYPE envoy_listener_admin_downstream_cx_active gauge
+envoy_listener_admin_downstream_cx_active{} 1
+# TYPE envoy_tcp_downstream_cx_tx_bytes_buffered gauge
+envoy_tcp_downstream_cx_tx_bytes_buffered{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_upstream_flush_active gauge
+envoy_tcp_upstream_flush_active{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_tcp_downstream_cx_rx_bytes_buffered gauge
+envoy_tcp_downstream_cx_rx_bytes_buffered{envoy_tcp_prefix="ingress_tcp"} 0
+# TYPE envoy_cluster_health_check_degraded gauge
+envoy_cluster_health_check_degraded{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_circuit_breakers_default_rq_pending_open gauge
+envoy_cluster_circuit_breakers_default_rq_pending_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_max_host_weight gauge
+envoy_cluster_max_host_weight{envoy_cluster_name="backend2015"} 1
+# TYPE envoy_cluster_circuit_breakers_default_rq_retry_open gauge
+envoy_cluster_circuit_breakers_default_rq_retry_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_circuit_breakers_high_cx_open gauge
+envoy_cluster_circuit_breakers_high_cx_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_rx_bytes_buffered gauge
+envoy_cluster_upstream_cx_rx_bytes_buffered{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_rq_active gauge
+envoy_cluster_upstream_rq_active{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_circuit_breakers_high_rq_open gauge
+envoy_cluster_circuit_breakers_high_rq_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_circuit_breakers_default_cx_pool_open gauge
+envoy_cluster_circuit_breakers_default_cx_pool_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_circuit_breakers_high_rq_pending_open gauge
+envoy_cluster_circuit_breakers_high_rq_pending_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_circuit_breakers_default_cx_open gauge
+envoy_cluster_circuit_breakers_default_cx_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_lb_subsets_active gauge
+envoy_cluster_lb_subsets_active{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_membership_healthy gauge
+envoy_cluster_membership_healthy{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_circuit_breakers_default_rq_open gauge
+envoy_cluster_circuit_breakers_default_rq_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_circuit_breakers_high_rq_retry_open gauge
+envoy_cluster_circuit_breakers_high_rq_retry_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_health_check_healthy gauge
+envoy_cluster_health_check_healthy{envoy_cluster_name="backend2015"} 1
+# TYPE envoy_cluster_membership_degraded gauge
+envoy_cluster_membership_degraded{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_membership_total gauge
+envoy_cluster_membership_total{envoy_cluster_name="backend2015"} 1
+# TYPE envoy_cluster_upstream_rq_pending_active gauge
+envoy_cluster_upstream_rq_pending_active{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_version gauge
+envoy_cluster_version{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_active gauge
+envoy_cluster_upstream_cx_active{envoy_cluster_name="backend2015"} 50
+# TYPE envoy_cluster_circuit_breakers_high_cx_pool_open gauge
+envoy_cluster_circuit_breakers_high_cx_pool_open{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_tx_bytes_buffered gauge
+envoy_cluster_upstream_cx_tx_bytes_buffered{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_membership_excluded gauge
+envoy_cluster_membership_excluded{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_server_initialization_time_ms histogram
+envoy_server_initialization_time_ms_bucket{le="0.5"} 0
+envoy_server_initialization_time_ms_bucket{le="1"} 0
+envoy_server_initialization_time_ms_bucket{le="5"} 0
+envoy_server_initialization_time_ms_bucket{le="10"} 0
+envoy_server_initialization_time_ms_bucket{le="25"} 1
+envoy_server_initialization_time_ms_bucket{le="50"} 1
+envoy_server_initialization_time_ms_bucket{le="100"} 1
+envoy_server_initialization_time_ms_bucket{le="250"} 1
+envoy_server_initialization_time_ms_bucket{le="500"} 1
+envoy_server_initialization_time_ms_bucket{le="1000"} 1
+envoy_server_initialization_time_ms_bucket{le="2500"} 1
+envoy_server_initialization_time_ms_bucket{le="5000"} 1
+envoy_server_initialization_time_ms_bucket{le="10000"} 1
+envoy_server_initialization_time_ms_bucket{le="30000"} 1
+envoy_server_initialization_time_ms_bucket{le="60000"} 1
+envoy_server_initialization_time_ms_bucket{le="300000"} 1
+envoy_server_initialization_time_ms_bucket{le="600000"} 1
+envoy_server_initialization_time_ms_bucket{le="1800000"} 1
+envoy_server_initialization_time_ms_bucket{le="3600000"} 1
+envoy_server_initialization_time_ms_bucket{le="+Inf"} 1
+envoy_server_initialization_time_ms_sum{} 15.5
+envoy_server_initialization_time_ms_count{} 1
+# TYPE envoy_http_downstream_rq_time histogram
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="0.5"} 1715
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="1"} 1715
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="5"} 4036
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="10"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="25"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="50"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="100"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="250"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="500"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="1000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="2500"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="5000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="10000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="30000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="60000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="300000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="600000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="1800000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="3600000"} 4079
+envoy_http_downstream_rq_time_bucket{envoy_http_conn_manager_prefix="admin",le="+Inf"} 4079
+envoy_http_downstream_rq_time_sum{envoy_http_conn_manager_prefix="admin"} 3256.2000000000002728484105318785
+envoy_http_downstream_rq_time_count{envoy_http_conn_manager_prefix="admin"} 4079
+# TYPE envoy_http_downstream_cx_length_ms histogram
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="0.5"} 1177
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="1"} 1177
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="5"} 3852
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="10"} 4074
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="25"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="50"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="100"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="250"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="500"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="1000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="2500"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="5000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="10000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="30000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="60000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="300000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="600000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="1800000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="3600000"} 4079
+envoy_http_downstream_cx_length_ms_bucket{envoy_http_conn_manager_prefix="admin",le="+Inf"} 4079
+envoy_http_downstream_cx_length_ms_sum{envoy_http_conn_manager_prefix="admin"} 6363.3500000000003637978807091713
+envoy_http_downstream_cx_length_ms_count{envoy_http_conn_manager_prefix="admin"} 4079
+# TYPE envoy_listener_downstream_cx_length_ms histogram
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="0.5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="1"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="10"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="25"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="50"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="100"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="250"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="1000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="2500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="5000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="10000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="30000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="60000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="300000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="600000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="1800000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="3600000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{envoy_listener_address="0.0.0.0_2015",le="+Inf"} 0
+envoy_listener_downstream_cx_length_ms_sum{envoy_listener_address="0.0.0.0_2015"} 0
+envoy_listener_downstream_cx_length_ms_count{envoy_listener_address="0.0.0.0_2015"} 0
+# TYPE envoy_listener_admin_downstream_cx_length_ms histogram
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="0.5"} 1177
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="1"} 1177
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="5"} 3851
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="10"} 4074
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="25"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="50"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="100"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="250"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="500"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="1000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="2500"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="5000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="10000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="30000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="60000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="300000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="600000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="1800000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="3600000"} 4079
+envoy_listener_admin_downstream_cx_length_ms_bucket{le="+Inf"} 4079
+envoy_listener_admin_downstream_cx_length_ms_sum{} 6359.3499999999985448084771633148
+envoy_listener_admin_downstream_cx_length_ms_count{} 4079
+# TYPE envoy_cluster_upstream_cx_connect_ms histogram
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="10"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="25"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="50"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="100"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="250"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="1000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="2500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="5000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="10000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="30000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="60000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="300000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="1800000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="3600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{envoy_cluster_name="backend2015",le="+Inf"} 0
+envoy_cluster_upstream_cx_connect_ms_sum{envoy_cluster_name="backend2015"} 0
+envoy_cluster_upstream_cx_connect_ms_count{envoy_cluster_name="backend2015"} 0
+# TYPE envoy_cluster_upstream_cx_length_ms histogram
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{envoy_cluster_name="backend2015",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{envoy_cluster_name="backend2015"} 0
+envoy_cluster_upstream_cx_length_ms_count{envoy_cluster_name="backend2015"} 0
+`

--- a/shepherd/fake_envoy_exporter/fake_envoy_exporter.go
+++ b/shepherd/fake_envoy_exporter/fake_envoy_exporter.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	baselog "log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/mobiledgex/edge-cloud/log"
+)
+
+// Fake envoy exporter serves prometheus stats as if it were an Envoy
+// load balancer.
+// To query it, use
+// curl --unix-socket <sockfile> http:/sock/stats/prometheus
+// To set a measure, use
+// curl --unix-socket <sockfile> --data-urlencode 'measure=envoy_cluster_upstream_cx_actve{envoy_cluster_name="myclust"}' --data-urlencode 'val=10' http:/sock/setval
+
+var sockFile = flag.String("sockfile", "", "unix domain socket file to listen on")
+var cluster = flag.String("cluster", "", "cluster name")
+
+var stats []stat
+var measures map[string]*measure
+
+func main() {
+	flag.Parse()
+	ch := make(chan bool, 0)
+	run(ch)
+	<-ch
+}
+
+func run(ch chan bool) {
+	if *sockFile == "" {
+		baselog.Fatal("please specify sockfile to listen on")
+	}
+	if err := os.RemoveAll(*sockFile); err != nil {
+		baselog.Fatal(err)
+	}
+	if *cluster == "" {
+		baselog.Fatal("please specify cluster name")
+	}
+
+	measures = make(map[string]*measure)
+
+	replaceTags := make(map[string]string)
+	replaceTags["envoy_cluster_name"] = `"` + *cluster + `"`
+
+	stats = parseSampleStats(sampleOutput, replaceTags)
+
+	lis, err := net.Listen("unix", *sockFile)
+	if err != nil {
+		baselog.Fatal(err)
+	}
+
+	http.HandleFunc("/stats/prometheus", serveStatsProm)
+	http.HandleFunc("/setval", setVal)
+
+	log.DebugLog(log.DebugLevelInfo, "listening", "sockfile", *sockFile)
+	go func() {
+		err := http.Serve(lis, nil)
+		if err != nil && err != http.ErrServerClosed {
+			baselog.Fatal(err)
+		}
+		lis.Close()
+		close(ch)
+	}()
+}
+
+func serveStatsProm(w http.ResponseWriter, r *http.Request) {
+	for _, s := range stats {
+		fmt.Fprint(w, s.String()+"\n")
+	}
+}
+
+func setVal(w http.ResponseWriter, r *http.Request) {
+	measName := r.FormValue("measure")
+	m, found := measures[measName]
+	if !found {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintf("measure '%s' not found", measName)))
+		return
+	}
+	val := r.FormValue("val")
+	if val == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("val not specified"))
+		return
+	}
+	m.val = val
+	w.Write([]byte("measure updated"))
+	log.DebugLog(log.DebugLevelInfo, "updated measure", "measure", measName, "val", val)
+}
+
+type stat interface {
+	// single line string to write to prometheus scraper
+	String() string
+}
+
+func parseSampleStats(dat string, replaceTags map[string]string) []stat {
+	stats := []stat{}
+
+	scanner := bufio.NewScanner(strings.NewReader(dat))
+	// read line by line
+	lineno := 0
+	for scanner.Scan() {
+		lineno++
+		line := scanner.Text()
+		if len(line) == 0 {
+			continue
+		}
+		if strings.HasPrefix(line, "# TYPE") {
+			stats = append(stats, newHeader(line))
+		} else {
+			m, err := newMeasure(line, replaceTags)
+			if err != nil {
+				baselog.Fatalf("failed to parse: %s, at line %v", err, lineno)
+			}
+			stats = append(stats, m)
+			measures[m.name] = m
+		}
+	}
+	return stats
+}
+
+type header struct {
+	val string
+}
+
+func newHeader(line string) *header {
+	h := header{
+		val: line,
+	}
+	return &h
+}
+
+func (s *header) String() string { return s.val }
+
+type measure struct {
+	name string
+	val  string
+}
+
+func newMeasure(line string, replaceTags map[string]string) (*measure, error) {
+	// in order to replace tags, we need to parse the line
+	// line looks like name{key="val",...} val
+	m := measure{}
+	nameval := strings.Split(line, " ")
+	if len(nameval) != 2 {
+		return nil, fmt.Errorf("measure split by space expected 2 fields, but got %d: %s", len(nameval), line)
+	}
+	m.val = nameval[1]
+
+	openbrace := strings.Index(nameval[0], "{")
+	closebrace := strings.LastIndex(nameval[0], "}")
+	name := line[:openbrace]
+
+	// remove braces around tags
+	tags := line[openbrace+1 : closebrace]
+	newTags := []string{}
+	if tags != "" {
+		kvs := strings.Split(tags, ",")
+		for _, kvstr := range kvs {
+			kv := strings.Split(kvstr, "=")
+			if len(kv) != 2 {
+				return nil, fmt.Errorf("failed to split key value into 2, %s", kvstr)
+			}
+			if v, found := replaceTags[kv[0]]; found {
+				kv[1] = v
+			}
+			newTags = append(newTags, kv[0]+"="+kv[1])
+		}
+	}
+	m.name = name + "{" + strings.Join(newTags, ",") + "}"
+	return &m, nil
+}
+
+func (s *measure) String() string {
+	return s.name + " " + s.val
+}

--- a/shepherd/fake_envoy_exporter/fake_envoy_exporter_test.go
+++ b/shepherd/fake_envoy_exporter/fake_envoy_exporter_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExporter(t *testing.T) {
+	*sockFile = "/tmp/fake_envoy_exporter_unit_test"
+	*cluster = "testclust"
+
+	ch := make(chan bool, 0)
+	run(ch)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", *sockFile)
+			},
+		},
+	}
+
+	ensureMeas(t, client, `envoy_cluster_upstream_cx_active{envoy_cluster_name="testclust"} 50`)
+
+	// update measure
+	params := url.Values{}
+	params.Set("measure", `envoy_cluster_upstream_cx_active{envoy_cluster_name="testclust"}`)
+	params.Set("val", "11")
+	resp, err := client.PostForm("http://unix/setval", params)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+
+	ensureMeas(t, client, `envoy_cluster_upstream_cx_active{envoy_cluster_name="testclust"} 11`)
+}
+
+func ensureMeas(t *testing.T, client *http.Client, meas string) {
+	resp, err := client.Get("http://unix/stats/prometheus")
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	defer resp.Body.Close()
+
+	dat, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+	// rather than check the whole data, just check length and one part
+	arr := strings.Split(string(dat), "\n")
+	require.Greater(t, len(arr), 600)
+
+	found := false
+	for _, str := range arr {
+		if str == meas {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "searched:\n%s", strings.Join(arr, "\n"))
+}

--- a/shepherd/shepherd-alerts.go
+++ b/shepherd/shepherd-alerts.go
@@ -46,8 +46,7 @@ func pruneCloudletForeignAlerts(key interface{}, keys map[edgeproto.AlertKey]str
 	for key, _ := range keys {
 		edgeproto.AlertKeyStringParse(string(key), &alertFromKey)
 		if alertName, found := alertFromKey.Labels["alertname"]; !found ||
-			(alertName != cloudcommon.AlertAppInstDown &&
-				alertName != cloudcommon.AlertAutoProvDown) {
+			!cloudcommon.IsMonitoredAlert(alertName) {
 			delete(keys, key)
 		}
 	}

--- a/shepherd/shepherd_common/shepherd-names.go
+++ b/shepherd/shepherd_common/shepherd-names.go
@@ -1,0 +1,27 @@
+package shepherd_common
+
+import (
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/proxy"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
+)
+
+func GetProxyKey(appInstKey *edgeproto.AppInstKey) string {
+	return appInstKey.AppKey.Name + "-" + appInstKey.ClusterInstKey.ClusterKey.Name + "-" +
+		appInstKey.AppKey.Organization + "-" + appInstKey.AppKey.Version
+}
+
+func ShouldRunEnvoy(app *edgeproto.App, appInst *edgeproto.AppInst) bool {
+	log.DebugLog(log.DebugLevelInfo, "ShouldRunEnvoy", "app", app.Key)
+	needEnvoy, _ := proxy.CheckProtocols("", appInst.MappedPorts)
+	if !needEnvoy {
+		log.DebugLog(log.DebugLevelInfo, "ShouldRunEnvoy", "app", app.Key, "needEnvoy", needEnvoy)
+		return false
+	}
+	if app.InternalPorts || app.AccessType != edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER {
+		log.DebugLog(log.DebugLevelInfo, "ShouldRunEnvoy", "app", app.Key, "appCheck", false)
+		return false
+	}
+	log.DebugLog(log.DebugLevelInfo, "ShouldRunEnvoy", "app", app.Key, "ok", true)
+	return true
+}

--- a/shepherd/shepherd_test/testdata.go
+++ b/shepherd/shepherd_test/testdata.go
@@ -12,6 +12,9 @@ var (
 		Organization: "testoperator",
 		Name:         "testcloudlet",
 	}
+	TestCloudlet = edgeproto.Cloudlet{
+		Key: TestCloudletKey,
+	}
 	TestClusterKey     = edgeproto.ClusterKey{Name: "testcluster"}
 	TestClusterInstKey = edgeproto.ClusterInstKey{
 		ClusterKey:   TestClusterKey,
@@ -22,6 +25,19 @@ var (
 		Key:        TestClusterInstKey,
 		Deployment: cloudcommon.DeploymentTypeDocker,
 	}
+	TestAutoProvPolicyKey = edgeproto.PolicyKey{
+		Name: "autoprov",
+	}
+	TestAutoProvPolicy = edgeproto.AutoProvPolicy{
+		Key:                   TestAutoProvPolicyKey,
+		UndeployClientCount:   3,
+		UndeployIntervalCount: 3,
+		Cloudlets: []*edgeproto.AutoProvCloudlet{
+			&edgeproto.AutoProvCloudlet{
+				Key: TestCloudletKey,
+			},
+		},
+	}
 	TestAppKey = edgeproto.AppKey{
 		Name: "App",
 	}
@@ -29,6 +45,9 @@ var (
 		Key:         TestAppKey,
 		AccessPorts: "tcp:1234",
 		AccessType:  edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER,
+		AutoProvPolicies: []string{
+			TestAutoProvPolicyKey.Name,
+		},
 	}
 	TestAppInstKey = edgeproto.AppInstKey{
 		AppKey:         TestAppKey,
@@ -38,6 +57,7 @@ var (
 		Key:         TestAppInstKey,
 		State:       edgeproto.TrackedState_READY,
 		HealthCheck: edgeproto.HealthCheck_HEALTH_CHECK_OK,
+		Liveness:    edgeproto.Liveness_LIVENESS_AUTOPROV,
 		MappedPorts: []dme.AppPort{
 			dme.AppPort{
 				Proto:      dme.LProto_L_PROTO_TCP,

--- a/shepherd/shepherd_update_test.go
+++ b/shepherd/shepherd_update_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	intprocess "github.com/mobiledgex/edge-cloud-infra/e2e-tests/int-process"
+	"github.com/mobiledgex/edge-cloud-infra/shepherd/shepherd_test"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/notify"
+	"github.com/stretchr/testify/require"
+)
+
+// Test notify and updates
+func TestShepherdUpdate(t *testing.T) {
+	flag.Parse()
+	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi | log.DebugLevelInfra | log.DebugLevelMetrics)
+	ctx := setupLog()
+	defer log.FinishTracer()
+	// set up args
+	*notifyAddrs = "127.0.0.1:60001"
+	ckey, err := json.Marshal(shepherd_test.TestCloudletKey)
+	require.Nil(t, err)
+	*cloudletKeyStr = string(ckey)
+	*platformName = "PLATFORM_TYPE_FAKEINFRA"
+	cloudletWaitDelay = 20 * time.Millisecond
+
+	crm := notify.NewDummyHandler()
+	crmServer := &notify.ServerMgr{}
+	crm.RegisterServer(crmServer)
+	crmServer.Start("crm", *notifyAddrs, nil)
+	defer crmServer.Stop()
+
+	// cloudlet must be sent during startup
+	crm.CloudletCache.Update(ctx, &shepherd_test.TestCloudlet, 0)
+	set := edgeproto.GetDefaultSettings()
+	set.ShepherdMetricsCollectionInterval = edgeproto.Duration(time.Second)
+	set.ShepherdAlertEvaluationInterval = edgeproto.Duration(3 * time.Second)
+	crm.SettingsCache.Update(ctx, set, 0)
+
+	start()
+	defer stop()
+
+	crmServer.WaitServerCount(1)
+
+	// test settings update
+
+	crm.ClusterInstCache.Update(ctx, &shepherd_test.TestClusterInst, 0)
+	crm.AutoProvPolicyCache.Update(ctx, &shepherd_test.TestAutoProvPolicy, 0)
+	crm.AppCache.Update(ctx, &shepherd_test.TestApp, 0)
+	crm.AppInstCache.Update(ctx, &shepherd_test.TestAppInst, 0)
+
+	// wait for changes
+	notify.WaitFor(&AppInstCache, 1)
+	targetFileWorkers.WaitIdle()
+	appInstAlertWorkers.WaitIdle()
+
+	// check global config based on settings
+	configFile := intprocess.GetCloudletPrometheusConfigHostFilePath()
+	fileContents, err := ioutil.ReadFile(configFile)
+	require.Nil(t, err)
+	expected := `global:
+  evaluation_interval: 3s
+rule_files:
+- "/tmp/rulefile_*"
+scrape_configs:
+- job_name: envoy_targets
+  scrape_interval: 1s
+  file_sd_configs:
+  - files:
+    - '/tmp/prom_targets.json'
+`
+	require.Equal(t, expected, string(fileContents))
+
+	// check targets based on appinsts
+	fileContents, err = ioutil.ReadFile(*promTargetsFile)
+	require.Nil(t, err)
+	expected = `[
+{
+	"targets": ["host.docker.internal:9091"],
+	"labels": {
+		"app": "App",
+		"appver": "",
+		"apporg": "",
+		"cluster": "testcluster",
+		"clusterorg": "",
+		"cloudlet": "testcloudlet",
+		"cloudletorg": "testoperator",
+		"__metrics_path__":"/metrics/App-testcluster--"
+	}
+}]`
+	require.Equal(t, expected, string(fileContents))
+
+	// check alerts based on appinsts and policy
+
+	rulesFile := getAppInstRulesFileName(shepherd_test.TestAppInstKey)
+	fileContents, err = ioutil.ReadFile(rulesFile)
+	require.Nil(t, err)
+	expected = `groups:
+- name: autoprov-feature
+  rules:
+  - alert: AutoProvUndeploy
+    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} <= 3
+    for: 15m
+`
+	require.Equal(t, expected, string(fileContents))
+
+	// update settings, check for changes
+	set.ShepherdAlertEvaluationInterval = edgeproto.Duration(5 * time.Second)
+	set.AutoDeployIntervalSec = float64(15)
+	crm.SettingsCache.Update(ctx, set, 0)
+	// wait for changes
+	for ii := 0; ii < 50; ii++ {
+		if settings.AutoDeployIntervalSec == set.AutoDeployIntervalSec {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	appInstAlertWorkers.WaitIdle()
+	// check global config (new eval time)
+	fileContents, err = ioutil.ReadFile(configFile)
+	require.Nil(t, err)
+	expected = `global:
+  evaluation_interval: 5s
+rule_files:
+- "/tmp/rulefile_*"
+scrape_configs:
+- job_name: envoy_targets
+  scrape_interval: 1s
+  file_sd_configs:
+  - files:
+    - '/tmp/prom_targets.json'
+`
+	require.Equal(t, expected, string(fileContents))
+	// check rules file (new "for" time)
+	fileContents, err = ioutil.ReadFile(rulesFile)
+	require.Nil(t, err)
+	expected = `groups:
+- name: autoprov-feature
+  rules:
+  - alert: AutoProvUndeploy
+    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} <= 3
+    for: 45s
+`
+	require.Equal(t, expected, string(fileContents))
+
+	// update policy, check for changes
+	policy := shepherd_test.TestAutoProvPolicy
+	policy.UndeployClientCount = 5
+	crm.AutoProvPolicyCache.Update(ctx, &policy, 0)
+	// wait for changes
+	for ii := 0; ii < 50; ii++ {
+		p := edgeproto.AutoProvPolicy{}
+		if found := AutoProvPoliciesCache.Get(&policy.Key, &p); found && p.UndeployClientCount == policy.UndeployClientCount {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	appInstAlertWorkers.WaitIdle()
+	// check rules file (new expr)
+	fileContents, err = ioutil.ReadFile(rulesFile)
+	require.Nil(t, err)
+	expected = `groups:
+- name: autoprov-feature
+  rules:
+  - alert: AutoProvUndeploy
+    expr: envoy_cluster_upstream_cx_active{app="App",appver="",apporg=""} <= 5
+    for: 45s
+`
+	require.Equal(t, expected, string(fileContents))
+
+	// remove appinst, check for changes
+	crm.AppInstCache.Delete(ctx, &shepherd_test.TestAppInst, 0)
+	notify.WaitFor(&AppInstCache, 0)
+	targetFileWorkers.WaitIdle()
+	appInstAlertWorkers.WaitIdle()
+	// check targets file (should be empty)
+	fileContents, err = ioutil.ReadFile(*promTargetsFile)
+	require.Nil(t, err)
+	expected = `[]`
+	require.Equal(t, expected, string(fileContents))
+	// check rules file (should be removed)
+	_, err = os.Stat(rulesFile)
+	require.True(t, os.IsNotExist(err), "error is %v", err)
+	require.Equal(t, 0, len(AppInstByAutoProvPolicy.PolicyKeys))
+}


### PR DESCRIPTION
This implements AutoProv undeploy. Please first see: https://github.com/mobiledgex/edge-cloud/pull/1003

When Shepherd sees an AutoProv policy for an AppInst, it will add alert rules to the CloudletPrometheus which monitor the active connections in the Envoy LB for that AppInst. If the number of active connections drop below the threshold for the specified number of intervals, the alert will fire. The AutoProv service will see this alert and delete the AppInst, subject to min active instance requirements.

To be able to test this locally, I added a fake_envoy_exporter for e2e tests. This runs for each AppInst deployed to the fakeinfra-platform cloudlet. This allows CloudletPrometheus to scrape (through Shepherd) a fake envoy which will return the same set of stuff that Envoy would return. To avoid port conflicts, the fake_envoy_exporter listens on a unix domain socket. It also allows for a http call to override the value of the measurement returns. e2e tests uses this to tweak the "envoy_upstream_cx_active{...}" measurement, thereby triggering and validating undeployment.

Other changes:
- move AutoProv alerts definitions to common autorules package (from cluster-svc-plugin (no changes to autoscale code) and shepherd)
- changed a bunch of the shepherd go threads to keyworkers
- added updates for settings and autoprovpolicy to shepherd
- shepherd unit tests to verify notify changes trigger expected config file changes
- added e2e test api to show alerts
- e2e test changes for retry, same as in the edge-cloud PR



