### PR TITLE
Infra alerts to PagerDuty

### DIFF
--- a/ansible/files/kapacitor/tasks/cloudflare-dns-entries.tick
+++ b/ansible/files/kapacitor/tasks/cloudflare-dns-entries.tick
@@ -3,15 +3,21 @@ dbrp "cloudflare"."autogen"
 var name = 'Cloudflare DNS Entries'
 
 var info = 2500
+
 var warn = 3000
+
 var crit = 3250
 
 var period = 60m
+
 var every = 60m
 
 var outputDB = 'chronograf'
+
 var outputRP = 'autogen'
+
 var outputMeasurement = 'alerts'
+
 var triggerType = 'threshold'
 
 // Dataframe
@@ -28,6 +34,7 @@ var alert = data
         .info(lambda: "nrecs" > info)
         .warn(lambda: "nrecs" > warn)
         .crit(lambda: "nrecs" > crit)
+        .pagerDuty2()
         .slack()
         .channel('#alerts')
 

--- a/ansible/files/kapacitor/tasks/cpu-usage.tick
+++ b/ansible/files/kapacitor/tasks/cpu-usage.tick
@@ -56,9 +56,10 @@ var trigger = data
     |alert()
         .id(idVar)
         .message(' {{ .ID }} is {{.Level}}: {{ index .Fields "stat_round" }}% mean CPU usage')
-        .info(lambda: "stat" > info OR "sigma" > infoSig)
-        .warn(lambda: "stat" > warn OR "sigma" > warnSig)
-        .crit(lambda: "stat" > crit OR "sigma" > critSig)
+        .info(lambda: "stat" > info)
+        .warn(lambda: "stat" > warn)
+        .crit(lambda: "stat" > crit)
+        .pagerDuty2()
         .slack()
 
 trigger

--- a/ansible/files/kapacitor/tasks/disk-usage.tick
+++ b/ansible/files/kapacitor/tasks/disk-usage.tick
@@ -54,9 +54,10 @@ var trigger = data
     |alert()
         .id(idVar)
         .message(' {{ .ID }} is {{.Level}}: {{ index .Fields "stat_round" }}% disk usage')
-        .info(lambda: "stat" > info OR "sigma" > infoSig)
-        .warn(lambda: "stat" > warn OR "sigma" > warnSig)
-        .crit(lambda: "stat" > crit OR "sigma" > critSig)
+        .info(lambda: "stat" > info)
+        .warn(lambda: "stat" > warn)
+        .crit(lambda: "stat" > crit)
+        .pagerDuty2()
         .slack()
 
 trigger

--- a/ansible/files/kapacitor/tasks/etcd-db.tick
+++ b/ansible/files/kapacitor/tasks/etcd-db.tick
@@ -3,10 +3,13 @@ dbrp "etcd"."autogen"
 var name = 'Etcd DB Size'
 
 var info = 70
+
 var warn = 80
+
 var crit = 90
 
 var period = 15m
+
 var every = 15m
 
 var triggerType = 'threshold'
@@ -29,4 +32,5 @@ var alert = data
         .warn(lambda: "dbsize" > warn)
         .crit(lambda: "dbsize" > crit)
         .message('{{ .Level }}: Etcd DB Size: {{ index .Tags "env" }}: {{ index .Fields "dbsize" }} MB')
+        .pagerDuty2()
         .slack()

--- a/ansible/files/kapacitor/tasks/memory-usage.tick
+++ b/ansible/files/kapacitor/tasks/memory-usage.tick
@@ -54,9 +54,10 @@ var trigger = data
     |alert()
         .id(idVar)
         .message(' {{ .ID }} is {{.Level}}: {{ index .Fields "stat_round" }}% mean memory usage')
-        .info(lambda: "stat" > info OR "sigma" > infoSig)
-        .warn(lambda: "stat" > warn OR "sigma" > warnSig)
-        .crit(lambda: "stat" > crit OR "sigma" > critSig)
+        .info(lambda: "stat" > info)
+        .warn(lambda: "stat" > warn)
+        .crit(lambda: "stat" > crit)
+        .pagerDuty2()
         .slack()
 
 trigger

--- a/ansible/files/kapacitor/tasks/vault-seal-status.tick
+++ b/ansible/files/kapacitor/tasks/vault-seal-status.tick
@@ -1,19 +1,22 @@
 dbrp "telegraf"."autogen"
 
 var name = 'Vault Seal Status Alert'
+
 var period = 1m
+
 var alert_interval = 15m
 
 var data = batch
-    | query(''' SELECT LAST(sealed) AS is_sealed FROM "telegraf"."autogen"."vault_status" ''')
+    |query(''' SELECT LAST(sealed) AS is_sealed FROM "telegraf"."autogen"."vault_status" ''')
         .period(period)
         .every(period)
         .groupBy('host', 'environ')
 
 var alert = data
-    | alert()
+    |alert()
         .id('vault-{{ index .Tags "environ" }}/{{ index .Tags "host" }}')
         .message('{{ .ID }}: Seal status is {{ .Level }}')
         .crit(lambda: "is_sealed")
         .stateChangesOnly(alert_interval)
+        .pagerDuty2()
         .slack()

--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -4,11 +4,11 @@
     chronograf_google_creds_path: "secret/ansible/{{ deploy_environ }}/accounts/chronograf_google"
     influxdb_conf_file: /etc/influxdb/influxdb.conf
     ansible_managed_header: "MANAGED BY ANSIBLE"
-    chronograf_version: 1.7.12
-    chronograf_checksum: "sha256:ea261d5de9ad7738980f091cb78c5762ee57cdac8bf56ec1fdf36953351ff2cc"
+    chronograf_version: 1.8.5
+    chronograf_checksum: "sha256:fb52a9bc691949ce9131574586bb69d3422d5c64085a77923da26f78bc57387f"
     chronograf_canned_path: /usr/share/chronograf/canned
-    kapacitor_version: 1.5.3
-    kapacitor_checksum: "md5:2fb06503a66e3cc5fb1f9b86875da39d"
+    kapacitor_version: 1.5.4-1
+    kapacitor_checksum: "md5:fcb4b7ee7a9be484f0d0a73a61795a29"
     kapacitor_conf_file: /etc/kapacitor/kapacitor.conf
     kapacitor_load_dir: /etc/kapacitor/load
 


### PR DESCRIPTION
Also:
- Update kapacitor and chronograf versions.
- Get rid of stddev-based alerts. The intent was to alert if
  CPU/memory/disk usage was X stddevs away from mean, but in practice,
  our loads tend to be spiky, resulting in far too many false alarms.