### PR TITLE
EDGECLOUD-3340 AutoProv policy honor CloudletPools

### DIFF
--- a/mc/orm/alert_mc2_test.go
+++ b/mc/orm/alert_mc2_test.go
@@ -146,14 +146,14 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermShowAlert(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAlert(mcClient, uri, token, region, org)
+func badPermShowAlert(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Alert)) {
+	_, status, err := testutil.TestPermShowAlert(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowAlert(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAlert(mcClient, uri, token, region, org)
+func goodPermShowAlert(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Alert)) {
+	_, status, err := testutil.TestPermShowAlert(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/app_mc2_test.go
+++ b/mc/orm/app_mc2_test.go
@@ -25,94 +25,94 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateApp(mcClient, uri, token, region, org)
+func badPermCreateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	_, status, err := testutil.TestPermCreateApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateApp(mcClient, uri, token, region, org)
+func goodPermCreateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	_, status, err := testutil.TestPermCreateApp(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteApp(mcClient, uri, token, region, org)
+func badPermDeleteApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	_, status, err := testutil.TestPermDeleteApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteApp(mcClient, uri, token, region, org)
+func goodPermDeleteApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	_, status, err := testutil.TestPermDeleteApp(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateApp(mcClient, uri, token, region, org)
+func badPermUpdateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	_, status, err := testutil.TestPermUpdateApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateApp(mcClient, uri, token, region, org)
+func goodPermUpdateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	_, status, err := testutil.TestPermUpdateApp(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowApp(mcClient, uri, token, region, org)
+func badPermShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	_, status, err := testutil.TestPermShowApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowApp(mcClient, uri, token, region, org)
+func goodPermShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	_, status, err := testutil.TestPermShowApp(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermAddAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddAppAutoProvPolicy(mcClient, uri, token, region, org)
+func badPermAddAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
+	_, status, err := testutil.TestPermAddAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermAddAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddAppAutoProvPolicy(mcClient, uri, token, region, org)
+func goodPermAddAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
+	_, status, err := testutil.TestPermAddAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRemoveAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveAppAutoProvPolicy(mcClient, uri, token, region, org)
+func badPermRemoveAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
+	_, status, err := testutil.TestPermRemoveAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRemoveAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveAppAutoProvPolicy(mcClient, uri, token, region, org)
+func goodPermRemoveAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
+	_, status, err := testutil.TestPermRemoveAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateApp(t, mcClient, uri, token, region, org)
-	badPermUpdateApp(t, mcClient, uri, token, region, org)
-	badPermDeleteApp(t, mcClient, uri, token, region, org)
+func badPermTestApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
+	badPermCreateApp(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermUpdateApp(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteApp(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -125,21 +125,21 @@ func badPermTestShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, re
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.App)) {
 	goodPermCreateApp(t, mcClient, uri, token, region, org)
 	goodPermUpdateApp(t, mcClient, uri, token, region, org)
 	goodPermDeleteApp(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateApp(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateApp(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdateApp(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermUpdateApp(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteApp(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteApp(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -164,12 +164,12 @@ func goodPermTestShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, r
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestApp(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestApp(t, mcClient, uri, token1, region, org2)
+func permTestApp(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.App)) {
+	badPermTestApp(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowApp(t, mcClient, uri, token1, region, org2)
-	badPermTestApp(t, mcClient, uri, token2, region, org1)
+	badPermTestApp(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowApp(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestApp(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestApp(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestApp(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestApp(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/appinst_mc2_test.go
+++ b/mc/orm/appinst_mc2_test.go
@@ -27,80 +27,80 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermCreateAppInst(mcClient, uri, token, region, org, targetCloudlet)
+func badPermCreateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermCreateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermCreateAppInst(mcClient, uri, token, region, org, targetCloudlet)
+func goodPermCreateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermCreateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermDeleteAppInst(mcClient, uri, token, region, org, targetCloudlet)
+func badPermDeleteAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermDeleteAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermDeleteAppInst(mcClient, uri, token, region, org, targetCloudlet)
+func goodPermDeleteAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermDeleteAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRefreshAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermRefreshAppInst(mcClient, uri, token, region, org, targetCloudlet)
+func badPermRefreshAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermRefreshAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRefreshAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermRefreshAppInst(mcClient, uri, token, region, org, targetCloudlet)
+func goodPermRefreshAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermRefreshAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermUpdateAppInst(mcClient, uri, token, region, org, targetCloudlet)
+func badPermUpdateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermUpdateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermUpdateAppInst(mcClient, uri, token, region, org, targetCloudlet)
+func goodPermUpdateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermUpdateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAppInst(mcClient, uri, token, region, org)
+func badPermShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermShowAppInst(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAppInst(mcClient, uri, token, region, org)
+func goodPermShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInst)) {
+	_, status, err := testutil.TestPermShowAppInst(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	badPermCreateAppInst(t, mcClient, uri, token, region, org, targetCloudlet)
-	badPermUpdateAppInst(t, mcClient, uri, token, region, org, targetCloudlet)
-	badPermDeleteAppInst(t, mcClient, uri, token, region, org, targetCloudlet)
+func badPermTestAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	badPermCreateAppInst(t, mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	badPermUpdateAppInst(t, mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	badPermDeleteAppInst(t, mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 }
 
 func badPermTestShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -113,21 +113,21 @@ func badPermTestShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, showcount int) {
+func goodPermTestAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, showcount int, modFuncs ...func(*edgeproto.AppInst)) {
 	goodPermCreateAppInst(t, mcClient, uri, token, region, org, targetCloudlet)
 	goodPermUpdateAppInst(t, mcClient, uri, token, region, org, targetCloudlet)
 	goodPermDeleteAppInst(t, mcClient, uri, token, region, org, targetCloudlet)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateAppInst(mcClient, uri, token, "bad region", org, targetCloudlet)
+	_, status, err := testutil.TestPermCreateAppInst(mcClient, uri, token, "bad region", org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdateAppInst(mcClient, uri, token, "bad region", org, targetCloudlet)
+	_, status, err = testutil.TestPermUpdateAppInst(mcClient, uri, token, "bad region", org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteAppInst(mcClient, uri, token, "bad region", org, targetCloudlet)
+	_, status, err = testutil.TestPermDeleteAppInst(mcClient, uri, token, "bad region", org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -152,12 +152,12 @@ func goodPermTestShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, toke
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestAppInst(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, targetCloudlet *edgeproto.CloudletKey, showcount int) {
-	badPermTestAppInst(t, mcClient, uri, token1, region, org2, targetCloudlet)
+func permTestAppInst(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, targetCloudlet *edgeproto.CloudletKey, showcount int, modFuncs ...func(*edgeproto.AppInst)) {
+	badPermTestAppInst(t, mcClient, uri, token1, region, org2, targetCloudlet, modFuncs...)
 	badPermTestShowAppInst(t, mcClient, uri, token1, region, org2)
-	badPermTestAppInst(t, mcClient, uri, token2, region, org1, targetCloudlet)
+	badPermTestAppInst(t, mcClient, uri, token2, region, org1, targetCloudlet, modFuncs...)
 	badPermTestShowAppInst(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestAppInst(t, mcClient, uri, token1, region, org1, targetCloudlet, showcount)
-	goodPermTestAppInst(t, mcClient, uri, token2, region, org2, targetCloudlet, showcount)
+	goodPermTestAppInst(t, mcClient, uri, token1, region, org1, targetCloudlet, showcount, modFuncs...)
+	goodPermTestAppInst(t, mcClient, uri, token2, region, org2, targetCloudlet, showcount, modFuncs...)
 }

--- a/mc/orm/appinstclient_mc2_test.go
+++ b/mc/orm/appinstclient_mc2_test.go
@@ -26,14 +26,14 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermShowAppInstClient(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAppInstClient(mcClient, uri, token, region, org)
+func badPermShowAppInstClient(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstClientKey)) {
+	_, status, err := testutil.TestPermShowAppInstClient(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowAppInstClient(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAppInstClient(mcClient, uri, token, region, org)
+func goodPermShowAppInstClient(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstClientKey)) {
+	_, status, err := testutil.TestPermShowAppInstClient(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/autoprovpolicy.mc2.go
+++ b/mc/orm/autoprovpolicy.mc2.go
@@ -53,8 +53,8 @@ func CreateAutoProvPolicy(c echo.Context) error {
 
 func CreateAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoProvPolicy) (*edgeproto.Result, error) {
 	if !rc.skipAuthz {
-		if err := authorized(ctx, rc.username, obj.Key.Organization,
-			ResourceDeveloperPolicy, ActionManage, withRequiresOrg(obj.Key.Organization)); err != nil {
+		if err := authzCreateAutoProvPolicy(ctx, rc.region, rc.username, obj,
+			ResourceDeveloperPolicy, ActionManage); err != nil {
 			return nil, err
 		}
 	}
@@ -147,7 +147,7 @@ func UpdateAutoProvPolicy(c echo.Context) error {
 
 func UpdateAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoProvPolicy) (*edgeproto.Result, error) {
 	if !rc.skipAuthz {
-		if err := authorized(ctx, rc.username, obj.Key.Organization,
+		if err := authzUpdateAutoProvPolicy(ctx, rc.region, rc.username, obj,
 			ResourceDeveloperPolicy, ActionManage); err != nil {
 			return nil, err
 		}
@@ -279,7 +279,7 @@ func AddAutoProvPolicyCloudlet(c echo.Context) error {
 
 func AddAutoProvPolicyCloudletObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoProvPolicyCloudlet) (*edgeproto.Result, error) {
 	if !rc.skipAuthz {
-		if err := authorized(ctx, rc.username, obj.Key.Organization,
+		if err := authzAddAutoProvPolicyCloudlet(ctx, rc.region, rc.username, obj,
 			ResourceDeveloperPolicy, ActionManage); err != nil {
 			return nil, err
 		}

--- a/mc/orm/autoprovpolicy_mc2_test.go
+++ b/mc/orm/autoprovpolicy_mc2_test.go
@@ -27,94 +27,94 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, region, org)
+func badPermCreateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, status, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, region, org)
+func goodPermCreateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, status, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, region, org)
+func badPermDeleteAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, status, err := testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, region, org)
+func goodPermDeleteAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, status, err := testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, region, org)
+func badPermUpdateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, status, err := testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, region, org)
+func goodPermUpdateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, status, err := testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAutoProvPolicy(mcClient, uri, token, region, org)
+func badPermShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, status, err := testutil.TestPermShowAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAutoProvPolicy(mcClient, uri, token, region, org)
+func goodPermShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, status, err := testutil.TestPermShowAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermAddAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddAutoProvPolicyCloudlet(mcClient, uri, token, region, org)
+func badPermAddAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
+	_, status, err := testutil.TestPermAddAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermAddAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddAutoProvPolicyCloudlet(mcClient, uri, token, region, org)
+func goodPermAddAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
+	_, status, err := testutil.TestPermAddAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRemoveAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, org)
+func badPermRemoveAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
+	_, status, err := testutil.TestPermRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRemoveAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, org)
+func goodPermRemoveAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
+	_, status, err := testutil.TestPermRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateAutoProvPolicy(t, mcClient, uri, token, region, org)
-	badPermUpdateAutoProvPolicy(t, mcClient, uri, token, region, org)
-	badPermDeleteAutoProvPolicy(t, mcClient, uri, token, region, org)
+func badPermTestAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	badPermCreateAutoProvPolicy(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermUpdateAutoProvPolicy(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteAutoProvPolicy(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -127,21 +127,21 @@ func badPermTestShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
 	goodPermCreateAutoProvPolicy(t, mcClient, uri, token, region, org)
 	goodPermUpdateAutoProvPolicy(t, mcClient, uri, token, region, org)
 	goodPermDeleteAutoProvPolicy(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -166,12 +166,12 @@ func goodPermTestShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, ur
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestAutoProvPolicy(t, mcClient, uri, token1, region, org2)
+func permTestAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	badPermTestAutoProvPolicy(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowAutoProvPolicy(t, mcClient, uri, token1, region, org2)
-	badPermTestAutoProvPolicy(t, mcClient, uri, token2, region, org1)
+	badPermTestAutoProvPolicy(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowAutoProvPolicy(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestAutoProvPolicy(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestAutoProvPolicy(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestAutoProvPolicy(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestAutoProvPolicy(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/autoscalepolicy_mc2_test.go
+++ b/mc/orm/autoscalepolicy_mc2_test.go
@@ -25,66 +25,66 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, region, org)
+func badPermCreateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, status, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, region, org)
+func goodPermCreateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, status, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, region, org)
+func badPermDeleteAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, status, err := testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, region, org)
+func goodPermDeleteAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, status, err := testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, region, org)
+func badPermUpdateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, status, err := testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, region, org)
+func goodPermUpdateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, status, err := testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAutoScalePolicy(mcClient, uri, token, region, org)
+func badPermShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, status, err := testutil.TestPermShowAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAutoScalePolicy(mcClient, uri, token, region, org)
+func goodPermShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, status, err := testutil.TestPermShowAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateAutoScalePolicy(t, mcClient, uri, token, region, org)
-	badPermUpdateAutoScalePolicy(t, mcClient, uri, token, region, org)
-	badPermDeleteAutoScalePolicy(t, mcClient, uri, token, region, org)
+func badPermTestAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	badPermCreateAutoScalePolicy(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermUpdateAutoScalePolicy(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteAutoScalePolicy(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -97,21 +97,21 @@ func badPermTestShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, ur
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
 	goodPermCreateAutoScalePolicy(t, mcClient, uri, token, region, org)
 	goodPermUpdateAutoScalePolicy(t, mcClient, uri, token, region, org)
 	goodPermDeleteAutoScalePolicy(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -136,12 +136,12 @@ func goodPermTestShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, u
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestAutoScalePolicy(t, mcClient, uri, token1, region, org2)
+func permTestAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	badPermTestAutoScalePolicy(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowAutoScalePolicy(t, mcClient, uri, token1, region, org2)
-	badPermTestAutoScalePolicy(t, mcClient, uri, token2, region, org1)
+	badPermTestAutoScalePolicy(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowAutoScalePolicy(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestAutoScalePolicy(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestAutoScalePolicy(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestAutoScalePolicy(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestAutoScalePolicy(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/cloudlet_mc2_test.go
+++ b/mc/orm/cloudlet_mc2_test.go
@@ -26,122 +26,122 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, region, org)
+func badPermCreateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, region, org)
+func goodPermCreateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteCloudlet(mcClient, uri, token, region, org)
+func badPermDeleteCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermDeleteCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteCloudlet(mcClient, uri, token, region, org)
+func goodPermDeleteCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermDeleteCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateCloudlet(mcClient, uri, token, region, org)
+func badPermUpdateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermUpdateCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateCloudlet(mcClient, uri, token, region, org)
+func goodPermUpdateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermUpdateCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowCloudlet(mcClient, uri, token, region, org)
+func badPermShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermShowCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowCloudlet(mcClient, uri, token, region, org)
+func goodPermShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermShowCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermGetCloudletManifest(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermGetCloudletManifest(mcClient, uri, token, region, org)
+func badPermGetCloudletManifest(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermGetCloudletManifest(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermGetCloudletManifest(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermGetCloudletManifest(mcClient, uri, token, region, org)
+func goodPermGetCloudletManifest(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, status, err := testutil.TestPermGetCloudletManifest(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermAddCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddCloudletResMapping(mcClient, uri, token, region, org)
+func badPermAddCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) {
+	_, status, err := testutil.TestPermAddCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermAddCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddCloudletResMapping(mcClient, uri, token, region, org)
+func goodPermAddCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) {
+	_, status, err := testutil.TestPermAddCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRemoveCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveCloudletResMapping(mcClient, uri, token, region, org)
+func badPermRemoveCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) {
+	_, status, err := testutil.TestPermRemoveCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRemoveCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveCloudletResMapping(mcClient, uri, token, region, org)
+func goodPermRemoveCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) {
+	_, status, err := testutil.TestPermRemoveCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermFindFlavorMatch(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermFindFlavorMatch(mcClient, uri, token, region, org)
+func badPermFindFlavorMatch(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.FlavorMatch)) {
+	_, status, err := testutil.TestPermFindFlavorMatch(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermFindFlavorMatch(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermFindFlavorMatch(mcClient, uri, token, region, org)
+func goodPermFindFlavorMatch(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.FlavorMatch)) {
+	_, status, err := testutil.TestPermFindFlavorMatch(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateCloudlet(t, mcClient, uri, token, region, org)
-	badPermUpdateCloudlet(t, mcClient, uri, token, region, org)
-	badPermDeleteCloudlet(t, mcClient, uri, token, region, org)
+func badPermTestCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
+	badPermCreateCloudlet(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermUpdateCloudlet(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteCloudlet(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -154,21 +154,21 @@ func badPermTestShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, toke
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.Cloudlet)) {
 	goodPermCreateCloudlet(t, mcClient, uri, token, region, org)
 	goodPermUpdateCloudlet(t, mcClient, uri, token, region, org)
 	goodPermDeleteCloudlet(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdateCloudlet(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermUpdateCloudlet(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteCloudlet(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteCloudlet(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -193,54 +193,54 @@ func goodPermTestShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, tok
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestCloudlet(t, mcClient, uri, token1, region, org2)
+func permTestCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.Cloudlet)) {
+	badPermTestCloudlet(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowCloudlet(t, mcClient, uri, token1, region, org2)
-	badPermTestCloudlet(t, mcClient, uri, token2, region, org1)
+	badPermTestCloudlet(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowCloudlet(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestCloudlet(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestCloudlet(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestCloudlet(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestCloudlet(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowCloudletInfo(mcClient, uri, token, region, org)
+func badPermShowCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, status, err := testutil.TestPermShowCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowCloudletInfo(mcClient, uri, token, region, org)
+func goodPermShowCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, status, err := testutil.TestPermShowCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermInjectCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermInjectCloudletInfo(mcClient, uri, token, region, org)
+func badPermInjectCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, status, err := testutil.TestPermInjectCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermInjectCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermInjectCloudletInfo(mcClient, uri, token, region, org)
+func goodPermInjectCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, status, err := testutil.TestPermInjectCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermEvictCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermEvictCloudletInfo(mcClient, uri, token, region, org)
+func badPermEvictCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, status, err := testutil.TestPermEvictCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermEvictCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermEvictCloudletInfo(mcClient, uri, token, region, org)
+func goodPermEvictCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, status, err := testutil.TestPermEvictCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/cloudletpool_mc2_test.go
+++ b/mc/orm/cloudletpool_mc2_test.go
@@ -25,93 +25,93 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, region, org)
+func badPermCreateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, status, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, region, org)
+func goodPermCreateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, status, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteCloudletPool(mcClient, uri, token, region, org)
+func badPermDeleteCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, status, err := testutil.TestPermDeleteCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteCloudletPool(mcClient, uri, token, region, org)
+func goodPermDeleteCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, status, err := testutil.TestPermDeleteCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateCloudletPool(mcClient, uri, token, region, org)
+func badPermUpdateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, status, err := testutil.TestPermUpdateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateCloudletPool(mcClient, uri, token, region, org)
+func goodPermUpdateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, status, err := testutil.TestPermUpdateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowCloudletPool(mcClient, uri, token, region, org)
+func badPermShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, status, err := testutil.TestPermShowCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowCloudletPool(mcClient, uri, token, region, org)
+func goodPermShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, status, err := testutil.TestPermShowCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermAddCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddCloudletPoolMember(mcClient, uri, token, region, org)
+func badPermAddCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
+	_, status, err := testutil.TestPermAddCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermAddCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddCloudletPoolMember(mcClient, uri, token, region, org)
+func goodPermAddCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
+	_, status, err := testutil.TestPermAddCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRemoveCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveCloudletPoolMember(mcClient, uri, token, region, org)
+func badPermRemoveCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
+	_, status, err := testutil.TestPermRemoveCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRemoveCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveCloudletPoolMember(mcClient, uri, token, region, org)
+func goodPermRemoveCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
+	_, status, err := testutil.TestPermRemoveCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateCloudletPool(t, mcClient, uri, token, region, org)
-	badPermDeleteCloudletPool(t, mcClient, uri, token, region, org)
+func badPermTestCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
+	badPermCreateCloudletPool(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteCloudletPool(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -124,16 +124,16 @@ func badPermTestShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, 
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.CloudletPool)) {
 	goodPermCreateCloudletPool(t, mcClient, uri, token, region, org)
 	goodPermDeleteCloudletPool(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteCloudletPool(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteCloudletPool(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -158,12 +158,12 @@ func goodPermTestShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri,
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestCloudletPool(t, mcClient, uri, token1, region, org2)
+func permTestCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.CloudletPool)) {
+	badPermTestCloudletPool(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowCloudletPool(t, mcClient, uri, token1, region, org2)
-	badPermTestCloudletPool(t, mcClient, uri, token2, region, org1)
+	badPermTestCloudletPool(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowCloudletPool(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestCloudletPool(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestCloudletPool(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestCloudletPool(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestCloudletPool(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/clusterinst_mc2_test.go
+++ b/mc/orm/clusterinst_mc2_test.go
@@ -25,66 +25,66 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, region, org, targetCloudlet)
+func badPermCreateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, status, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, region, org, targetCloudlet)
+func goodPermCreateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, status, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermDeleteClusterInst(mcClient, uri, token, region, org, targetCloudlet)
+func badPermDeleteClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, status, err := testutil.TestPermDeleteClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermDeleteClusterInst(mcClient, uri, token, region, org, targetCloudlet)
+func goodPermDeleteClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, status, err := testutil.TestPermDeleteClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermUpdateClusterInst(mcClient, uri, token, region, org, targetCloudlet)
+func badPermUpdateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, status, err := testutil.TestPermUpdateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	_, status, err := testutil.TestPermUpdateClusterInst(mcClient, uri, token, region, org, targetCloudlet)
+func goodPermUpdateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, status, err := testutil.TestPermUpdateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowClusterInst(mcClient, uri, token, region, org)
+func badPermShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, status, err := testutil.TestPermShowClusterInst(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowClusterInst(mcClient, uri, token, region, org)
+func goodPermShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, status, err := testutil.TestPermShowClusterInst(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) {
-	badPermCreateClusterInst(t, mcClient, uri, token, region, org, targetCloudlet)
-	badPermUpdateClusterInst(t, mcClient, uri, token, region, org, targetCloudlet)
-	badPermDeleteClusterInst(t, mcClient, uri, token, region, org, targetCloudlet)
+func badPermTestClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	badPermCreateClusterInst(t, mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	badPermUpdateClusterInst(t, mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	badPermDeleteClusterInst(t, mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 }
 
 func badPermTestShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -97,21 +97,21 @@ func badPermTestShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, t
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, showcount int) {
+func goodPermTestClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, showcount int, modFuncs ...func(*edgeproto.ClusterInst)) {
 	goodPermCreateClusterInst(t, mcClient, uri, token, region, org, targetCloudlet)
 	goodPermUpdateClusterInst(t, mcClient, uri, token, region, org, targetCloudlet)
 	goodPermDeleteClusterInst(t, mcClient, uri, token, region, org, targetCloudlet)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, "bad region", org, targetCloudlet)
+	_, status, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, "bad region", org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdateClusterInst(mcClient, uri, token, "bad region", org, targetCloudlet)
+	_, status, err = testutil.TestPermUpdateClusterInst(mcClient, uri, token, "bad region", org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteClusterInst(mcClient, uri, token, "bad region", org, targetCloudlet)
+	_, status, err = testutil.TestPermDeleteClusterInst(mcClient, uri, token, "bad region", org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -136,12 +136,12 @@ func goodPermTestShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, 
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, targetCloudlet *edgeproto.CloudletKey, showcount int) {
-	badPermTestClusterInst(t, mcClient, uri, token1, region, org2, targetCloudlet)
+func permTestClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, targetCloudlet *edgeproto.CloudletKey, showcount int, modFuncs ...func(*edgeproto.ClusterInst)) {
+	badPermTestClusterInst(t, mcClient, uri, token1, region, org2, targetCloudlet, modFuncs...)
 	badPermTestShowClusterInst(t, mcClient, uri, token1, region, org2)
-	badPermTestClusterInst(t, mcClient, uri, token2, region, org1, targetCloudlet)
+	badPermTestClusterInst(t, mcClient, uri, token2, region, org1, targetCloudlet, modFuncs...)
 	badPermTestShowClusterInst(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestClusterInst(t, mcClient, uri, token1, region, org1, targetCloudlet, showcount)
-	goodPermTestClusterInst(t, mcClient, uri, token2, region, org2, targetCloudlet, showcount)
+	goodPermTestClusterInst(t, mcClient, uri, token1, region, org1, targetCloudlet, showcount, modFuncs...)
+	goodPermTestClusterInst(t, mcClient, uri, token2, region, org2, targetCloudlet, showcount, modFuncs...)
 }

--- a/mc/orm/debug_mc2_test.go
+++ b/mc/orm/debug_mc2_test.go
@@ -25,56 +25,56 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermEnableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermEnableDebugLevels(mcClient, uri, token, region, org)
+func badPermEnableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, status, err := testutil.TestPermEnableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermEnableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermEnableDebugLevels(mcClient, uri, token, region, org)
+func goodPermEnableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, status, err := testutil.TestPermEnableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDisableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDisableDebugLevels(mcClient, uri, token, region, org)
+func badPermDisableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, status, err := testutil.TestPermDisableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDisableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDisableDebugLevels(mcClient, uri, token, region, org)
+func goodPermDisableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, status, err := testutil.TestPermDisableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowDebugLevels(mcClient, uri, token, region, org)
+func badPermShowDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, status, err := testutil.TestPermShowDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowDebugLevels(mcClient, uri, token, region, org)
+func goodPermShowDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, status, err := testutil.TestPermShowDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRunDebug(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRunDebug(mcClient, uri, token, region, org)
+func badPermRunDebug(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, status, err := testutil.TestPermRunDebug(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRunDebug(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRunDebug(mcClient, uri, token, region, org)
+func goodPermRunDebug(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, status, err := testutil.TestPermRunDebug(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/device_mc2_test.go
+++ b/mc/orm/device_mc2_test.go
@@ -26,56 +26,56 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermInjectDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermInjectDevice(mcClient, uri, token, region, org)
+func badPermInjectDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
+	_, status, err := testutil.TestPermInjectDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermInjectDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermInjectDevice(mcClient, uri, token, region, org)
+func goodPermInjectDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
+	_, status, err := testutil.TestPermInjectDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowDevice(mcClient, uri, token, region, org)
+func badPermShowDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
+	_, status, err := testutil.TestPermShowDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowDevice(mcClient, uri, token, region, org)
+func goodPermShowDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
+	_, status, err := testutil.TestPermShowDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermEvictDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermEvictDevice(mcClient, uri, token, region, org)
+func badPermEvictDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
+	_, status, err := testutil.TestPermEvictDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermEvictDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermEvictDevice(mcClient, uri, token, region, org)
+func goodPermEvictDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
+	_, status, err := testutil.TestPermEvictDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowDeviceReport(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowDeviceReport(mcClient, uri, token, region, org)
+func badPermShowDeviceReport(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DeviceReport)) {
+	_, status, err := testutil.TestPermShowDeviceReport(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowDeviceReport(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowDeviceReport(mcClient, uri, token, region, org)
+func goodPermShowDeviceReport(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DeviceReport)) {
+	_, status, err := testutil.TestPermShowDeviceReport(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/exec_mc2_test.go
+++ b/mc/orm/exec_mc2_test.go
@@ -24,56 +24,56 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermRunCommand(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRunCommand(mcClient, uri, token, region, org)
+func badPermRunCommand(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, status, err := testutil.TestPermRunCommand(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRunCommand(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRunCommand(mcClient, uri, token, region, org)
+func goodPermRunCommand(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, status, err := testutil.TestPermRunCommand(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRunConsole(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRunConsole(mcClient, uri, token, region, org)
+func badPermRunConsole(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, status, err := testutil.TestPermRunConsole(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRunConsole(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRunConsole(mcClient, uri, token, region, org)
+func goodPermRunConsole(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, status, err := testutil.TestPermRunConsole(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowLogs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowLogs(mcClient, uri, token, region, org)
+func badPermShowLogs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, status, err := testutil.TestPermShowLogs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowLogs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowLogs(mcClient, uri, token, region, org)
+func goodPermShowLogs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, status, err := testutil.TestPermShowLogs(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermAccessCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAccessCloudlet(mcClient, uri, token, region, org)
+func badPermAccessCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, status, err := testutil.TestPermAccessCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermAccessCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAccessCloudlet(mcClient, uri, token, region, org)
+func goodPermAccessCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, status, err := testutil.TestPermAccessCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/flavor_mc2_test.go
+++ b/mc/orm/flavor_mc2_test.go
@@ -25,94 +25,94 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateFlavor(mcClient, uri, token, region, org)
+func badPermCreateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermCreateFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateFlavor(mcClient, uri, token, region, org)
+func goodPermCreateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermCreateFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteFlavor(mcClient, uri, token, region, org)
+func badPermDeleteFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermDeleteFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteFlavor(mcClient, uri, token, region, org)
+func goodPermDeleteFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermDeleteFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateFlavor(mcClient, uri, token, region, org)
+func badPermUpdateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermUpdateFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateFlavor(mcClient, uri, token, region, org)
+func goodPermUpdateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermUpdateFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowFlavor(mcClient, uri, token, region, org)
+func badPermShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermShowFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowFlavor(mcClient, uri, token, region, org)
+func goodPermShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermShowFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermAddFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddFlavorRes(mcClient, uri, token, region, org)
+func badPermAddFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermAddFlavorRes(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermAddFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddFlavorRes(mcClient, uri, token, region, org)
+func goodPermAddFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermAddFlavorRes(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRemoveFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveFlavorRes(mcClient, uri, token, region, org)
+func badPermRemoveFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermRemoveFlavorRes(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRemoveFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveFlavorRes(mcClient, uri, token, region, org)
+func goodPermRemoveFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	_, status, err := testutil.TestPermRemoveFlavorRes(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateFlavor(t, mcClient, uri, token, region, org)
-	badPermUpdateFlavor(t, mcClient, uri, token, region, org)
-	badPermDeleteFlavor(t, mcClient, uri, token, region, org)
+func badPermTestFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
+	badPermCreateFlavor(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermUpdateFlavor(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteFlavor(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -125,21 +125,21 @@ func badPermTestShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token,
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.Flavor)) {
 	goodPermCreateFlavor(t, mcClient, uri, token, region, org)
 	goodPermUpdateFlavor(t, mcClient, uri, token, region, org)
 	goodPermDeleteFlavor(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateFlavor(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateFlavor(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdateFlavor(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermUpdateFlavor(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteFlavor(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteFlavor(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -164,12 +164,12 @@ func goodPermTestShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestFlavor(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestFlavor(t, mcClient, uri, token1, region, org2)
+func permTestFlavor(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.Flavor)) {
+	badPermTestFlavor(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowFlavor(t, mcClient, uri, token1, region, org2)
-	badPermTestFlavor(t, mcClient, uri, token2, region, org1)
+	badPermTestFlavor(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowFlavor(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestFlavor(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestFlavor(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestFlavor(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestFlavor(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/node_mc2_test.go
+++ b/mc/orm/node_mc2_test.go
@@ -25,14 +25,14 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermShowNode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowNode(mcClient, uri, token, region, org)
+func badPermShowNode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Node)) {
+	_, status, err := testutil.TestPermShowNode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowNode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowNode(mcClient, uri, token, region, org)
+func goodPermShowNode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Node)) {
+	_, status, err := testutil.TestPermShowNode(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/operatorcode_mc2_test.go
+++ b/mc/orm/operatorcode_mc2_test.go
@@ -24,51 +24,51 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, region, org)
+func badPermCreateOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, status, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, region, org)
+func goodPermCreateOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, status, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteOperatorCode(mcClient, uri, token, region, org)
+func badPermDeleteOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, status, err := testutil.TestPermDeleteOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteOperatorCode(mcClient, uri, token, region, org)
+func goodPermDeleteOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, status, err := testutil.TestPermDeleteOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowOperatorCode(mcClient, uri, token, region, org)
+func badPermShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, status, err := testutil.TestPermShowOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowOperatorCode(mcClient, uri, token, region, org)
+func goodPermShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, status, err := testutil.TestPermShowOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateOperatorCode(t, mcClient, uri, token, region, org)
-	badPermDeleteOperatorCode(t, mcClient, uri, token, region, org)
+func badPermTestOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
+	badPermCreateOperatorCode(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteOperatorCode(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -81,16 +81,16 @@ func badPermTestShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, 
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.OperatorCode)) {
 	goodPermCreateOperatorCode(t, mcClient, uri, token, region, org)
 	goodPermDeleteOperatorCode(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteOperatorCode(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteOperatorCode(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -115,12 +115,12 @@ func goodPermTestShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri,
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestOperatorCode(t, mcClient, uri, token1, region, org2)
+func permTestOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.OperatorCode)) {
+	badPermTestOperatorCode(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowOperatorCode(t, mcClient, uri, token1, region, org2)
-	badPermTestOperatorCode(t, mcClient, uri, token2, region, org1)
+	badPermTestOperatorCode(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowOperatorCode(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestOperatorCode(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestOperatorCode(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestOperatorCode(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestOperatorCode(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/privacypolicy_mc2_test.go
+++ b/mc/orm/privacypolicy_mc2_test.go
@@ -25,66 +25,66 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreatePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreatePrivacyPolicy(mcClient, uri, token, region, org)
+func badPermCreatePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	_, status, err := testutil.TestPermCreatePrivacyPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreatePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreatePrivacyPolicy(mcClient, uri, token, region, org)
+func goodPermCreatePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	_, status, err := testutil.TestPermCreatePrivacyPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeletePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeletePrivacyPolicy(mcClient, uri, token, region, org)
+func badPermDeletePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	_, status, err := testutil.TestPermDeletePrivacyPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeletePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeletePrivacyPolicy(mcClient, uri, token, region, org)
+func goodPermDeletePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	_, status, err := testutil.TestPermDeletePrivacyPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdatePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdatePrivacyPolicy(mcClient, uri, token, region, org)
+func badPermUpdatePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	_, status, err := testutil.TestPermUpdatePrivacyPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdatePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdatePrivacyPolicy(mcClient, uri, token, region, org)
+func goodPermUpdatePrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	_, status, err := testutil.TestPermUpdatePrivacyPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowPrivacyPolicy(mcClient, uri, token, region, org)
+func badPermShowPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	_, status, err := testutil.TestPermShowPrivacyPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowPrivacyPolicy(mcClient, uri, token, region, org)
+func goodPermShowPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	_, status, err := testutil.TestPermShowPrivacyPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreatePrivacyPolicy(t, mcClient, uri, token, region, org)
-	badPermUpdatePrivacyPolicy(t, mcClient, uri, token, region, org)
-	badPermDeletePrivacyPolicy(t, mcClient, uri, token, region, org)
+func badPermTestPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	badPermCreatePrivacyPolicy(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermUpdatePrivacyPolicy(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeletePrivacyPolicy(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -97,21 +97,21 @@ func badPermTestShowPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri,
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
 	goodPermCreatePrivacyPolicy(t, mcClient, uri, token, region, org)
 	goodPermUpdatePrivacyPolicy(t, mcClient, uri, token, region, org)
 	goodPermDeletePrivacyPolicy(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreatePrivacyPolicy(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreatePrivacyPolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdatePrivacyPolicy(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermUpdatePrivacyPolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeletePrivacyPolicy(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeletePrivacyPolicy(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -136,12 +136,12 @@ func goodPermTestShowPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestPrivacyPolicy(t, mcClient, uri, token1, region, org2)
+func permTestPrivacyPolicy(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.PrivacyPolicy)) {
+	badPermTestPrivacyPolicy(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowPrivacyPolicy(t, mcClient, uri, token1, region, org2)
-	badPermTestPrivacyPolicy(t, mcClient, uri, token2, region, org1)
+	badPermTestPrivacyPolicy(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowPrivacyPolicy(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestPrivacyPolicy(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestPrivacyPolicy(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestPrivacyPolicy(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestPrivacyPolicy(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/refs_mc2_test.go
+++ b/mc/orm/refs_mc2_test.go
@@ -24,42 +24,42 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermShowCloudletRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowCloudletRefs(mcClient, uri, token, region, org)
+func badPermShowCloudletRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletRefs)) {
+	_, status, err := testutil.TestPermShowCloudletRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowCloudletRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowCloudletRefs(mcClient, uri, token, region, org)
+func goodPermShowCloudletRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletRefs)) {
+	_, status, err := testutil.TestPermShowCloudletRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowClusterRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowClusterRefs(mcClient, uri, token, region, org)
+func badPermShowClusterRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterRefs)) {
+	_, status, err := testutil.TestPermShowClusterRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowClusterRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowClusterRefs(mcClient, uri, token, region, org)
+func goodPermShowClusterRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterRefs)) {
+	_, status, err := testutil.TestPermShowClusterRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowAppInstRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAppInstRefs(mcClient, uri, token, region, org)
+func badPermShowAppInstRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstRefs)) {
+	_, status, err := testutil.TestPermShowAppInstRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowAppInstRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowAppInstRefs(mcClient, uri, token, region, org)
+func goodPermShowAppInstRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstRefs)) {
+	_, status, err := testutil.TestPermShowAppInstRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/restagtable_mc2_test.go
+++ b/mc/orm/restagtable_mc2_test.go
@@ -25,107 +25,107 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, region, org)
+func badPermCreateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, region, org)
+func goodPermCreateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteResTagTable(mcClient, uri, token, region, org)
+func badPermDeleteResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermDeleteResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteResTagTable(mcClient, uri, token, region, org)
+func goodPermDeleteResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermDeleteResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateResTagTable(mcClient, uri, token, region, org)
+func badPermUpdateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermUpdateResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateResTagTable(mcClient, uri, token, region, org)
+func goodPermUpdateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermUpdateResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowResTagTable(mcClient, uri, token, region, org)
+func badPermShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermShowResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowResTagTable(mcClient, uri, token, region, org)
+func goodPermShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermShowResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermAddResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddResTag(mcClient, uri, token, region, org)
+func badPermAddResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermAddResTag(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermAddResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddResTag(mcClient, uri, token, region, org)
+func goodPermAddResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermAddResTag(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRemoveResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveResTag(mcClient, uri, token, region, org)
+func badPermRemoveResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermRemoveResTag(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRemoveResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveResTag(mcClient, uri, token, region, org)
+func goodPermRemoveResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, status, err := testutil.TestPermRemoveResTag(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermGetResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermGetResTagTable(mcClient, uri, token, region, org)
+func badPermGetResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTableKey)) {
+	_, status, err := testutil.TestPermGetResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermGetResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermGetResTagTable(mcClient, uri, token, region, org)
+func goodPermGetResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTableKey)) {
+	_, status, err := testutil.TestPermGetResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateResTagTable(t, mcClient, uri, token, region, org)
-	badPermDeleteResTagTable(t, mcClient, uri, token, region, org)
+func badPermTestResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
+	badPermCreateResTagTable(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteResTagTable(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -138,16 +138,16 @@ func badPermTestShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, t
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.ResTagTable)) {
 	goodPermCreateResTagTable(t, mcClient, uri, token, region, org)
 	goodPermDeleteResTagTable(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteResTagTable(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteResTagTable(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -172,12 +172,12 @@ func goodPermTestShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, 
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestResTagTable(t, mcClient, uri, token1, region, org2)
+func permTestResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.ResTagTable)) {
+	badPermTestResTagTable(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowResTagTable(t, mcClient, uri, token1, region, org2)
-	badPermTestResTagTable(t, mcClient, uri, token2, region, org1)
+	badPermTestResTagTable(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowResTagTable(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestResTagTable(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestResTagTable(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestResTagTable(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestResTagTable(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/settings_mc2_test.go
+++ b/mc/orm/settings_mc2_test.go
@@ -25,42 +25,42 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateSettings(mcClient, uri, token, region, org)
+func badPermUpdateSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
+	_, status, err := testutil.TestPermUpdateSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateSettings(mcClient, uri, token, region, org)
+func goodPermUpdateSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
+	_, status, err := testutil.TestPermUpdateSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermResetSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermResetSettings(mcClient, uri, token, region, org)
+func badPermResetSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
+	_, status, err := testutil.TestPermResetSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermResetSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermResetSettings(mcClient, uri, token, region, org)
+func goodPermResetSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
+	_, status, err := testutil.TestPermResetSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowSettings(mcClient, uri, token, region, org)
+func badPermShowSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
+	_, status, err := testutil.TestPermShowSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowSettings(mcClient, uri, token, region, org)
+func goodPermShowSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
+	_, status, err := testutil.TestPermShowSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/testutil/alert_mc2_testutil.go
+++ b/mc/orm/testutil/alert_mc2_testutil.go
@@ -142,15 +142,18 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestShowAlert(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Alert) ([]edgeproto.Alert, int, error) {
+func TestShowAlert(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Alert, modFuncs ...func(*edgeproto.Alert)) ([]edgeproto.Alert, int, error) {
 	dat := &ormapi.RegionAlert{}
 	dat.Region = region
 	dat.Alert = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Alert)
+	}
 	return mcClient.ShowAlert(uri, token, dat)
 }
-func TestPermShowAlert(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Alert, int, error) {
+func TestPermShowAlert(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Alert)) ([]edgeproto.Alert, int, error) {
 	in := &edgeproto.Alert{}
-	return TestShowAlert(mcClient, uri, token, region, in)
+	return TestShowAlert(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) ShowAlert(ctx context.Context, in *edgeproto.Alert) ([]edgeproto.Alert, error) {

--- a/mc/orm/testutil/app_mc2_testutil.go
+++ b/mc/orm/testutil/app_mc2_testutil.go
@@ -21,76 +21,94 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateApp(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.App) (*edgeproto.Result, int, error) {
+func TestCreateApp(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.App, modFuncs ...func(*edgeproto.App)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionApp{}
 	dat.Region = region
 	dat.App = *in
+	for _, fn := range modFuncs {
+		fn(&dat.App)
+	}
 	return mcClient.CreateApp(uri, token, dat)
 }
-func TestPermCreateApp(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreateApp(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.App{}
 	in.Key.Organization = org
-	return TestCreateApp(mcClient, uri, token, region, in)
+	return TestCreateApp(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteApp(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.App) (*edgeproto.Result, int, error) {
+func TestDeleteApp(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.App, modFuncs ...func(*edgeproto.App)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionApp{}
 	dat.Region = region
 	dat.App = *in
+	for _, fn := range modFuncs {
+		fn(&dat.App)
+	}
 	return mcClient.DeleteApp(uri, token, dat)
 }
-func TestPermDeleteApp(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeleteApp(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.App{}
 	in.Key.Organization = org
-	return TestDeleteApp(mcClient, uri, token, region, in)
+	return TestDeleteApp(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateApp(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.App) (*edgeproto.Result, int, error) {
+func TestUpdateApp(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.App, modFuncs ...func(*edgeproto.App)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionApp{}
 	dat.Region = region
 	dat.App = *in
+	for _, fn := range modFuncs {
+		fn(&dat.App)
+	}
 	return mcClient.UpdateApp(uri, token, dat)
 }
-func TestPermUpdateApp(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdateApp(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.App{}
 	in.Key.Organization = org
-	return TestUpdateApp(mcClient, uri, token, region, in)
+	return TestUpdateApp(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowApp(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.App) ([]edgeproto.App, int, error) {
+func TestShowApp(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.App, modFuncs ...func(*edgeproto.App)) ([]edgeproto.App, int, error) {
 	dat := &ormapi.RegionApp{}
 	dat.Region = region
 	dat.App = *in
+	for _, fn := range modFuncs {
+		fn(&dat.App)
+	}
 	return mcClient.ShowApp(uri, token, dat)
 }
-func TestPermShowApp(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.App, int, error) {
+func TestPermShowApp(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) ([]edgeproto.App, int, error) {
 	in := &edgeproto.App{}
 	in.Key.Organization = org
-	return TestShowApp(mcClient, uri, token, region, in)
+	return TestShowApp(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestAddAppAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppAutoProvPolicy) (*edgeproto.Result, int, error) {
+func TestAddAppAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppAutoProvPolicy, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAppAutoProvPolicy{}
 	dat.Region = region
 	dat.AppAutoProvPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppAutoProvPolicy)
+	}
 	return mcClient.AddAppAutoProvPolicy(uri, token, dat)
 }
-func TestPermAddAppAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermAddAppAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AppAutoProvPolicy{}
 	in.AppKey.Organization = org
-	return TestAddAppAutoProvPolicy(mcClient, uri, token, region, in)
+	return TestAddAppAutoProvPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRemoveAppAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppAutoProvPolicy) (*edgeproto.Result, int, error) {
+func TestRemoveAppAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppAutoProvPolicy, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAppAutoProvPolicy{}
 	dat.Region = region
 	dat.AppAutoProvPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppAutoProvPolicy)
+	}
 	return mcClient.RemoveAppAutoProvPolicy(uri, token, dat)
 }
-func TestPermRemoveAppAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermRemoveAppAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AppAutoProvPolicy{}
 	in.AppKey.Organization = org
-	return TestRemoveAppAutoProvPolicy(mcClient, uri, token, region, in)
+	return TestRemoveAppAutoProvPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateApp(ctx context.Context, in *edgeproto.App) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/appinst_mc2_testutil.go
+++ b/mc/orm/testutil/appinst_mc2_testutil.go
@@ -23,76 +23,91 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst) ([]edgeproto.Result, int, error) {
+func TestCreateAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAppInst{}
 	dat.Region = region
 	dat.AppInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppInst)
+	}
 	return mcClient.CreateAppInst(uri, token, dat)
 }
-func TestPermCreateAppInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) ([]edgeproto.Result, int, error) {
+func TestPermCreateAppInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.AppInst{}
 	if targetCloudlet != nil {
 		in.Key.ClusterInstKey.CloudletKey = *targetCloudlet
 	}
 	in.Key.AppKey.Organization = org
-	return TestCreateAppInst(mcClient, uri, token, region, in)
+	return TestCreateAppInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst) ([]edgeproto.Result, int, error) {
+func TestDeleteAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAppInst{}
 	dat.Region = region
 	dat.AppInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppInst)
+	}
 	return mcClient.DeleteAppInst(uri, token, dat)
 }
-func TestPermDeleteAppInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) ([]edgeproto.Result, int, error) {
+func TestPermDeleteAppInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.AppInst{}
 	if targetCloudlet != nil {
 		in.Key.ClusterInstKey.CloudletKey = *targetCloudlet
 	}
 	in.Key.AppKey.Organization = org
-	return TestDeleteAppInst(mcClient, uri, token, region, in)
+	return TestDeleteAppInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRefreshAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst) ([]edgeproto.Result, int, error) {
+func TestRefreshAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAppInst{}
 	dat.Region = region
 	dat.AppInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppInst)
+	}
 	return mcClient.RefreshAppInst(uri, token, dat)
 }
-func TestPermRefreshAppInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) ([]edgeproto.Result, int, error) {
+func TestPermRefreshAppInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.AppInst{}
 	if targetCloudlet != nil {
 		in.Key.ClusterInstKey.CloudletKey = *targetCloudlet
 	}
 	in.Key.AppKey.Organization = org
-	return TestRefreshAppInst(mcClient, uri, token, region, in)
+	return TestRefreshAppInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst) ([]edgeproto.Result, int, error) {
+func TestUpdateAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAppInst{}
 	dat.Region = region
 	dat.AppInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppInst)
+	}
 	return mcClient.UpdateAppInst(uri, token, dat)
 }
-func TestPermUpdateAppInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) ([]edgeproto.Result, int, error) {
+func TestPermUpdateAppInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.AppInst{}
 	if targetCloudlet != nil {
 		in.Key.ClusterInstKey.CloudletKey = *targetCloudlet
 	}
 	in.Key.AppKey.Organization = org
-	return TestUpdateAppInst(mcClient, uri, token, region, in)
+	return TestUpdateAppInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst) ([]edgeproto.AppInst, int, error) {
+func TestShowAppInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInst, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.AppInst, int, error) {
 	dat := &ormapi.RegionAppInst{}
 	dat.Region = region
 	dat.AppInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppInst)
+	}
 	return mcClient.ShowAppInst(uri, token, dat)
 }
-func TestPermShowAppInst(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.AppInst, int, error) {
+func TestPermShowAppInst(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInst)) ([]edgeproto.AppInst, int, error) {
 	in := &edgeproto.AppInst{}
 	in.Key.AppKey.Organization = org
-	return TestShowAppInst(mcClient, uri, token, region, in)
+	return TestShowAppInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateAppInst(ctx context.Context, in *edgeproto.AppInst) ([]edgeproto.Result, error) {

--- a/mc/orm/testutil/appinstclient_mc2_testutil.go
+++ b/mc/orm/testutil/appinstclient_mc2_testutil.go
@@ -22,16 +22,19 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestShowAppInstClient(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInstClientKey) ([]edgeproto.AppInstClient, int, error) {
+func TestShowAppInstClient(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInstClientKey, modFuncs ...func(*edgeproto.AppInstClientKey)) ([]edgeproto.AppInstClient, int, error) {
 	dat := &ormapi.RegionAppInstClientKey{}
 	dat.Region = region
 	dat.AppInstClientKey = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppInstClientKey)
+	}
 	return mcClient.ShowAppInstClient(uri, token, dat)
 }
-func TestPermShowAppInstClient(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.AppInstClient, int, error) {
+func TestPermShowAppInstClient(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstClientKey)) ([]edgeproto.AppInstClient, int, error) {
 	in := &edgeproto.AppInstClientKey{}
 	in.Key.AppKey.Organization = org
-	return TestShowAppInstClient(mcClient, uri, token, region, in)
+	return TestShowAppInstClient(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) ShowAppInstClient(ctx context.Context, in *edgeproto.AppInstClientKey) ([]edgeproto.AppInstClient, error) {

--- a/mc/orm/testutil/autoprovpolicy_mc2_testutil.go
+++ b/mc/orm/testutil/autoprovpolicy_mc2_testutil.go
@@ -23,76 +23,94 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicy) (*edgeproto.Result, int, error) {
+func TestCreateAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicy, modFuncs ...func(*edgeproto.AutoProvPolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAutoProvPolicy{}
 	dat.Region = region
 	dat.AutoProvPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoProvPolicy)
+	}
 	return mcClient.CreateAutoProvPolicy(uri, token, dat)
 }
-func TestPermCreateAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreateAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AutoProvPolicy{}
 	in.Key.Organization = org
-	return TestCreateAutoProvPolicy(mcClient, uri, token, region, in)
+	return TestCreateAutoProvPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicy) (*edgeproto.Result, int, error) {
+func TestDeleteAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicy, modFuncs ...func(*edgeproto.AutoProvPolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAutoProvPolicy{}
 	dat.Region = region
 	dat.AutoProvPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoProvPolicy)
+	}
 	return mcClient.DeleteAutoProvPolicy(uri, token, dat)
 }
-func TestPermDeleteAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeleteAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AutoProvPolicy{}
 	in.Key.Organization = org
-	return TestDeleteAutoProvPolicy(mcClient, uri, token, region, in)
+	return TestDeleteAutoProvPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicy) (*edgeproto.Result, int, error) {
+func TestUpdateAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicy, modFuncs ...func(*edgeproto.AutoProvPolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAutoProvPolicy{}
 	dat.Region = region
 	dat.AutoProvPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoProvPolicy)
+	}
 	return mcClient.UpdateAutoProvPolicy(uri, token, dat)
 }
-func TestPermUpdateAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdateAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AutoProvPolicy{}
 	in.Key.Organization = org
-	return TestUpdateAutoProvPolicy(mcClient, uri, token, region, in)
+	return TestUpdateAutoProvPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicy) ([]edgeproto.AutoProvPolicy, int, error) {
+func TestShowAutoProvPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicy, modFuncs ...func(*edgeproto.AutoProvPolicy)) ([]edgeproto.AutoProvPolicy, int, error) {
 	dat := &ormapi.RegionAutoProvPolicy{}
 	dat.Region = region
 	dat.AutoProvPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoProvPolicy)
+	}
 	return mcClient.ShowAutoProvPolicy(uri, token, dat)
 }
-func TestPermShowAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.AutoProvPolicy, int, error) {
+func TestPermShowAutoProvPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) ([]edgeproto.AutoProvPolicy, int, error) {
 	in := &edgeproto.AutoProvPolicy{}
 	in.Key.Organization = org
-	return TestShowAutoProvPolicy(mcClient, uri, token, region, in)
+	return TestShowAutoProvPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestAddAutoProvPolicyCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicyCloudlet) (*edgeproto.Result, int, error) {
+func TestAddAutoProvPolicyCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicyCloudlet, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAutoProvPolicyCloudlet{}
 	dat.Region = region
 	dat.AutoProvPolicyCloudlet = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoProvPolicyCloudlet)
+	}
 	return mcClient.AddAutoProvPolicyCloudlet(uri, token, dat)
 }
-func TestPermAddAutoProvPolicyCloudlet(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermAddAutoProvPolicyCloudlet(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AutoProvPolicyCloudlet{}
 	in.Key.Organization = org
-	return TestAddAutoProvPolicyCloudlet(mcClient, uri, token, region, in)
+	return TestAddAutoProvPolicyCloudlet(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRemoveAutoProvPolicyCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicyCloudlet) (*edgeproto.Result, int, error) {
+func TestRemoveAutoProvPolicyCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoProvPolicyCloudlet, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAutoProvPolicyCloudlet{}
 	dat.Region = region
 	dat.AutoProvPolicyCloudlet = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoProvPolicyCloudlet)
+	}
 	return mcClient.RemoveAutoProvPolicyCloudlet(uri, token, dat)
 }
-func TestPermRemoveAutoProvPolicyCloudlet(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermRemoveAutoProvPolicyCloudlet(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AutoProvPolicyCloudlet{}
 	in.Key.Organization = org
-	return TestRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, in)
+	return TestRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateAutoProvPolicy(ctx context.Context, in *edgeproto.AutoProvPolicy) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/autoscalepolicy_mc2_testutil.go
+++ b/mc/orm/testutil/autoscalepolicy_mc2_testutil.go
@@ -21,52 +21,64 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateAutoScalePolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoScalePolicy) (*edgeproto.Result, int, error) {
+func TestCreateAutoScalePolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoScalePolicy, modFuncs ...func(*edgeproto.AutoScalePolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAutoScalePolicy{}
 	dat.Region = region
 	dat.AutoScalePolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoScalePolicy)
+	}
 	return mcClient.CreateAutoScalePolicy(uri, token, dat)
 }
-func TestPermCreateAutoScalePolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreateAutoScalePolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AutoScalePolicy{}
 	in.Key.Organization = org
-	return TestCreateAutoScalePolicy(mcClient, uri, token, region, in)
+	return TestCreateAutoScalePolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteAutoScalePolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoScalePolicy) (*edgeproto.Result, int, error) {
+func TestDeleteAutoScalePolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoScalePolicy, modFuncs ...func(*edgeproto.AutoScalePolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAutoScalePolicy{}
 	dat.Region = region
 	dat.AutoScalePolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoScalePolicy)
+	}
 	return mcClient.DeleteAutoScalePolicy(uri, token, dat)
 }
-func TestPermDeleteAutoScalePolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeleteAutoScalePolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AutoScalePolicy{}
 	in.Key.Organization = org
-	return TestDeleteAutoScalePolicy(mcClient, uri, token, region, in)
+	return TestDeleteAutoScalePolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateAutoScalePolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoScalePolicy) (*edgeproto.Result, int, error) {
+func TestUpdateAutoScalePolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoScalePolicy, modFuncs ...func(*edgeproto.AutoScalePolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionAutoScalePolicy{}
 	dat.Region = region
 	dat.AutoScalePolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoScalePolicy)
+	}
 	return mcClient.UpdateAutoScalePolicy(uri, token, dat)
 }
-func TestPermUpdateAutoScalePolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdateAutoScalePolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.AutoScalePolicy{}
 	in.Key.Organization = org
-	return TestUpdateAutoScalePolicy(mcClient, uri, token, region, in)
+	return TestUpdateAutoScalePolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowAutoScalePolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoScalePolicy) ([]edgeproto.AutoScalePolicy, int, error) {
+func TestShowAutoScalePolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AutoScalePolicy, modFuncs ...func(*edgeproto.AutoScalePolicy)) ([]edgeproto.AutoScalePolicy, int, error) {
 	dat := &ormapi.RegionAutoScalePolicy{}
 	dat.Region = region
 	dat.AutoScalePolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AutoScalePolicy)
+	}
 	return mcClient.ShowAutoScalePolicy(uri, token, dat)
 }
-func TestPermShowAutoScalePolicy(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.AutoScalePolicy, int, error) {
+func TestPermShowAutoScalePolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) ([]edgeproto.AutoScalePolicy, int, error) {
 	in := &edgeproto.AutoScalePolicy{}
 	in.Key.Organization = org
-	return TestShowAutoScalePolicy(mcClient, uri, token, region, in)
+	return TestShowAutoScalePolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateAutoScalePolicy(ctx context.Context, in *edgeproto.AutoScalePolicy) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/cloudlet_mc2_testutil.go
+++ b/mc/orm/testutil/cloudlet_mc2_testutil.go
@@ -22,99 +22,123 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet) ([]edgeproto.Result, int, error) {
+func TestCreateCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet, modFuncs ...func(*edgeproto.Cloudlet)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudlet{}
 	dat.Region = region
 	dat.Cloudlet = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Cloudlet)
+	}
 	return mcClient.CreateCloudlet(uri, token, dat)
 }
-func TestPermCreateCloudlet(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Result, int, error) {
+func TestPermCreateCloudlet(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.Cloudlet{}
 	in.Key.Organization = org
-	return TestCreateCloudlet(mcClient, uri, token, region, in)
+	return TestCreateCloudlet(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet) ([]edgeproto.Result, int, error) {
+func TestDeleteCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet, modFuncs ...func(*edgeproto.Cloudlet)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudlet{}
 	dat.Region = region
 	dat.Cloudlet = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Cloudlet)
+	}
 	return mcClient.DeleteCloudlet(uri, token, dat)
 }
-func TestPermDeleteCloudlet(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Result, int, error) {
+func TestPermDeleteCloudlet(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.Cloudlet{}
 	in.Key.Organization = org
-	return TestDeleteCloudlet(mcClient, uri, token, region, in)
+	return TestDeleteCloudlet(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet) ([]edgeproto.Result, int, error) {
+func TestUpdateCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet, modFuncs ...func(*edgeproto.Cloudlet)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudlet{}
 	dat.Region = region
 	dat.Cloudlet = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Cloudlet)
+	}
 	return mcClient.UpdateCloudlet(uri, token, dat)
 }
-func TestPermUpdateCloudlet(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Result, int, error) {
+func TestPermUpdateCloudlet(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.Cloudlet{}
 	in.Key.Organization = org
-	return TestUpdateCloudlet(mcClient, uri, token, region, in)
+	return TestUpdateCloudlet(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet) ([]edgeproto.Cloudlet, int, error) {
+func TestShowCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet, modFuncs ...func(*edgeproto.Cloudlet)) ([]edgeproto.Cloudlet, int, error) {
 	dat := &ormapi.RegionCloudlet{}
 	dat.Region = region
 	dat.Cloudlet = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Cloudlet)
+	}
 	return mcClient.ShowCloudlet(uri, token, dat)
 }
-func TestPermShowCloudlet(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Cloudlet, int, error) {
+func TestPermShowCloudlet(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) ([]edgeproto.Cloudlet, int, error) {
 	in := &edgeproto.Cloudlet{}
-	return TestShowCloudlet(mcClient, uri, token, region, in)
+	return TestShowCloudlet(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestGetCloudletManifest(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet) (*edgeproto.CloudletManifest, int, error) {
+func TestGetCloudletManifest(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Cloudlet, modFuncs ...func(*edgeproto.Cloudlet)) (*edgeproto.CloudletManifest, int, error) {
 	dat := &ormapi.RegionCloudlet{}
 	dat.Region = region
 	dat.Cloudlet = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Cloudlet)
+	}
 	return mcClient.GetCloudletManifest(uri, token, dat)
 }
-func TestPermGetCloudletManifest(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.CloudletManifest, int, error) {
+func TestPermGetCloudletManifest(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) (*edgeproto.CloudletManifest, int, error) {
 	in := &edgeproto.Cloudlet{}
 	in.Key.Organization = org
-	return TestGetCloudletManifest(mcClient, uri, token, region, in)
+	return TestGetCloudletManifest(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestAddCloudletResMapping(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletResMap) (*edgeproto.Result, int, error) {
+func TestAddCloudletResMapping(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletResMap, modFuncs ...func(*edgeproto.CloudletResMap)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletResMap{}
 	dat.Region = region
 	dat.CloudletResMap = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletResMap)
+	}
 	return mcClient.AddCloudletResMapping(uri, token, dat)
 }
-func TestPermAddCloudletResMapping(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermAddCloudletResMapping(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletResMap{}
 	in.Key.Organization = org
-	return TestAddCloudletResMapping(mcClient, uri, token, region, in)
+	return TestAddCloudletResMapping(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRemoveCloudletResMapping(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletResMap) (*edgeproto.Result, int, error) {
+func TestRemoveCloudletResMapping(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletResMap, modFuncs ...func(*edgeproto.CloudletResMap)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletResMap{}
 	dat.Region = region
 	dat.CloudletResMap = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletResMap)
+	}
 	return mcClient.RemoveCloudletResMapping(uri, token, dat)
 }
-func TestPermRemoveCloudletResMapping(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermRemoveCloudletResMapping(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletResMap{}
 	in.Key.Organization = org
-	return TestRemoveCloudletResMapping(mcClient, uri, token, region, in)
+	return TestRemoveCloudletResMapping(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestFindFlavorMatch(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.FlavorMatch) (*edgeproto.FlavorMatch, int, error) {
+func TestFindFlavorMatch(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.FlavorMatch, modFuncs ...func(*edgeproto.FlavorMatch)) (*edgeproto.FlavorMatch, int, error) {
 	dat := &ormapi.RegionFlavorMatch{}
 	dat.Region = region
 	dat.FlavorMatch = *in
+	for _, fn := range modFuncs {
+		fn(&dat.FlavorMatch)
+	}
 	return mcClient.FindFlavorMatch(uri, token, dat)
 }
-func TestPermFindFlavorMatch(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.FlavorMatch, int, error) {
+func TestPermFindFlavorMatch(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.FlavorMatch)) (*edgeproto.FlavorMatch, int, error) {
 	in := &edgeproto.FlavorMatch{}
 	in.Key.Organization = org
-	return TestFindFlavorMatch(mcClient, uri, token, region, in)
+	return TestFindFlavorMatch(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateCloudlet(ctx context.Context, in *edgeproto.Cloudlet) ([]edgeproto.Result, error) {
@@ -213,40 +237,49 @@ func (s *TestClient) FindFlavorMatch(ctx context.Context, in *edgeproto.FlavorMa
 	return out, err
 }
 
-func TestShowCloudletInfo(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletInfo) ([]edgeproto.CloudletInfo, int, error) {
+func TestShowCloudletInfo(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletInfo, modFuncs ...func(*edgeproto.CloudletInfo)) ([]edgeproto.CloudletInfo, int, error) {
 	dat := &ormapi.RegionCloudletInfo{}
 	dat.Region = region
 	dat.CloudletInfo = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletInfo)
+	}
 	return mcClient.ShowCloudletInfo(uri, token, dat)
 }
-func TestPermShowCloudletInfo(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.CloudletInfo, int, error) {
+func TestPermShowCloudletInfo(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) ([]edgeproto.CloudletInfo, int, error) {
 	in := &edgeproto.CloudletInfo{}
 	in.Key.Organization = org
-	return TestShowCloudletInfo(mcClient, uri, token, region, in)
+	return TestShowCloudletInfo(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestInjectCloudletInfo(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletInfo) (*edgeproto.Result, int, error) {
+func TestInjectCloudletInfo(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletInfo, modFuncs ...func(*edgeproto.CloudletInfo)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletInfo{}
 	dat.Region = region
 	dat.CloudletInfo = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletInfo)
+	}
 	return mcClient.InjectCloudletInfo(uri, token, dat)
 }
-func TestPermInjectCloudletInfo(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermInjectCloudletInfo(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletInfo{}
 	in.Key.Organization = org
-	return TestInjectCloudletInfo(mcClient, uri, token, region, in)
+	return TestInjectCloudletInfo(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestEvictCloudletInfo(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletInfo) (*edgeproto.Result, int, error) {
+func TestEvictCloudletInfo(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletInfo, modFuncs ...func(*edgeproto.CloudletInfo)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletInfo{}
 	dat.Region = region
 	dat.CloudletInfo = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletInfo)
+	}
 	return mcClient.EvictCloudletInfo(uri, token, dat)
 }
-func TestPermEvictCloudletInfo(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermEvictCloudletInfo(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletInfo{}
 	in.Key.Organization = org
-	return TestEvictCloudletInfo(mcClient, uri, token, region, in)
+	return TestEvictCloudletInfo(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) ShowCloudletInfo(ctx context.Context, in *edgeproto.CloudletInfo) ([]edgeproto.CloudletInfo, error) {

--- a/mc/orm/testutil/cloudletpool_mc2_testutil.go
+++ b/mc/orm/testutil/cloudletpool_mc2_testutil.go
@@ -21,76 +21,94 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateCloudletPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPool) (*edgeproto.Result, int, error) {
+func TestCreateCloudletPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPool, modFuncs ...func(*edgeproto.CloudletPool)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletPool{}
 	dat.Region = region
 	dat.CloudletPool = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletPool)
+	}
 	return mcClient.CreateCloudletPool(uri, token, dat)
 }
-func TestPermCreateCloudletPool(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreateCloudletPool(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletPool{}
 	in.Key.Organization = org
-	return TestCreateCloudletPool(mcClient, uri, token, region, in)
+	return TestCreateCloudletPool(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteCloudletPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPool) (*edgeproto.Result, int, error) {
+func TestDeleteCloudletPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPool, modFuncs ...func(*edgeproto.CloudletPool)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletPool{}
 	dat.Region = region
 	dat.CloudletPool = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletPool)
+	}
 	return mcClient.DeleteCloudletPool(uri, token, dat)
 }
-func TestPermDeleteCloudletPool(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeleteCloudletPool(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletPool{}
 	in.Key.Organization = org
-	return TestDeleteCloudletPool(mcClient, uri, token, region, in)
+	return TestDeleteCloudletPool(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateCloudletPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPool) (*edgeproto.Result, int, error) {
+func TestUpdateCloudletPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPool, modFuncs ...func(*edgeproto.CloudletPool)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletPool{}
 	dat.Region = region
 	dat.CloudletPool = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletPool)
+	}
 	return mcClient.UpdateCloudletPool(uri, token, dat)
 }
-func TestPermUpdateCloudletPool(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdateCloudletPool(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletPool{}
 	in.Key.Organization = org
-	return TestUpdateCloudletPool(mcClient, uri, token, region, in)
+	return TestUpdateCloudletPool(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowCloudletPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPool) ([]edgeproto.CloudletPool, int, error) {
+func TestShowCloudletPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPool, modFuncs ...func(*edgeproto.CloudletPool)) ([]edgeproto.CloudletPool, int, error) {
 	dat := &ormapi.RegionCloudletPool{}
 	dat.Region = region
 	dat.CloudletPool = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletPool)
+	}
 	return mcClient.ShowCloudletPool(uri, token, dat)
 }
-func TestPermShowCloudletPool(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.CloudletPool, int, error) {
+func TestPermShowCloudletPool(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) ([]edgeproto.CloudletPool, int, error) {
 	in := &edgeproto.CloudletPool{}
 	in.Key.Organization = org
-	return TestShowCloudletPool(mcClient, uri, token, region, in)
+	return TestShowCloudletPool(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestAddCloudletPoolMember(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPoolMember) (*edgeproto.Result, int, error) {
+func TestAddCloudletPoolMember(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPoolMember, modFuncs ...func(*edgeproto.CloudletPoolMember)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletPoolMember{}
 	dat.Region = region
 	dat.CloudletPoolMember = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletPoolMember)
+	}
 	return mcClient.AddCloudletPoolMember(uri, token, dat)
 }
-func TestPermAddCloudletPoolMember(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermAddCloudletPoolMember(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletPoolMember{}
 	in.Key.Organization = org
-	return TestAddCloudletPoolMember(mcClient, uri, token, region, in)
+	return TestAddCloudletPoolMember(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRemoveCloudletPoolMember(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPoolMember) (*edgeproto.Result, int, error) {
+func TestRemoveCloudletPoolMember(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletPoolMember, modFuncs ...func(*edgeproto.CloudletPoolMember)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletPoolMember{}
 	dat.Region = region
 	dat.CloudletPoolMember = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletPoolMember)
+	}
 	return mcClient.RemoveCloudletPoolMember(uri, token, dat)
 }
-func TestPermRemoveCloudletPoolMember(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermRemoveCloudletPoolMember(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.CloudletPoolMember{}
 	in.Key.Organization = org
-	return TestRemoveCloudletPoolMember(mcClient, uri, token, region, in)
+	return TestRemoveCloudletPoolMember(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateCloudletPool(ctx context.Context, in *edgeproto.CloudletPool) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/clusterinst_mc2_testutil.go
+++ b/mc/orm/testutil/clusterinst_mc2_testutil.go
@@ -21,61 +21,73 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateClusterInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterInst) ([]edgeproto.Result, int, error) {
+func TestCreateClusterInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterInst, modFuncs ...func(*edgeproto.ClusterInst)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionClusterInst{}
 	dat.Region = region
 	dat.ClusterInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ClusterInst)
+	}
 	return mcClient.CreateClusterInst(uri, token, dat)
 }
-func TestPermCreateClusterInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) ([]edgeproto.Result, int, error) {
+func TestPermCreateClusterInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.ClusterInst{}
 	if targetCloudlet != nil {
 		in.Key.CloudletKey = *targetCloudlet
 	}
 	in.Key.Organization = org
-	return TestCreateClusterInst(mcClient, uri, token, region, in)
+	return TestCreateClusterInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteClusterInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterInst) ([]edgeproto.Result, int, error) {
+func TestDeleteClusterInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterInst, modFuncs ...func(*edgeproto.ClusterInst)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionClusterInst{}
 	dat.Region = region
 	dat.ClusterInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ClusterInst)
+	}
 	return mcClient.DeleteClusterInst(uri, token, dat)
 }
-func TestPermDeleteClusterInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) ([]edgeproto.Result, int, error) {
+func TestPermDeleteClusterInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.ClusterInst{}
 	if targetCloudlet != nil {
 		in.Key.CloudletKey = *targetCloudlet
 	}
 	in.Key.Organization = org
-	return TestDeleteClusterInst(mcClient, uri, token, region, in)
+	return TestDeleteClusterInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateClusterInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterInst) ([]edgeproto.Result, int, error) {
+func TestUpdateClusterInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterInst, modFuncs ...func(*edgeproto.ClusterInst)) ([]edgeproto.Result, int, error) {
 	dat := &ormapi.RegionClusterInst{}
 	dat.Region = region
 	dat.ClusterInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ClusterInst)
+	}
 	return mcClient.UpdateClusterInst(uri, token, dat)
 }
-func TestPermUpdateClusterInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey) ([]edgeproto.Result, int, error) {
+func TestPermUpdateClusterInst(mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) ([]edgeproto.Result, int, error) {
 	in := &edgeproto.ClusterInst{}
 	if targetCloudlet != nil {
 		in.Key.CloudletKey = *targetCloudlet
 	}
 	in.Key.Organization = org
-	return TestUpdateClusterInst(mcClient, uri, token, region, in)
+	return TestUpdateClusterInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowClusterInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterInst) ([]edgeproto.ClusterInst, int, error) {
+func TestShowClusterInst(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterInst, modFuncs ...func(*edgeproto.ClusterInst)) ([]edgeproto.ClusterInst, int, error) {
 	dat := &ormapi.RegionClusterInst{}
 	dat.Region = region
 	dat.ClusterInst = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ClusterInst)
+	}
 	return mcClient.ShowClusterInst(uri, token, dat)
 }
-func TestPermShowClusterInst(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.ClusterInst, int, error) {
+func TestPermShowClusterInst(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterInst)) ([]edgeproto.ClusterInst, int, error) {
 	in := &edgeproto.ClusterInst{}
 	in.Key.Organization = org
-	return TestShowClusterInst(mcClient, uri, token, region, in)
+	return TestShowClusterInst(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateClusterInst(ctx context.Context, in *edgeproto.ClusterInst) ([]edgeproto.Result, error) {

--- a/mc/orm/testutil/debug_mc2_testutil.go
+++ b/mc/orm/testutil/debug_mc2_testutil.go
@@ -21,48 +21,60 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestEnableDebugLevels(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DebugRequest) ([]edgeproto.DebugReply, int, error) {
+func TestEnableDebugLevels(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DebugRequest, modFuncs ...func(*edgeproto.DebugRequest)) ([]edgeproto.DebugReply, int, error) {
 	dat := &ormapi.RegionDebugRequest{}
 	dat.Region = region
 	dat.DebugRequest = *in
+	for _, fn := range modFuncs {
+		fn(&dat.DebugRequest)
+	}
 	return mcClient.EnableDebugLevels(uri, token, dat)
 }
-func TestPermEnableDebugLevels(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.DebugReply, int, error) {
+func TestPermEnableDebugLevels(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) ([]edgeproto.DebugReply, int, error) {
 	in := &edgeproto.DebugRequest{}
-	return TestEnableDebugLevels(mcClient, uri, token, region, in)
+	return TestEnableDebugLevels(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDisableDebugLevels(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DebugRequest) ([]edgeproto.DebugReply, int, error) {
+func TestDisableDebugLevels(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DebugRequest, modFuncs ...func(*edgeproto.DebugRequest)) ([]edgeproto.DebugReply, int, error) {
 	dat := &ormapi.RegionDebugRequest{}
 	dat.Region = region
 	dat.DebugRequest = *in
+	for _, fn := range modFuncs {
+		fn(&dat.DebugRequest)
+	}
 	return mcClient.DisableDebugLevels(uri, token, dat)
 }
-func TestPermDisableDebugLevels(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.DebugReply, int, error) {
+func TestPermDisableDebugLevels(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) ([]edgeproto.DebugReply, int, error) {
 	in := &edgeproto.DebugRequest{}
-	return TestDisableDebugLevels(mcClient, uri, token, region, in)
+	return TestDisableDebugLevels(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowDebugLevels(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DebugRequest) ([]edgeproto.DebugReply, int, error) {
+func TestShowDebugLevels(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DebugRequest, modFuncs ...func(*edgeproto.DebugRequest)) ([]edgeproto.DebugReply, int, error) {
 	dat := &ormapi.RegionDebugRequest{}
 	dat.Region = region
 	dat.DebugRequest = *in
+	for _, fn := range modFuncs {
+		fn(&dat.DebugRequest)
+	}
 	return mcClient.ShowDebugLevels(uri, token, dat)
 }
-func TestPermShowDebugLevels(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.DebugReply, int, error) {
+func TestPermShowDebugLevels(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) ([]edgeproto.DebugReply, int, error) {
 	in := &edgeproto.DebugRequest{}
-	return TestShowDebugLevels(mcClient, uri, token, region, in)
+	return TestShowDebugLevels(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRunDebug(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DebugRequest) ([]edgeproto.DebugReply, int, error) {
+func TestRunDebug(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DebugRequest, modFuncs ...func(*edgeproto.DebugRequest)) ([]edgeproto.DebugReply, int, error) {
 	dat := &ormapi.RegionDebugRequest{}
 	dat.Region = region
 	dat.DebugRequest = *in
+	for _, fn := range modFuncs {
+		fn(&dat.DebugRequest)
+	}
 	return mcClient.RunDebug(uri, token, dat)
 }
-func TestPermRunDebug(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.DebugReply, int, error) {
+func TestPermRunDebug(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) ([]edgeproto.DebugReply, int, error) {
 	in := &edgeproto.DebugRequest{}
-	return TestRunDebug(mcClient, uri, token, region, in)
+	return TestRunDebug(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) EnableDebugLevels(ctx context.Context, in *edgeproto.DebugRequest) ([]edgeproto.DebugReply, error) {

--- a/mc/orm/testutil/device_mc2_testutil.go
+++ b/mc/orm/testutil/device_mc2_testutil.go
@@ -22,48 +22,60 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestInjectDevice(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Device) (*edgeproto.Result, int, error) {
+func TestInjectDevice(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Device, modFuncs ...func(*edgeproto.Device)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionDevice{}
 	dat.Region = region
 	dat.Device = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Device)
+	}
 	return mcClient.InjectDevice(uri, token, dat)
 }
-func TestPermInjectDevice(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermInjectDevice(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Device{}
-	return TestInjectDevice(mcClient, uri, token, region, in)
+	return TestInjectDevice(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowDevice(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Device) ([]edgeproto.Device, int, error) {
+func TestShowDevice(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Device, modFuncs ...func(*edgeproto.Device)) ([]edgeproto.Device, int, error) {
 	dat := &ormapi.RegionDevice{}
 	dat.Region = region
 	dat.Device = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Device)
+	}
 	return mcClient.ShowDevice(uri, token, dat)
 }
-func TestPermShowDevice(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Device, int, error) {
+func TestPermShowDevice(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) ([]edgeproto.Device, int, error) {
 	in := &edgeproto.Device{}
-	return TestShowDevice(mcClient, uri, token, region, in)
+	return TestShowDevice(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestEvictDevice(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Device) (*edgeproto.Result, int, error) {
+func TestEvictDevice(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Device, modFuncs ...func(*edgeproto.Device)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionDevice{}
 	dat.Region = region
 	dat.Device = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Device)
+	}
 	return mcClient.EvictDevice(uri, token, dat)
 }
-func TestPermEvictDevice(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermEvictDevice(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Device{}
-	return TestEvictDevice(mcClient, uri, token, region, in)
+	return TestEvictDevice(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowDeviceReport(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DeviceReport) ([]edgeproto.Device, int, error) {
+func TestShowDeviceReport(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.DeviceReport, modFuncs ...func(*edgeproto.DeviceReport)) ([]edgeproto.Device, int, error) {
 	dat := &ormapi.RegionDeviceReport{}
 	dat.Region = region
 	dat.DeviceReport = *in
+	for _, fn := range modFuncs {
+		fn(&dat.DeviceReport)
+	}
 	return mcClient.ShowDeviceReport(uri, token, dat)
 }
-func TestPermShowDeviceReport(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Device, int, error) {
+func TestPermShowDeviceReport(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DeviceReport)) ([]edgeproto.Device, int, error) {
 	in := &edgeproto.DeviceReport{}
-	return TestShowDeviceReport(mcClient, uri, token, region, in)
+	return TestShowDeviceReport(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) InjectDevice(ctx context.Context, in *edgeproto.Device) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/exec_mc2_testutil.go
+++ b/mc/orm/testutil/exec_mc2_testutil.go
@@ -20,51 +20,63 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestRunCommand(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ExecRequest) (*edgeproto.ExecRequest, int, error) {
+func TestRunCommand(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ExecRequest, modFuncs ...func(*edgeproto.ExecRequest)) (*edgeproto.ExecRequest, int, error) {
 	dat := &ormapi.RegionExecRequest{}
 	dat.Region = region
 	dat.ExecRequest = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ExecRequest)
+	}
 	return mcClient.RunCommand(uri, token, dat)
 }
-func TestPermRunCommand(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.ExecRequest, int, error) {
+func TestPermRunCommand(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) (*edgeproto.ExecRequest, int, error) {
 	in := &edgeproto.ExecRequest{}
 	in.AppInstKey.AppKey.Organization = org
-	return TestRunCommand(mcClient, uri, token, region, in)
+	return TestRunCommand(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRunConsole(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ExecRequest) (*edgeproto.ExecRequest, int, error) {
+func TestRunConsole(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ExecRequest, modFuncs ...func(*edgeproto.ExecRequest)) (*edgeproto.ExecRequest, int, error) {
 	dat := &ormapi.RegionExecRequest{}
 	dat.Region = region
 	dat.ExecRequest = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ExecRequest)
+	}
 	return mcClient.RunConsole(uri, token, dat)
 }
-func TestPermRunConsole(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.ExecRequest, int, error) {
+func TestPermRunConsole(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) (*edgeproto.ExecRequest, int, error) {
 	in := &edgeproto.ExecRequest{}
 	in.AppInstKey.AppKey.Organization = org
-	return TestRunConsole(mcClient, uri, token, region, in)
+	return TestRunConsole(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowLogs(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ExecRequest) (*edgeproto.ExecRequest, int, error) {
+func TestShowLogs(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ExecRequest, modFuncs ...func(*edgeproto.ExecRequest)) (*edgeproto.ExecRequest, int, error) {
 	dat := &ormapi.RegionExecRequest{}
 	dat.Region = region
 	dat.ExecRequest = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ExecRequest)
+	}
 	return mcClient.ShowLogs(uri, token, dat)
 }
-func TestPermShowLogs(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.ExecRequest, int, error) {
+func TestPermShowLogs(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) (*edgeproto.ExecRequest, int, error) {
 	in := &edgeproto.ExecRequest{}
 	in.AppInstKey.AppKey.Organization = org
-	return TestShowLogs(mcClient, uri, token, region, in)
+	return TestShowLogs(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestAccessCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ExecRequest) (*edgeproto.ExecRequest, int, error) {
+func TestAccessCloudlet(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ExecRequest, modFuncs ...func(*edgeproto.ExecRequest)) (*edgeproto.ExecRequest, int, error) {
 	dat := &ormapi.RegionExecRequest{}
 	dat.Region = region
 	dat.ExecRequest = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ExecRequest)
+	}
 	return mcClient.AccessCloudlet(uri, token, dat)
 }
-func TestPermAccessCloudlet(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.ExecRequest, int, error) {
+func TestPermAccessCloudlet(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) (*edgeproto.ExecRequest, int, error) {
 	in := &edgeproto.ExecRequest{}
-	return TestAccessCloudlet(mcClient, uri, token, region, in)
+	return TestAccessCloudlet(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) RunCommand(ctx context.Context, in *edgeproto.ExecRequest) (*edgeproto.ExecRequest, error) {

--- a/mc/orm/testutil/flavor_mc2_testutil.go
+++ b/mc/orm/testutil/flavor_mc2_testutil.go
@@ -21,70 +21,88 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateFlavor(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor) (*edgeproto.Result, int, error) {
+func TestCreateFlavor(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionFlavor{}
 	dat.Region = region
 	dat.Flavor = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Flavor)
+	}
 	return mcClient.CreateFlavor(uri, token, dat)
 }
-func TestPermCreateFlavor(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreateFlavor(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Flavor{}
-	return TestCreateFlavor(mcClient, uri, token, region, in)
+	return TestCreateFlavor(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteFlavor(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor) (*edgeproto.Result, int, error) {
+func TestDeleteFlavor(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionFlavor{}
 	dat.Region = region
 	dat.Flavor = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Flavor)
+	}
 	return mcClient.DeleteFlavor(uri, token, dat)
 }
-func TestPermDeleteFlavor(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeleteFlavor(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Flavor{}
-	return TestDeleteFlavor(mcClient, uri, token, region, in)
+	return TestDeleteFlavor(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateFlavor(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor) (*edgeproto.Result, int, error) {
+func TestUpdateFlavor(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionFlavor{}
 	dat.Region = region
 	dat.Flavor = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Flavor)
+	}
 	return mcClient.UpdateFlavor(uri, token, dat)
 }
-func TestPermUpdateFlavor(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdateFlavor(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Flavor{}
-	return TestUpdateFlavor(mcClient, uri, token, region, in)
+	return TestUpdateFlavor(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowFlavor(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor) ([]edgeproto.Flavor, int, error) {
+func TestShowFlavor(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor, modFuncs ...func(*edgeproto.Flavor)) ([]edgeproto.Flavor, int, error) {
 	dat := &ormapi.RegionFlavor{}
 	dat.Region = region
 	dat.Flavor = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Flavor)
+	}
 	return mcClient.ShowFlavor(uri, token, dat)
 }
-func TestPermShowFlavor(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Flavor, int, error) {
+func TestPermShowFlavor(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) ([]edgeproto.Flavor, int, error) {
 	in := &edgeproto.Flavor{}
-	return TestShowFlavor(mcClient, uri, token, region, in)
+	return TestShowFlavor(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestAddFlavorRes(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor) (*edgeproto.Result, int, error) {
+func TestAddFlavorRes(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionFlavor{}
 	dat.Region = region
 	dat.Flavor = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Flavor)
+	}
 	return mcClient.AddFlavorRes(uri, token, dat)
 }
-func TestPermAddFlavorRes(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermAddFlavorRes(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Flavor{}
-	return TestAddFlavorRes(mcClient, uri, token, region, in)
+	return TestAddFlavorRes(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRemoveFlavorRes(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor) (*edgeproto.Result, int, error) {
+func TestRemoveFlavorRes(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Flavor, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionFlavor{}
 	dat.Region = region
 	dat.Flavor = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Flavor)
+	}
 	return mcClient.RemoveFlavorRes(uri, token, dat)
 }
-func TestPermRemoveFlavorRes(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermRemoveFlavorRes(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Flavor{}
-	return TestRemoveFlavorRes(mcClient, uri, token, region, in)
+	return TestRemoveFlavorRes(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateFlavor(ctx context.Context, in *edgeproto.Flavor) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/node_mc2_testutil.go
+++ b/mc/orm/testutil/node_mc2_testutil.go
@@ -21,15 +21,18 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestShowNode(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Node) ([]edgeproto.Node, int, error) {
+func TestShowNode(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Node, modFuncs ...func(*edgeproto.Node)) ([]edgeproto.Node, int, error) {
 	dat := &ormapi.RegionNode{}
 	dat.Region = region
 	dat.Node = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Node)
+	}
 	return mcClient.ShowNode(uri, token, dat)
 }
-func TestPermShowNode(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.Node, int, error) {
+func TestPermShowNode(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Node)) ([]edgeproto.Node, int, error) {
 	in := &edgeproto.Node{}
-	return TestShowNode(mcClient, uri, token, region, in)
+	return TestShowNode(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) ShowNode(ctx context.Context, in *edgeproto.Node) ([]edgeproto.Node, error) {

--- a/mc/orm/testutil/operatorcode_mc2_testutil.go
+++ b/mc/orm/testutil/operatorcode_mc2_testutil.go
@@ -20,40 +20,49 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateOperatorCode(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.OperatorCode) (*edgeproto.Result, int, error) {
+func TestCreateOperatorCode(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.OperatorCode, modFuncs ...func(*edgeproto.OperatorCode)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionOperatorCode{}
 	dat.Region = region
 	dat.OperatorCode = *in
+	for _, fn := range modFuncs {
+		fn(&dat.OperatorCode)
+	}
 	return mcClient.CreateOperatorCode(uri, token, dat)
 }
-func TestPermCreateOperatorCode(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreateOperatorCode(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.OperatorCode{}
 	in.Organization = org
-	return TestCreateOperatorCode(mcClient, uri, token, region, in)
+	return TestCreateOperatorCode(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteOperatorCode(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.OperatorCode) (*edgeproto.Result, int, error) {
+func TestDeleteOperatorCode(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.OperatorCode, modFuncs ...func(*edgeproto.OperatorCode)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionOperatorCode{}
 	dat.Region = region
 	dat.OperatorCode = *in
+	for _, fn := range modFuncs {
+		fn(&dat.OperatorCode)
+	}
 	return mcClient.DeleteOperatorCode(uri, token, dat)
 }
-func TestPermDeleteOperatorCode(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeleteOperatorCode(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.OperatorCode{}
 	in.Organization = org
-	return TestDeleteOperatorCode(mcClient, uri, token, region, in)
+	return TestDeleteOperatorCode(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowOperatorCode(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.OperatorCode) ([]edgeproto.OperatorCode, int, error) {
+func TestShowOperatorCode(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.OperatorCode, modFuncs ...func(*edgeproto.OperatorCode)) ([]edgeproto.OperatorCode, int, error) {
 	dat := &ormapi.RegionOperatorCode{}
 	dat.Region = region
 	dat.OperatorCode = *in
+	for _, fn := range modFuncs {
+		fn(&dat.OperatorCode)
+	}
 	return mcClient.ShowOperatorCode(uri, token, dat)
 }
-func TestPermShowOperatorCode(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.OperatorCode, int, error) {
+func TestPermShowOperatorCode(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) ([]edgeproto.OperatorCode, int, error) {
 	in := &edgeproto.OperatorCode{}
 	in.Organization = org
-	return TestShowOperatorCode(mcClient, uri, token, region, in)
+	return TestShowOperatorCode(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateOperatorCode(ctx context.Context, in *edgeproto.OperatorCode) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/privacypolicy_mc2_testutil.go
+++ b/mc/orm/testutil/privacypolicy_mc2_testutil.go
@@ -21,52 +21,64 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreatePrivacyPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.PrivacyPolicy) (*edgeproto.Result, int, error) {
+func TestCreatePrivacyPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.PrivacyPolicy, modFuncs ...func(*edgeproto.PrivacyPolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionPrivacyPolicy{}
 	dat.Region = region
 	dat.PrivacyPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.PrivacyPolicy)
+	}
 	return mcClient.CreatePrivacyPolicy(uri, token, dat)
 }
-func TestPermCreatePrivacyPolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreatePrivacyPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.PrivacyPolicy{}
 	in.Key.Organization = org
-	return TestCreatePrivacyPolicy(mcClient, uri, token, region, in)
+	return TestCreatePrivacyPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeletePrivacyPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.PrivacyPolicy) (*edgeproto.Result, int, error) {
+func TestDeletePrivacyPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.PrivacyPolicy, modFuncs ...func(*edgeproto.PrivacyPolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionPrivacyPolicy{}
 	dat.Region = region
 	dat.PrivacyPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.PrivacyPolicy)
+	}
 	return mcClient.DeletePrivacyPolicy(uri, token, dat)
 }
-func TestPermDeletePrivacyPolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeletePrivacyPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.PrivacyPolicy{}
 	in.Key.Organization = org
-	return TestDeletePrivacyPolicy(mcClient, uri, token, region, in)
+	return TestDeletePrivacyPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdatePrivacyPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.PrivacyPolicy) (*edgeproto.Result, int, error) {
+func TestUpdatePrivacyPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.PrivacyPolicy, modFuncs ...func(*edgeproto.PrivacyPolicy)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionPrivacyPolicy{}
 	dat.Region = region
 	dat.PrivacyPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.PrivacyPolicy)
+	}
 	return mcClient.UpdatePrivacyPolicy(uri, token, dat)
 }
-func TestPermUpdatePrivacyPolicy(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdatePrivacyPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.PrivacyPolicy{}
 	in.Key.Organization = org
-	return TestUpdatePrivacyPolicy(mcClient, uri, token, region, in)
+	return TestUpdatePrivacyPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowPrivacyPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.PrivacyPolicy) ([]edgeproto.PrivacyPolicy, int, error) {
+func TestShowPrivacyPolicy(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.PrivacyPolicy, modFuncs ...func(*edgeproto.PrivacyPolicy)) ([]edgeproto.PrivacyPolicy, int, error) {
 	dat := &ormapi.RegionPrivacyPolicy{}
 	dat.Region = region
 	dat.PrivacyPolicy = *in
+	for _, fn := range modFuncs {
+		fn(&dat.PrivacyPolicy)
+	}
 	return mcClient.ShowPrivacyPolicy(uri, token, dat)
 }
-func TestPermShowPrivacyPolicy(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.PrivacyPolicy, int, error) {
+func TestPermShowPrivacyPolicy(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.PrivacyPolicy)) ([]edgeproto.PrivacyPolicy, int, error) {
 	in := &edgeproto.PrivacyPolicy{}
 	in.Key.Organization = org
-	return TestShowPrivacyPolicy(mcClient, uri, token, region, in)
+	return TestShowPrivacyPolicy(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreatePrivacyPolicy(ctx context.Context, in *edgeproto.PrivacyPolicy) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/refs_mc2_testutil.go
+++ b/mc/orm/testutil/refs_mc2_testutil.go
@@ -20,16 +20,19 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestShowCloudletRefs(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletRefs) ([]edgeproto.CloudletRefs, int, error) {
+func TestShowCloudletRefs(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.CloudletRefs, modFuncs ...func(*edgeproto.CloudletRefs)) ([]edgeproto.CloudletRefs, int, error) {
 	dat := &ormapi.RegionCloudletRefs{}
 	dat.Region = region
 	dat.CloudletRefs = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletRefs)
+	}
 	return mcClient.ShowCloudletRefs(uri, token, dat)
 }
-func TestPermShowCloudletRefs(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.CloudletRefs, int, error) {
+func TestPermShowCloudletRefs(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletRefs)) ([]edgeproto.CloudletRefs, int, error) {
 	in := &edgeproto.CloudletRefs{}
 	in.Key.Organization = org
-	return TestShowCloudletRefs(mcClient, uri, token, region, in)
+	return TestShowCloudletRefs(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) ShowCloudletRefs(ctx context.Context, in *edgeproto.CloudletRefs) ([]edgeproto.CloudletRefs, error) {
@@ -44,15 +47,18 @@ func (s *TestClient) ShowCloudletRefs(ctx context.Context, in *edgeproto.Cloudle
 	return out, err
 }
 
-func TestShowClusterRefs(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterRefs) ([]edgeproto.ClusterRefs, int, error) {
+func TestShowClusterRefs(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ClusterRefs, modFuncs ...func(*edgeproto.ClusterRefs)) ([]edgeproto.ClusterRefs, int, error) {
 	dat := &ormapi.RegionClusterRefs{}
 	dat.Region = region
 	dat.ClusterRefs = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ClusterRefs)
+	}
 	return mcClient.ShowClusterRefs(uri, token, dat)
 }
-func TestPermShowClusterRefs(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.ClusterRefs, int, error) {
+func TestPermShowClusterRefs(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterRefs)) ([]edgeproto.ClusterRefs, int, error) {
 	in := &edgeproto.ClusterRefs{}
-	return TestShowClusterRefs(mcClient, uri, token, region, in)
+	return TestShowClusterRefs(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) ShowClusterRefs(ctx context.Context, in *edgeproto.ClusterRefs) ([]edgeproto.ClusterRefs, error) {
@@ -67,16 +73,19 @@ func (s *TestClient) ShowClusterRefs(ctx context.Context, in *edgeproto.ClusterR
 	return out, err
 }
 
-func TestShowAppInstRefs(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInstRefs) ([]edgeproto.AppInstRefs, int, error) {
+func TestShowAppInstRefs(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.AppInstRefs, modFuncs ...func(*edgeproto.AppInstRefs)) ([]edgeproto.AppInstRefs, int, error) {
 	dat := &ormapi.RegionAppInstRefs{}
 	dat.Region = region
 	dat.AppInstRefs = *in
+	for _, fn := range modFuncs {
+		fn(&dat.AppInstRefs)
+	}
 	return mcClient.ShowAppInstRefs(uri, token, dat)
 }
-func TestPermShowAppInstRefs(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.AppInstRefs, int, error) {
+func TestPermShowAppInstRefs(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstRefs)) ([]edgeproto.AppInstRefs, int, error) {
 	in := &edgeproto.AppInstRefs{}
 	in.Key.Organization = org
-	return TestShowAppInstRefs(mcClient, uri, token, region, in)
+	return TestShowAppInstRefs(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) ShowAppInstRefs(ctx context.Context, in *edgeproto.AppInstRefs) ([]edgeproto.AppInstRefs, error) {

--- a/mc/orm/testutil/restagtable_mc2_testutil.go
+++ b/mc/orm/testutil/restagtable_mc2_testutil.go
@@ -21,87 +21,108 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable) (*edgeproto.Result, int, error) {
+func TestCreateResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionResTagTable{}
 	dat.Region = region
 	dat.ResTagTable = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ResTagTable)
+	}
 	return mcClient.CreateResTagTable(uri, token, dat)
 }
-func TestPermCreateResTagTable(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreateResTagTable(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.ResTagTable{}
 	in.Key.Organization = org
-	return TestCreateResTagTable(mcClient, uri, token, region, in)
+	return TestCreateResTagTable(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable) (*edgeproto.Result, int, error) {
+func TestDeleteResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionResTagTable{}
 	dat.Region = region
 	dat.ResTagTable = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ResTagTable)
+	}
 	return mcClient.DeleteResTagTable(uri, token, dat)
 }
-func TestPermDeleteResTagTable(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeleteResTagTable(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.ResTagTable{}
 	in.Key.Organization = org
-	return TestDeleteResTagTable(mcClient, uri, token, region, in)
+	return TestDeleteResTagTable(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable) (*edgeproto.Result, int, error) {
+func TestUpdateResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionResTagTable{}
 	dat.Region = region
 	dat.ResTagTable = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ResTagTable)
+	}
 	return mcClient.UpdateResTagTable(uri, token, dat)
 }
-func TestPermUpdateResTagTable(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdateResTagTable(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.ResTagTable{}
 	in.Key.Organization = org
-	return TestUpdateResTagTable(mcClient, uri, token, region, in)
+	return TestUpdateResTagTable(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable) ([]edgeproto.ResTagTable, int, error) {
+func TestShowResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable, modFuncs ...func(*edgeproto.ResTagTable)) ([]edgeproto.ResTagTable, int, error) {
 	dat := &ormapi.RegionResTagTable{}
 	dat.Region = region
 	dat.ResTagTable = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ResTagTable)
+	}
 	return mcClient.ShowResTagTable(uri, token, dat)
 }
-func TestPermShowResTagTable(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.ResTagTable, int, error) {
+func TestPermShowResTagTable(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) ([]edgeproto.ResTagTable, int, error) {
 	in := &edgeproto.ResTagTable{}
 	in.Key.Organization = org
-	return TestShowResTagTable(mcClient, uri, token, region, in)
+	return TestShowResTagTable(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestAddResTag(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable) (*edgeproto.Result, int, error) {
+func TestAddResTag(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionResTagTable{}
 	dat.Region = region
 	dat.ResTagTable = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ResTagTable)
+	}
 	return mcClient.AddResTag(uri, token, dat)
 }
-func TestPermAddResTag(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermAddResTag(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.ResTagTable{}
 	in.Key.Organization = org
-	return TestAddResTag(mcClient, uri, token, region, in)
+	return TestAddResTag(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRemoveResTag(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable) (*edgeproto.Result, int, error) {
+func TestRemoveResTag(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTable, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionResTagTable{}
 	dat.Region = region
 	dat.ResTagTable = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ResTagTable)
+	}
 	return mcClient.RemoveResTag(uri, token, dat)
 }
-func TestPermRemoveResTag(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermRemoveResTag(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.ResTagTable{}
 	in.Key.Organization = org
-	return TestRemoveResTag(mcClient, uri, token, region, in)
+	return TestRemoveResTag(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestGetResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTableKey) (*edgeproto.ResTagTable, int, error) {
+func TestGetResTagTable(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.ResTagTableKey, modFuncs ...func(*edgeproto.ResTagTableKey)) (*edgeproto.ResTagTable, int, error) {
 	dat := &ormapi.RegionResTagTableKey{}
 	dat.Region = region
 	dat.ResTagTableKey = *in
+	for _, fn := range modFuncs {
+		fn(&dat.ResTagTableKey)
+	}
 	return mcClient.GetResTagTable(uri, token, dat)
 }
-func TestPermGetResTagTable(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.ResTagTable, int, error) {
+func TestPermGetResTagTable(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTableKey)) (*edgeproto.ResTagTable, int, error) {
 	in := &edgeproto.ResTagTableKey{}
-	return TestGetResTagTable(mcClient, uri, token, region, in)
+	return TestGetResTagTable(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateResTagTable(ctx context.Context, in *edgeproto.ResTagTable) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/settings_mc2_testutil.go
+++ b/mc/orm/testutil/settings_mc2_testutil.go
@@ -21,37 +21,46 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestUpdateSettings(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Settings) (*edgeproto.Result, int, error) {
+func TestUpdateSettings(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Settings, modFuncs ...func(*edgeproto.Settings)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionSettings{}
 	dat.Region = region
 	dat.Settings = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Settings)
+	}
 	return mcClient.UpdateSettings(uri, token, dat)
 }
-func TestPermUpdateSettings(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdateSettings(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Settings{}
-	return TestUpdateSettings(mcClient, uri, token, region, in)
+	return TestUpdateSettings(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestResetSettings(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Settings) (*edgeproto.Result, int, error) {
+func TestResetSettings(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Settings, modFuncs ...func(*edgeproto.Settings)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionSettings{}
 	dat.Region = region
 	dat.Settings = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Settings)
+	}
 	return mcClient.ResetSettings(uri, token, dat)
 }
-func TestPermResetSettings(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermResetSettings(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.Settings{}
-	return TestResetSettings(mcClient, uri, token, region, in)
+	return TestResetSettings(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowSettings(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Settings) (*edgeproto.Settings, int, error) {
+func TestShowSettings(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.Settings, modFuncs ...func(*edgeproto.Settings)) (*edgeproto.Settings, int, error) {
 	dat := &ormapi.RegionSettings{}
 	dat.Region = region
 	dat.Settings = *in
+	for _, fn := range modFuncs {
+		fn(&dat.Settings)
+	}
 	return mcClient.ShowSettings(uri, token, dat)
 }
-func TestPermShowSettings(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Settings, int, error) {
+func TestPermShowSettings(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) (*edgeproto.Settings, int, error) {
 	in := &edgeproto.Settings{}
-	return TestShowSettings(mcClient, uri, token, region, in)
+	return TestShowSettings(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) UpdateSettings(ctx context.Context, in *edgeproto.Settings) (*edgeproto.Result, error) {

--- a/mc/orm/testutil/vmpool_mc2_testutil.go
+++ b/mc/orm/testutil/vmpool_mc2_testutil.go
@@ -23,76 +23,94 @@ var _ = math.Inf
 
 // Auto-generated code: DO NOT EDIT
 
-func TestCreateVMPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPool) (*edgeproto.Result, int, error) {
+func TestCreateVMPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPool, modFuncs ...func(*edgeproto.VMPool)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionVMPool{}
 	dat.Region = region
 	dat.VMPool = *in
+	for _, fn := range modFuncs {
+		fn(&dat.VMPool)
+	}
 	return mcClient.CreateVMPool(uri, token, dat)
 }
-func TestPermCreateVMPool(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermCreateVMPool(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.VMPool{}
 	in.Key.Organization = org
-	return TestCreateVMPool(mcClient, uri, token, region, in)
+	return TestCreateVMPool(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestDeleteVMPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPool) (*edgeproto.Result, int, error) {
+func TestDeleteVMPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPool, modFuncs ...func(*edgeproto.VMPool)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionVMPool{}
 	dat.Region = region
 	dat.VMPool = *in
+	for _, fn := range modFuncs {
+		fn(&dat.VMPool)
+	}
 	return mcClient.DeleteVMPool(uri, token, dat)
 }
-func TestPermDeleteVMPool(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermDeleteVMPool(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.VMPool{}
 	in.Key.Organization = org
-	return TestDeleteVMPool(mcClient, uri, token, region, in)
+	return TestDeleteVMPool(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestUpdateVMPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPool) (*edgeproto.Result, int, error) {
+func TestUpdateVMPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPool, modFuncs ...func(*edgeproto.VMPool)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionVMPool{}
 	dat.Region = region
 	dat.VMPool = *in
+	for _, fn := range modFuncs {
+		fn(&dat.VMPool)
+	}
 	return mcClient.UpdateVMPool(uri, token, dat)
 }
-func TestPermUpdateVMPool(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermUpdateVMPool(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.VMPool{}
 	in.Key.Organization = org
-	return TestUpdateVMPool(mcClient, uri, token, region, in)
+	return TestUpdateVMPool(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestShowVMPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPool) ([]edgeproto.VMPool, int, error) {
+func TestShowVMPool(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPool, modFuncs ...func(*edgeproto.VMPool)) ([]edgeproto.VMPool, int, error) {
 	dat := &ormapi.RegionVMPool{}
 	dat.Region = region
 	dat.VMPool = *in
+	for _, fn := range modFuncs {
+		fn(&dat.VMPool)
+	}
 	return mcClient.ShowVMPool(uri, token, dat)
 }
-func TestPermShowVMPool(mcClient *ormclient.Client, uri, token, region, org string) ([]edgeproto.VMPool, int, error) {
+func TestPermShowVMPool(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) ([]edgeproto.VMPool, int, error) {
 	in := &edgeproto.VMPool{}
 	in.Key.Organization = org
-	return TestShowVMPool(mcClient, uri, token, region, in)
+	return TestShowVMPool(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestAddVMPoolMember(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPoolMember) (*edgeproto.Result, int, error) {
+func TestAddVMPoolMember(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPoolMember, modFuncs ...func(*edgeproto.VMPoolMember)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionVMPoolMember{}
 	dat.Region = region
 	dat.VMPoolMember = *in
+	for _, fn := range modFuncs {
+		fn(&dat.VMPoolMember)
+	}
 	return mcClient.AddVMPoolMember(uri, token, dat)
 }
-func TestPermAddVMPoolMember(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermAddVMPoolMember(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.VMPoolMember{}
 	in.Key.Organization = org
-	return TestAddVMPoolMember(mcClient, uri, token, region, in)
+	return TestAddVMPoolMember(mcClient, uri, token, region, in, modFuncs...)
 }
 
-func TestRemoveVMPoolMember(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPoolMember) (*edgeproto.Result, int, error) {
+func TestRemoveVMPoolMember(mcClient *ormclient.Client, uri, token, region string, in *edgeproto.VMPoolMember, modFuncs ...func(*edgeproto.VMPoolMember)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionVMPoolMember{}
 	dat.Region = region
 	dat.VMPoolMember = *in
+	for _, fn := range modFuncs {
+		fn(&dat.VMPoolMember)
+	}
 	return mcClient.RemoveVMPoolMember(uri, token, dat)
 }
-func TestPermRemoveVMPoolMember(mcClient *ormclient.Client, uri, token, region, org string) (*edgeproto.Result, int, error) {
+func TestPermRemoveVMPoolMember(mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) (*edgeproto.Result, int, error) {
 	in := &edgeproto.VMPoolMember{}
 	in.Key.Organization = org
-	return TestRemoveVMPoolMember(mcClient, uri, token, region, in)
+	return TestRemoveVMPoolMember(mcClient, uri, token, region, in, modFuncs...)
 }
 
 func (s *TestClient) CreateVMPool(ctx context.Context, in *edgeproto.VMPool) (*edgeproto.Result, error) {

--- a/mc/orm/vmpool_mc2_test.go
+++ b/mc/orm/vmpool_mc2_test.go
@@ -27,94 +27,94 @@ var _ = math.Inf
 
 var _ = edgeproto.GetFields
 
-func badPermCreateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateVMPool(mcClient, uri, token, region, org)
+func badPermCreateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	_, status, err := testutil.TestPermCreateVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermCreateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermCreateVMPool(mcClient, uri, token, region, org)
+func goodPermCreateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	_, status, err := testutil.TestPermCreateVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermDeleteVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteVMPool(mcClient, uri, token, region, org)
+func badPermDeleteVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	_, status, err := testutil.TestPermDeleteVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermDeleteVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermDeleteVMPool(mcClient, uri, token, region, org)
+func goodPermDeleteVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	_, status, err := testutil.TestPermDeleteVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermUpdateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateVMPool(mcClient, uri, token, region, org)
+func badPermUpdateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	_, status, err := testutil.TestPermUpdateVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermUpdateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermUpdateVMPool(mcClient, uri, token, region, org)
+func goodPermUpdateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	_, status, err := testutil.TestPermUpdateVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowVMPool(mcClient, uri, token, region, org)
+func badPermShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	_, status, err := testutil.TestPermShowVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermShowVMPool(mcClient, uri, token, region, org)
+func goodPermShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	_, status, err := testutil.TestPermShowVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermAddVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddVMPoolMember(mcClient, uri, token, region, org)
+func badPermAddVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) {
+	_, status, err := testutil.TestPermAddVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermAddVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermAddVMPoolMember(mcClient, uri, token, region, org)
+func goodPermAddVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) {
+	_, status, err := testutil.TestPermAddVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 var _ = edgeproto.GetFields
 
-func badPermRemoveVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveVMPoolMember(mcClient, uri, token, region, org)
+func badPermRemoveVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) {
+	_, status, err := testutil.TestPermRemoveVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 }
 
-func goodPermRemoveVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	_, status, err := testutil.TestPermRemoveVMPoolMember(mcClient, uri, token, region, org)
+func goodPermRemoveVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) {
+	_, status, err := testutil.TestPermRemoveVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 }
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
-	badPermCreateVMPool(t, mcClient, uri, token, region, org)
-	badPermUpdateVMPool(t, mcClient, uri, token, region, org)
-	badPermDeleteVMPool(t, mcClient, uri, token, region, org)
+func badPermTestVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
+	badPermCreateVMPool(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermUpdateVMPool(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermDeleteVMPool(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 func badPermTestShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string) {
@@ -127,21 +127,21 @@ func badPermTestShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token,
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int) {
+func goodPermTestVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.VMPool)) {
 	goodPermCreateVMPool(t, mcClient, uri, token, region, org)
 	goodPermUpdateVMPool(t, mcClient, uri, token, region, org)
 	goodPermDeleteVMPool(t, mcClient, uri, token, region, org)
 
 	// make sure region check works
-	_, status, err := testutil.TestPermCreateVMPool(mcClient, uri, token, "bad region", org)
+	_, status, err := testutil.TestPermCreateVMPool(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermUpdateVMPool(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermUpdateVMPool(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
-	_, status, err = testutil.TestPermDeleteVMPool(mcClient, uri, token, "bad region", org)
+	_, status, err = testutil.TestPermDeleteVMPool(mcClient, uri, token, "bad region", org, modFuncs...)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "\"bad region\" not found")
 	require.Equal(t, http.StatusBadRequest, status)
@@ -166,12 +166,12 @@ func goodPermTestShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestVMPool(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int) {
-	badPermTestVMPool(t, mcClient, uri, token1, region, org2)
+func permTestVMPool(t *testing.T, mcClient *ormclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.VMPool)) {
+	badPermTestVMPool(t, mcClient, uri, token1, region, org2, modFuncs...)
 	badPermTestShowVMPool(t, mcClient, uri, token1, region, org2)
-	badPermTestVMPool(t, mcClient, uri, token2, region, org1)
+	badPermTestVMPool(t, mcClient, uri, token2, region, org1, modFuncs...)
 	badPermTestShowVMPool(t, mcClient, uri, token2, region, org1)
 
-	goodPermTestVMPool(t, mcClient, uri, token1, region, org1, showcount)
-	goodPermTestVMPool(t, mcClient, uri, token2, region, org2, showcount)
+	goodPermTestVMPool(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestVMPool(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }


### PR DESCRIPTION
This adds checks when creating/updating an AutoProvPolicy, or adding a Cloudlet to an AutoProv policy. This prevents a user from Auto-deploying to a private Cloudlet that they don't have access to.

The custom authz functions make sure that the org that is creating the AutoProvPolicy has permissions to use the Cloudlet based on how the CloudletPools are set up. There is already some existing custom authz funcs for ClusterInsts and AppInsts that basically does the same thing.

I added a bunch of unit test code to check this, plus some other checks for vmpool and autoscale/privacy policies (which don't require cloudlet checks but do have the usual org checks). To check AutoProv policy cloudlets which are a sublist on AutoProvPolicy, I added some modFunc hooks to the existing test funcs so I could add the cloudlet to the policy.