### PR TITLE
fix localhost in hosts file

### DIFF
--- a/crm-platforms/vmpool/vmpool-provider.go
+++ b/crm-platforms/vmpool/vmpool-provider.go
@@ -126,7 +126,7 @@ func setupHostname(ctx context.Context, client ssh.Client, hostname string) erro
 	if err != nil {
 		return fmt.Errorf("failed to execute hostnamectl: %s, %v", out, err)
 	}
-	cmd = fmt.Sprintf(`sudo sed -i "s/127.0.0.1 \+.\+/127.0.0.1 %s/" /etc/hosts`, hostname)
+	cmd = fmt.Sprintf(`sudo sed -i "/localhost/! s/127.0.0.1 \+.\+/127.0.0.1 %s/" /etc/hosts`, hostname)
 	out, err = client.Output(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to update /etc/hosts file: %s, %v", out, err)


### PR DESCRIPTION
Fix the /etc/hosts file for VMPool.  It seems the change for infra pr 920 broke k8s for VMPool because the modification to /etc/hosts overwrote the entry for localhost.  So you get this:

$ kubectl get pods
Unable to connect to the server: dial tcp: lookup localhost on 1.1.1.1:53: no such host 

Fix is to exclude localhost when changing the entries for 127.0.0.1 