### PR TITLE
Set up SSH keys for ubuntu user

### DIFF
--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 3.1.4
+VERSION = 3.1.5
 DISTRIBUTION = stratus
 COMPONENT = main
 

--- a/openstack-tenant/packer/setup.sh
+++ b/openstack-tenant/packer/setup.sh
@@ -85,11 +85,13 @@ download_artifactory_file keys/id_rsa_mobiledgex.pub /tmp/id_rsa_mobiledgex.pub
 log "Setting up SSH"
 sudo cp /etc/mobiledgex/id_rsa_mex /root/id_rsa_mex
 sudo chmod 600 /root/id_rsa_mex
-sudo mkdir -p /root/.ssh
-sudo cat /tmp/id_rsa_mex.pub /tmp/id_rsa_mobiledgex.pub | sudo tee /root/.ssh/authorized_keys
-sudo chmod 700 /root/.ssh
-sudo chmod 600 /root/.ssh/authorized_keys
-sudo rm -f /root/.ssh/known_hosts
+for SSH_HOME in /root /home/ubuntu; do
+	sudo mkdir -p ${SSH_HOME}/.ssh
+	sudo cat /tmp/id_rsa_mex.pub /tmp/id_rsa_mobiledgex.pub | sudo tee ${SSH_HOME}/.ssh/authorized_keys
+	sudo chmod 700 ${SSH_HOME}/.ssh
+	sudo chmod 600 ${SSH_HOME}/.ssh/authorized_keys
+	sudo rm -f ${SSH_HOME}/.ssh/known_hosts
+done
 
 log "Setting up $MEX_RELEASE"
 sudo tee "$MEX_RELEASE" <<EOT

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -28,7 +28,7 @@ type VMProperties struct {
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "3.1.4"
+var MEXInfraVersion = "3.1.5"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
This is a temporary change to help with the VMPool bringup. Before this
change, the ubuntu user's SSH authorized keys were being set up by
cloud-init.

This will be removed along with all ssh keys in the image once we have
vault-ssh in place.