### PR TITLE
Fix UpdateClusterInst for VMPool

### DIFF
--- a/crm-platforms/vmpool/vmpool-cmd.go
+++ b/crm-platforms/vmpool/vmpool-cmd.go
@@ -29,7 +29,7 @@ func (s *VMPoolPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.Flavor
 		}
 	}
 	if accessIP == "" {
-		return nil, fmt.Errorf("atleast one VM should have access to external network")
+		return nil, fmt.Errorf("At least one VM should have access to external network")
 	}
 	accessClient, err := s.VMProperties.GetSSHClientFromIPAddr(ctx, accessIP)
 	if err != nil {

--- a/openstack-tenant/packages/mobiledgex/cleanup-vm.sh
+++ b/openstack-tenant/packages/mobiledgex/cleanup-vm.sh
@@ -60,10 +60,7 @@ if [[ -f /etc/chef/client.rb ]]; then
   log "Remove chef client.rb file"
   rm /etc/chef/client.rb
 fi
-systemctl is-active --quiet chef-client
-if [[ $? -eq 0 ]]; then
-  log "Stop chef-client"
-  systemctl stop chef-client
-fi
+log "Stop chef-client"
+systemctl stop chef-client
 
 echo "[$(date)] Done cleanup-vm.sh ($( pwd ))"


### PR DESCRIPTION
* UpdateClusterInst was failing for increasing K8s nodes, be cause we using `mex-k8s-node-` prefix from hostname to figure k8s nodes from `kubectl get nodes` output.
* Fixed it by setting hostname when a VM is used. And resetting it to vm.Name defined in VMPool on cleanup
* This PR also fixes small typos
* Also, fixed cleanup script to stop chef-client, regardless of it being active or not. Because some time chef-client is running (in failed) and systemctl will not show that as active state