### PR TITLE
EDGECLOUD-3251 support VIO prop syntax

### DIFF
--- a/crm-platforms/openstack/openstack-network.go
+++ b/crm-platforms/openstack/openstack-network.go
@@ -270,7 +270,14 @@ func ParseFlavorProperties(f OSFlavorDetail) map[string]string {
 	props = make(map[string]string)
 	for _, m := range ms {
 		// ex: pci_passthrough:alias='t4gpu:1’
-		val := strings.Split(m, ":")
+		var val []string
+		if strings.Contains(m, ":") {
+			val = strings.Split(m, ":")
+		} else if strings.Contains(m, "=") {
+			// handle vio (wwt) flavor syntax
+			val = strings.Split(m, "=")
+		}
+
 		if len(val) > 1 {
 			val[0] = strings.TrimSpace(val[0])
 			var s []string

--- a/crm-platforms/openstack/openstack_test.go
+++ b/crm-platforms/openstack/openstack_test.go
@@ -114,6 +114,19 @@ var OSFlavors = []OSFlavorDetail{
 		RXTX_Factor: "1.0",
 		ID:          "94557fcc-d217-4270-8511-79bce1d6c0c9",
 	},
+	// Test auto created flavor in VIO unqiue syntax
+	OSFlavorDetail{
+		Name:        "vmware.medium-gpu",
+		RAM:         4096,
+		Ephemeral:   0,
+		Properties:  "vmware:vgpu='1'",
+		VCPUs:       2,
+		Swap:        "",
+		Public:      true,
+		Disk:        40,
+		RXTX_Factor: "1.0",
+		ID:          "94557fcc-d217-4270-8511-79bce1d6c0c9",
+	},
 }
 
 func TestParseFlavorProps(t *testing.T) {


### PR DESCRIPTION
What changed?
modified:   crm-platforms/openstack/openstack-network.go // accept : or = as count delim
modified:   crm-platforms/openstack/openstack_test.go       // add test OS flavor using =