### PR TITLE
EDGECLOUD-3199 Audit log time args

### DIFF
--- a/mc/mcctl/ormctl/audit.go
+++ b/mc/mcctl/ormctl/audit.go
@@ -9,16 +9,37 @@ import (
 func GetAuditCommand() *cobra.Command {
 	cmds := []*cli.Command{&cli.Command{
 		Use:          "showself",
-		OptionalArgs: "limit",
+		OptionalArgs: "limit starttime endtime startage endage",
+		Comments:     AuditSelfComments,
 		ReqData:      &ormapi.AuditQuery{},
 		ReplyData:    &[]ormapi.AuditResponse{},
 		Run:          runRest("/auth/audit/showself"),
 	}, &cli.Command{
 		Use:          "showorg",
-		OptionalArgs: "org limit",
+		OptionalArgs: "org limit starttime endtime startage endage",
+		Comments:     AuditOrgComments,
 		ReqData:      &ormapi.AuditQuery{},
 		ReplyData:    &[]ormapi.AuditResponse{},
 		Run:          runRest("/auth/audit/showorg"),
 	}}
 	return cli.GenGroup("audit", "show audit logs", cmds)
+}
+
+var AuditOrgComments = map[string]string{
+	"username":  "filter by user name",
+	"org":       "filter by organization name",
+	"limit":     "limit the number of returned results (default 100)",
+	"starttime": "absolute time of search range start (RFC3339)",
+	"endtime":   "absolute time of search range end (RFC3339)",
+	"startage":  "relative age from now of search range start (default 48h)",
+	"endage":    "relative age from now of search range end (default 0)",
+}
+
+var AuditSelfComments = map[string]string{
+	"org":       "filter by organization name",
+	"limit":     "limit the number of returned results (default 100)",
+	"starttime": "absolute time of search range start",
+	"endtime":   "absolute time of search range end",
+	"startage":  "relative age from now of search range start (default 48h)",
+	"endage":    "relative age from now of search range end (default 0)",
 }

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -277,32 +277,6 @@ func ShowOrgObj(ctx context.Context, claims *UserClaims) ([]ormapi.Organization,
 	return orgs, nil
 }
 
-// getUserOrgnames gets a map of all the org names the user belongs to.
-// If this is an admin, return boolean will be true.
-func getUserOrgnames(username string) (bool, map[string]struct{}, error) {
-	orgnames := make(map[string]struct{})
-	admin := false
-
-	groupings, err := enforcer.GetGroupingPolicy()
-	if err != nil {
-		return false, nil, err
-	}
-	for _, grp := range groupings {
-		if len(grp) < 2 {
-			continue
-		}
-		if grp[0] == username {
-			admin = true
-			continue
-		}
-		orguser := strings.Split(grp[0], "::")
-		if len(orguser) > 1 && orguser[1] == username {
-			orgnames[orguser[0]] = struct{}{}
-		}
-	}
-	return admin, orgnames, nil
-}
-
 func GetAllOrgs(ctx context.Context) (map[string]*ormapi.Organization, error) {
 	orgsT := make(map[string]*ormapi.Organization)
 	orgs := []ormapi.Organization{}

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -121,9 +121,13 @@ type CreateUser struct {
 }
 
 type AuditQuery struct {
-	Username string `json:"username"`
-	Org      string `form:"org" json:"org"`
-	Limit    int    `json:"limit"`
+	Username  string        `json:"username"`
+	Org       string        `form:"org" json:"org"`
+	Limit     int           `json:"limit"`
+	StartTime time.Time     `json:"starttime"`
+	EndTime   time.Time     `json:"endtime"`
+	StartAge  time.Duration `json:"startage"`
+	EndAge    time.Duration `json:"endage"`
 }
 
 type AuditResponse struct {

--- a/mc/ormapi/time.go
+++ b/mc/ormapi/time.go
@@ -40,8 +40,7 @@ func (s *TimeMicroseconds) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	if err != nil {
 		return err
 	}
-	*s = TimeMicroseconds(tt.Second() * int(Microsecond))
-	*s = *s + TimeMicroseconds((tt.Nanosecond()%int(Nanosecond))/1000)
+	s.FromTime(tt)
 	return nil
 }
 
@@ -54,6 +53,11 @@ func (s TimeMicroseconds) MarshalYAML() (interface{}, error) {
 		return nil, err
 	}
 	return string(byt), nil
+}
+
+func (s *TimeMicroseconds) FromTime(tt time.Time) {
+	*s = TimeMicroseconds(tt.Unix() * int64(Microsecond))
+	*s = *s + TimeMicroseconds(tt.Nanosecond()/1000)
 }
 
 func (s *DurationMicroseconds) UnmarshalYAML(unmarshal func(interface{}) error) error {


### PR DESCRIPTION
This fixes an issue with the audit log APIs where only the last 2 days worth of logs were displayable. This is because Jaeger would default the time range to 2 days if none was specified, which is what MC was doing when querying Jaeger. So, our MC API now has time args to be able to specify the time range. The start/end time can be specified either as absolute or relative times.

```
Optional Args:
  limit      limit the number of returned results (default 100)
  starttime  absolute time of search range start
  endtime    absolute time of search range end
  startage   relative age from now of search range start (default 48h)
  endage     relative age from now of search range end (default 0)
```

I have also included a fix for EDGECLOUD-3087, to make the "org" arg for "audit showorg" optional in all cases. It used to be required for non-admins so that it could be specified as part of the Jaeger query, but now for non-admins we pull all data from Jaeger regardless of org, and then MC filters by whatever orgs that user has permissions for.