### PR TITLE
EDGECLOUD-3171 make org exists check case sensitive

### DIFF
--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -340,6 +340,11 @@ func orgExists(ctx context.Context, orgName string) (*ormapi.Organization, error
 	if res.Error != nil {
 		return nil, res.Error
 	}
+	// SQL lookup by org name is case-insensitive.
+	// Make sure org name matches (case-sensitive).
+	if org.Name != orgName {
+		return nil, fmt.Errorf("lookup %s but found %s", orgName, org.Name)
+	}
 	return &org, nil
 }
 

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -175,6 +175,12 @@ func TestServer(t *testing.T) {
 	require.NotNil(t, err, "create duplicate org (case-insensitive)")
 	require.Equal(t, http.StatusBadRequest, status, "create dup org")
 
+	// EC-31717: Test org exists func. Should be case sensitive, so looking
+	// for "devy" should fail (does not exist), and not hit a false
+	//  positive for org "DevY", which does exist.
+	err = checkRequiresOrg(ctx, "devy", false)
+	require.NotNil(t, err, "devy should not exist")
+
 	// create new admin user
 	admin := ormapi.User{
 		Name:     "Admin",


### PR DESCRIPTION
In SQL, we store the org name with type case-insensitive. This is due to a requirement from gitlab that org names are all lowercase in gitlab. So although we store the org name with case in SQL, i.e. "Org123", because of the case-insensitive type on the sql column, attempting to create an org "oRG123" will result in a unique-key conflict.

Unfortunately, the other side to that was that a lookup of "oRG123" was returning success and giving back the record for "Org123". This made things very confusing for someone trying to create an AppInst for "oRG123" and ending up having it created for "Org123". The fix is that conflict checks (as before) remain case-insensitive, but for existence checks, we add an additional case-sensitive check after SQL's built-in case-insensitive check.