### PR TITLE
use guest tools state rather than guest state when updating template

### DIFF
--- a/crm-platforms/vsphere/vsphere-orch.go
+++ b/crm-platforms/vsphere/vsphere-orch.go
@@ -794,14 +794,14 @@ func (v *VSpherePlatform) CreateTemplateFromImage(ctx context.Context, imageFold
 		if err != nil {
 			return err
 		}
-		if vm.Guest.GuestState == "running" {
+		if vm.Guest.ToolsStatus == "toolsOk" {
 			break
 		}
 		elapsed := time.Since(start)
 		if elapsed > maxGuestWait {
 			return fmt.Errorf("timed out waiting for VM tools %s", templateName)
 		}
-		log.SpanLog(ctx, log.DebugLevelInfra, "Sleep and check guest tools again", "templateName", templateName, "GuestState", vm.Guest.GuestState)
+		log.SpanLog(ctx, log.DebugLevelInfra, "Sleep and check guest tools again", "templateName", templateName, "ToolsStatus", vm.Guest.ToolsStatus)
 		time.Sleep(5 * time.Second)
 	}
 


### PR DESCRIPTION
Fix race condition in vSphere template creation.  Previously were using GuestState to check that the template was ready to go but there can be a window in which GuestState is ok but the tools are not yet installed.  So use ToolsStatus instead