### PR TITLE
EDGECLOUD-3374 audit log tags

### DIFF
--- a/e2e-tests/data/mc_auditquery_oper.yml
+++ b/e2e-tests/data/mc_auditquery_oper.yml
@@ -1,0 +1,2 @@
+operation: /api/v1/auth/ctrl/CreateAppInst
+limit: 10

--- a/e2e-tests/data/mc_auditquery_tags.yml
+++ b/e2e-tests/data/mc_auditquery_tags.yml
@@ -1,0 +1,3 @@
+limit: 10
+tags:
+  app: someapplication1

--- a/e2e-tests/data/mc_showaudit_org.yml
+++ b/e2e-tests/data/mc_showaudit_org.yml
@@ -1,5 +1,6 @@
 - operationname: /api/v1/auth/org/delete
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:04:18.818859-07:00"
@@ -10,6 +11,7 @@
   traceid: f372c8a2f99c4b6
 - operationname: /api/v1/auth/ctrl/DeleteAutoProvPolicy
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-12-18T13:36:59.484291-08:00"
@@ -17,8 +19,12 @@
   request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 7d0896601b1411aa
+  tags:
+    policy: autoprov1
+    policyorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-10-23T17:28:29.223902-07:00"
@@ -26,8 +32,12 @@
   request: '{"Region":"locala","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
   response: '{}'
   traceid: 1e71004f9d5966b1
+  tags:
+    policy: scale1
+    policyorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteClusterInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:04:18.731179-07:00"
@@ -42,8 +52,14 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted ClusterInst successfully"}}
   traceid: 731726320ef94647
+  tags:
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteClusterInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:04:18.643366-07:00"
@@ -58,8 +74,14 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted ClusterInst successfully"}}
   traceid: 78a606d3224b7e07
+  tags:
+    cloudlet: tmus-cloud-3
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteApp
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-12-18T13:36:59.224084-08:00"
@@ -67,8 +89,13 @@
   request: '{"Region":"locala","App":{"key":{"organization":"AcmeAppCo","name":"autoprovapp","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:81","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","auto_prov_policy":"autoprov1"}}'
   response: '{}'
   traceid: 55f7274f5eddb00b
+  tags:
+    app: autoprovapp
+    apporg: AcmeAppCo
+    appver: "1.0"
 - operationname: /api/v1/auth/ctrl/DeleteApp
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:04:18.59613-07:00"
@@ -78,8 +105,13 @@
     PUBLIC KEY-----\n","deployment":"kubernetes","android_package_name":"com.acme.someapplication1"}}'
   response: '{}'
   traceid: 6d5d989b7af404ec
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
 - operationname: /api/v1/auth/ctrl/DeleteAppInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:04:18.551272-07:00"
@@ -90,8 +122,17 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted AppInst successfully"}}
   traceid: 673c172cdefa2da
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteAppInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:04:18.492601-07:00"
@@ -102,8 +143,17 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted AppInst successfully"}}
   traceid: 16280f277fec9a7a
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-3
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteAutoProvPolicy
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2020-03-18T11:41:44.411308-07:00"
@@ -111,3 +161,6 @@
   request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 73cbbf9e2299ef79
+  tags:
+    policy: autoprov1
+    policyorg: AcmeAppCo

--- a/e2e-tests/data/mc_showaudit_tags.yml
+++ b/e2e-tests/data/mc_showaudit_tags.yml
@@ -1,0 +1,198 @@
+- operationname: /api/v1/auth/ctrl/DeleteApp
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:53:00.422427-07:00"
+  duration: 36.45ms
+  request: '{"Region":"locala","App":{"key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:80,http:443,udp:10002","default_flavor":{"name":"x1.small"},"auth_public_key":"-----BEGIN
+    PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij\nTkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0\nVU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC\nGJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS\nz3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m\nQnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C\n/QIDAQAB\n-----END
+    PUBLIC KEY-----\n","deployment":"kubernetes","android_package_name":"com.acme.someapplication1"}}'
+  response: '{}'
+  traceid: 3466675612cd4ef4
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+- operationname: /api/v1/auth/ctrl/DeleteAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:53:00.348343-07:00"
+  duration: 69.927ms
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Deleting"}}
+    {"data":{"message":"NotPresent"}}
+    {"data":{"message":"Deleted AppInst successfully"}}
+  traceid: 1a85b37a06450386
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/DeleteAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:53:00.25542-07:00"
+  duration: 88.757ms
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-3"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Deleting"}}
+    {"data":{"message":"NotPresent"}}
+    {"data":{"message":"Deleted AppInst successfully"}}
+  traceid: 143959c31dceec96
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-3
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/DeleteApp
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:52:59.704924-07:00"
+  duration: 40.489ms
+  request: '{"Region":"local","App":{"key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:80,http:443,udp:10002","default_flavor":{"name":"x1.small"},"auth_public_key":"-----BEGIN
+    PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij\nTkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0\nVU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC\nGJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS\nz3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m\nQnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C\n/QIDAQAB\n-----END
+    PUBLIC KEY-----\n","deployment":"kubernetes","android_package_name":"com.acme.someapplication1"}}'
+  response: '{}'
+  traceid: 4ce4a3ff00daecc0
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+- operationname: /api/v1/auth/ctrl/DeleteAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:52:59.638718-07:00"
+  duration: 60.487ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Deleting"}}
+    {"data":{"message":"NotPresent"}}
+    {"data":{"message":"Deleted AppInst successfully"}}
+  traceid: 7a4fceccaf2c4405
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-2
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/DeleteAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:52:59.574468-07:00"
+  duration: 59.382ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Deleting"}}
+    {"data":{"message":"NotPresent"}}
+    {"data":{"message":"Deleted AppInst successfully"}}
+  traceid: 66c2c901b490f8d5
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-1
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:52:12.091852-07:00"
+  duration: 130.162ms
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 5a1867e6b2661af7
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:52:11.979092-07:00"
+  duration: 108.102ms
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-3"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 56d9f200170e6e42
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-3
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateApp
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:52:11.579378-07:00"
+  duration: 189.829ms
+  request: '{"Region":"locala","App":{"key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:80,http:443,udp:10002","default_flavor":{"name":"x1.small"},"auth_public_key":"-----BEGIN
+    PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Spdynjh+MPcziCH2Gij\nTkK9fspTH4onMtPTgxo+MQC+OZTwetvYFJjGV8jnYebtuvWWUCctYmt0SIPmA0F0\nVU6qzSlrBOKZ9yA7Rj3jSQtNrI5vfBIzK1wPDm7zuy5hytzauFupyfboXf4qS4uC\nGJCm9EOzUSCLRryyh7kTxa4cYHhhTTKNTTy06lc7YyxBsRsN/4jgxjjkxe3J0SfS\nz3eaHmfFn/GNwIAqy1dddTJSPugRkK7ZjFR+9+sscY9u1+F5QPwxa8vTB0U6hh1m\nQnhVd1d9osRwbyALfBY8R+gMgGgEBCPYpL3u5iSjgD6+n4d9RQS5zYRpeMJ1fX0C\n/QIDAQAB\n-----END
+    PUBLIC KEY-----\n","deployment":"kubernetes","android_package_name":"com.acme.someapplication1"}}'
+  response: '{}'
+  traceid: 61c23a4b5a240fa0
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:52:10.989455-07:00"
+  duration: 102.414ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 2ed3d49e059672c9
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-2
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo

--- a/e2e-tests/data/mc_showaudit_user2.yml
+++ b/e2e-tests/data/mc_showaudit_user2.yml
@@ -45,6 +45,7 @@
   traceid: 635be073ef98bea
 - operationname: /api/v1/auth/org/delete
   username: user2
+  org: Samsung
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-11T09:36:02.911463-07:00"
@@ -55,6 +56,7 @@
   traceid: 7531b8302d84aba7
 - operationname: /api/v1/auth/org/delete
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-11T09:36:02.901987-07:00"
@@ -65,6 +67,7 @@
   traceid: 70aa9663b5c13c3
 - operationname: /api/v1/auth/ctrl/DeleteAutoProvPolicy
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-12-18T13:42:42.48365-08:00"
@@ -72,8 +75,12 @@
   request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 7af113ec2d0b698c
+  tags:
+    policy: autoprov1
+    policyorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-10-23T17:33:40.487278-07:00"
@@ -81,8 +88,12 @@
   request: '{"Region":"locala","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
   response: '{}'
   traceid: 382475ae5bd5fddb
+  tags:
+    policy: scale1
+    policyorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteClusterInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-11T09:36:02.782934-07:00"
@@ -97,3 +108,8 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted ClusterInst successfully"}}
   traceid: 35078d27e23052f5
+  tags:
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo

--- a/e2e-tests/data/mc_showaudit_user2oper.yml
+++ b/e2e-tests/data/mc_showaudit_user2oper.yml
@@ -1,0 +1,176 @@
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:42:49.824473-07:00"
+  duration: 129.512ms
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 20b5fa8b29111d59
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:42:49.716537-07:00"
+  duration: 103.027ms
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-3"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 6c9577a37b88d6a3
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-3
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:42:48.696869-07:00"
+  duration: 112.482ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 3c844a6a12b3578e
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-2
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:42:48.560272-07:00"
+  duration: 131.949ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 36d5bc201908aca2
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-1
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:41:48.203686-07:00"
+  duration: 118.021ms
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-4"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 51a8a6d7e86ae608
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:41:48.107696-07:00"
+  duration: 91.872ms
+  request: '{"Region":"locala","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-3"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 3d568bc72ce1175d
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-3
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:41:47.122401-07:00"
+  duration: 129.241ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 320bd7326b74b621
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-2
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2020-08-07T10:41:46.993941-07:00"
+  duration: 124.167ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
+  response: |
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 62710ea8ab628e16
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-1
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo

--- a/e2e-tests/data/mc_showaudit_user2org.yml
+++ b/e2e-tests/data/mc_showaudit_user2org.yml
@@ -1,5 +1,6 @@
 - operationname: /api/v1/auth/org/delete
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:13:42.173053-07:00"
@@ -10,6 +11,7 @@
   traceid: 3f80227e8749927a
 - operationname: /api/v1/auth/ctrl/DeleteAutoProvPolicy
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-12-18T13:44:44.543446-08:00"
@@ -17,8 +19,12 @@
   request: '{"Region":"locala","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-3"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-4"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 1b1f287407047931
+  tags:
+    policy: autoprov1
+    policyorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteAutoScalePolicy
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-10-23T17:37:07.310346-07:00"
@@ -26,8 +32,12 @@
   request: '{"Region":"locala","AutoScalePolicy":{"key":{"organization":"AcmeAppCo","name":"scale1"},"min_nodes":1,"max_nodes":3,"scale_up_cpu_thresh":85,"scale_down_cpu_thresh":20,"trigger_time_sec":60}}'
   response: '{}'
   traceid: 4e507c541c45009a
+  tags:
+    policy: scale1
+    policyorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteClusterInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:13:42.071157-07:00"
@@ -42,8 +52,14 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted ClusterInst successfully"}}
   traceid: 14b6087cd25e2c9e
+  tags:
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteClusterInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:13:41.979993-07:00"
@@ -58,8 +74,14 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted ClusterInst successfully"}}
   traceid: 260e5bb9a9413721
+  tags:
+    cloudlet: tmus-cloud-3
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteApp
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-12-18T13:44:44.285586-08:00"
@@ -67,8 +89,13 @@
   request: '{"Region":"locala","App":{"key":{"organization":"AcmeAppCo","name":"autoprovapp","version":"1.0"},"image_path":"registry.mobiledgex.net/AcmeAppCo/someapplication1:1.0","image_type":1,"access_ports":"tcp:81","default_flavor":{"name":"x1.small"},"deployment":"kubernetes","auto_prov_policy":"autoprov1"}}'
   response: '{}'
   traceid: 38d6124bc329b12
+  tags:
+    app: autoprovapp
+    apporg: AcmeAppCo
+    appver: "1.0"
 - operationname: /api/v1/auth/ctrl/DeleteApp
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:13:41.93511-07:00"
@@ -78,8 +105,13 @@
     PUBLIC KEY-----\n","deployment":"kubernetes","android_package_name":"com.acme.someapplication1"}}'
   response: '{}'
   traceid: 55f441548b685db1
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
 - operationname: /api/v1/auth/ctrl/DeleteAppInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:13:41.888583-07:00"
@@ -90,8 +122,17 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted AppInst successfully"}}
   traceid: 46fdae027aa84e31
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-4
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteAppInst
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2019-08-10T16:13:41.844651-07:00"
@@ -102,8 +143,17 @@
     {"data":{"message":"NotPresent"}}
     {"data":{"message":"Deleted AppInst successfully"}}
   traceid: 4242788f1d2a702f
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-3
+    cloudletorg: tmus
+    cluster: SmallCluster
+    clusterorg: AcmeAppCo
 - operationname: /api/v1/auth/ctrl/DeleteAutoProvPolicy
   username: user2
+  org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
   starttime: "2020-03-18T14:19:48.41892-07:00"
@@ -111,3 +161,6 @@
   request: '{"Region":"local","AutoProvPolicy":{"key":{"organization":"AcmeAppCo","name":"autoprov1"},"deploy_client_count":3,"deploy_interval_count":3,"cloudlets":[{"key":{"organization":"tmus","name":"tmus-cloud-1"},"loc":{}},{"key":{"organization":"tmus","name":"tmus-cloud-2"},"loc":{}}],"undeploy_client_count":1,"undeploy_interval_count":3}}'
   response: '{}'
   traceid: 1bf7b6b1f18e9fe3
+  tags:
+    policy: autoprov1
+    policyorg: AcmeAppCo

--- a/e2e-tests/testfiles/mc_audit.yml
+++ b/e2e-tests/testfiles/mc_audit.yml
@@ -40,3 +40,19 @@ tests:
     yaml1: '{{outputdir}}/show-commands.yml'
     yaml2: '{{datadir2}}/mc_showaudit_user2org.yml'
     filetype: mcaudit
+- name: filter audit logs by operation
+  actions: [mcapi-auditself]
+  curuserfile: '{{datadir2}}/mc_user2.yml'
+  apifile: '{{datadir2}}/mc_auditquery_oper.yml'
+  compareyaml:
+    yaml1: '{{outputdir}}/show-commands.yml'
+    yaml2: '{{datadir2}}/mc_showaudit_user2oper.yml'
+    filetype: mcaudit
+- name: filter audit logs by tag
+  actions: [mcapi-auditorg]
+  curuserfile: '{{datadir2}}/mc_admin.yml'
+  apifile: '{{datadir2}}/mc_auditquery_tags.yml'
+  compareyaml:
+    yaml1: '{{outputdir}}/show-commands.yml'
+    yaml2: '{{datadir2}}/mc_showaudit_tags.yml'
+    filetype: mcaudit

--- a/mc/mcctl/cliwrapper/vmpool.mc2.go
+++ b/mc/mcctl/cliwrapper/vmpool.mc2.go
@@ -11,7 +11,6 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
-import _ "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
 

--- a/mc/mcctl/ormctl/audit.go
+++ b/mc/mcctl/ormctl/audit.go
@@ -1,34 +1,48 @@
 package ormctl
 
 import (
+	fmt "fmt"
+	"strings"
+
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/cli"
+	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/spf13/cobra"
 )
 
 func GetAuditCommand() *cobra.Command {
 	cmds := []*cli.Command{&cli.Command{
 		Use:          "showself",
-		OptionalArgs: "limit starttime endtime startage endage",
+		OptionalArgs: "limit operation tags starttime endtime startage endage",
 		Comments:     AuditSelfComments,
+		SpecialArgs:  &AuditSpecialArgs,
 		ReqData:      &ormapi.AuditQuery{},
 		ReplyData:    &[]ormapi.AuditResponse{},
 		Run:          runRest("/auth/audit/showself"),
 	}, &cli.Command{
 		Use:          "showorg",
-		OptionalArgs: "org limit starttime endtime startage endage",
+		OptionalArgs: "org limit operation tags starttime endtime startage endage",
 		Comments:     AuditOrgComments,
+		SpecialArgs:  &AuditSpecialArgs,
 		ReqData:      &ormapi.AuditQuery{},
 		ReplyData:    &[]ormapi.AuditResponse{},
 		Run:          runRest("/auth/audit/showorg"),
+	}, &cli.Command{
+		Use:       "operations",
+		ReplyData: &[]string{},
+		Run:       runRest("/auth/audit/operations"),
 	}}
 	return cli.GenGroup("audit", "show audit logs", cmds)
 }
+
+var tagsComment = fmt.Sprintf("key=value tag, may be specified multiple times, key may include %s", strings.Join(edgeproto.AllKeyTags, ", "))
 
 var AuditOrgComments = map[string]string{
 	"username":  "filter by user name",
 	"org":       "filter by organization name",
 	"limit":     "limit the number of returned results (default 100)",
+	"operation": "operation name (see operations command)",
+	"tags":      tagsComment,
 	"starttime": "absolute time of search range start (RFC3339)",
 	"endtime":   "absolute time of search range end (RFC3339)",
 	"startage":  "relative age from now of search range start (default 48h)",
@@ -38,8 +52,14 @@ var AuditOrgComments = map[string]string{
 var AuditSelfComments = map[string]string{
 	"org":       "filter by organization name",
 	"limit":     "limit the number of returned results (default 100)",
+	"operation": "operation name (see operations command)",
+	"tags":      tagsComment,
 	"starttime": "absolute time of search range start",
 	"endtime":   "absolute time of search range end",
 	"startage":  "relative age from now of search range start (default 48h)",
 	"endage":    "relative age from now of search range end (default 0)",
+}
+
+var AuditSpecialArgs = map[string]string{
+	"tags": "StringToString",
 }

--- a/mc/mcctl/ormctl/vmpool.mc2.go
+++ b/mc/mcctl/ormctl/vmpool.mc2.go
@@ -12,7 +12,6 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
-import _ "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
 

--- a/mc/orm/app.mc2.go
+++ b/mc/orm/app.mc2.go
@@ -50,6 +50,7 @@ func CreateApp(c echo.Context) error {
 }
 
 func CreateAppObj(ctx context.Context, rc *RegionContext, obj *edgeproto.App) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authzCreateApp(ctx, rc.region, rc.username, obj,
 			ResourceApps, ActionManage); err != nil {
@@ -97,6 +98,7 @@ func DeleteApp(c echo.Context) error {
 }
 
 func DeleteAppObj(ctx context.Context, rc *RegionContext, obj *edgeproto.App) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceApps, ActionManage); err != nil {
@@ -144,6 +146,7 @@ func UpdateApp(c echo.Context) error {
 }
 
 func UpdateAppObj(ctx context.Context, rc *RegionContext, obj *edgeproto.App) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authzUpdateApp(ctx, rc.region, rc.username, obj,
 			ResourceApps, ActionManage); err != nil {
@@ -276,6 +279,7 @@ func AddAppAutoProvPolicy(c echo.Context) error {
 }
 
 func AddAppAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AppAutoProvPolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.AppKey.Organization,
 			ResourceApps, ActionManage); err != nil {
@@ -323,6 +327,7 @@ func RemoveAppAutoProvPolicy(c echo.Context) error {
 }
 
 func RemoveAppAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AppAutoProvPolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.AppKey.Organization,
 			ResourceApps, ActionManage); err != nil {

--- a/mc/orm/appinst.mc2.go
+++ b/mc/orm/appinst.mc2.go
@@ -121,6 +121,7 @@ func CreateAppInst(c echo.Context) error {
 }
 
 func CreateAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.AppInst, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authzCreateAppInst(ctx, rc.region, rc.username, obj,
 			ResourceAppInsts, ActionManage); err != nil {
@@ -209,6 +210,7 @@ func DeleteAppInst(c echo.Context) error {
 }
 
 func DeleteAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.AppInst, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.AppKey.Organization,
 			ResourceAppInsts, ActionManage); err != nil {
@@ -297,6 +299,7 @@ func RefreshAppInst(c echo.Context) error {
 }
 
 func RefreshAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.AppInst, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.AppKey.Organization,
 			ResourceAppInsts, ActionManage); err != nil {
@@ -385,6 +388,7 @@ func UpdateAppInst(c echo.Context) error {
 }
 
 func UpdateAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.AppInst, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.AppKey.Organization,
 			ResourceAppInsts, ActionManage); err != nil {

--- a/mc/orm/appinstclient.mc2.go
+++ b/mc/orm/appinstclient.mc2.go
@@ -55,6 +55,7 @@ func ShowAppInstClient(c echo.Context) error {
 }
 
 func ShowAppInstClientStream(ctx context.Context, rc *RegionContext, obj *edgeproto.AppInstClientKey, cb func(res *edgeproto.AppInstClient)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.AppKey.Organization,
 			ResourceAppAnalytics, ActionView); err != nil {

--- a/mc/orm/autoprovpolicy.mc2.go
+++ b/mc/orm/autoprovpolicy.mc2.go
@@ -52,6 +52,7 @@ func CreateAutoProvPolicy(c echo.Context) error {
 }
 
 func CreateAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoProvPolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authzCreateAutoProvPolicy(ctx, rc.region, rc.username, obj,
 			ResourceDeveloperPolicy, ActionManage); err != nil {
@@ -99,6 +100,7 @@ func DeleteAutoProvPolicy(c echo.Context) error {
 }
 
 func DeleteAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoProvPolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceDeveloperPolicy, ActionManage); err != nil {
@@ -146,6 +148,7 @@ func UpdateAutoProvPolicy(c echo.Context) error {
 }
 
 func UpdateAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoProvPolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authzUpdateAutoProvPolicy(ctx, rc.region, rc.username, obj,
 			ResourceDeveloperPolicy, ActionManage); err != nil {
@@ -278,6 +281,7 @@ func AddAutoProvPolicyCloudlet(c echo.Context) error {
 }
 
 func AddAutoProvPolicyCloudletObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoProvPolicyCloudlet) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authzAddAutoProvPolicyCloudlet(ctx, rc.region, rc.username, obj,
 			ResourceDeveloperPolicy, ActionManage); err != nil {
@@ -325,6 +329,7 @@ func RemoveAutoProvPolicyCloudlet(c echo.Context) error {
 }
 
 func RemoveAutoProvPolicyCloudletObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoProvPolicyCloudlet) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceDeveloperPolicy, ActionManage); err != nil {

--- a/mc/orm/autoscalepolicy.mc2.go
+++ b/mc/orm/autoscalepolicy.mc2.go
@@ -50,6 +50,7 @@ func CreateAutoScalePolicy(c echo.Context) error {
 }
 
 func CreateAutoScalePolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoScalePolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceDeveloperPolicy, ActionManage, withRequiresOrg(obj.Key.Organization)); err != nil {
@@ -97,6 +98,7 @@ func DeleteAutoScalePolicy(c echo.Context) error {
 }
 
 func DeleteAutoScalePolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoScalePolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceDeveloperPolicy, ActionManage); err != nil {
@@ -144,6 +146,7 @@ func UpdateAutoScalePolicy(c echo.Context) error {
 }
 
 func UpdateAutoScalePolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.AutoScalePolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceDeveloperPolicy, ActionManage); err != nil {

--- a/mc/orm/cloudlet.mc2.go
+++ b/mc/orm/cloudlet.mc2.go
@@ -121,6 +121,7 @@ func CreateCloudlet(c echo.Context) error {
 }
 
 func CreateCloudletStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Cloudlet, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage, withRequiresOrg(obj.Key.Organization)); err != nil {
@@ -209,6 +210,7 @@ func DeleteCloudlet(c echo.Context) error {
 }
 
 func DeleteCloudletStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Cloudlet, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -297,6 +299,7 @@ func UpdateCloudlet(c echo.Context) error {
 }
 
 func UpdateCloudletStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Cloudlet, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -454,6 +457,7 @@ func GetCloudletManifest(c echo.Context) error {
 }
 
 func GetCloudletManifestObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Cloudlet) (*edgeproto.CloudletManifest, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -501,6 +505,7 @@ func AddCloudletResMapping(c echo.Context) error {
 }
 
 func AddCloudletResMappingObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletResMap) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -548,6 +553,7 @@ func RemoveCloudletResMapping(c echo.Context) error {
 }
 
 func RemoveCloudletResMappingObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletResMap) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -595,6 +601,7 @@ func FindFlavorMatch(c echo.Context) error {
 }
 
 func FindFlavorMatchObj(ctx context.Context, rc *RegionContext, obj *edgeproto.FlavorMatch) (*edgeproto.FlavorMatch, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionView); err != nil {
@@ -727,6 +734,7 @@ func InjectCloudletInfo(c echo.Context) error {
 }
 
 func InjectCloudletInfoObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletInfo) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -774,6 +782,7 @@ func EvictCloudletInfo(c echo.Context) error {
 }
 
 func EvictCloudletInfoObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletInfo) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {

--- a/mc/orm/cloudletpool.mc2.go
+++ b/mc/orm/cloudletpool.mc2.go
@@ -50,6 +50,7 @@ func CreateCloudletPool(c echo.Context) error {
 }
 
 func CreateCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletPool) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudletPools, ActionManage, withRequiresOrg(obj.Key.Organization)); err != nil {
@@ -97,6 +98,7 @@ func DeleteCloudletPool(c echo.Context) error {
 }
 
 func DeleteCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletPool) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudletPools, ActionManage); err != nil {
@@ -144,6 +146,7 @@ func UpdateCloudletPool(c echo.Context) error {
 }
 
 func UpdateCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletPool) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudletPools, ActionManage); err != nil {
@@ -276,6 +279,7 @@ func AddCloudletPoolMember(c echo.Context) error {
 }
 
 func AddCloudletPoolMemberObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletPoolMember) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudletPools, ActionManage); err != nil {
@@ -323,6 +327,7 @@ func RemoveCloudletPoolMember(c echo.Context) error {
 }
 
 func RemoveCloudletPoolMemberObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletPoolMember) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudletPools, ActionManage); err != nil {

--- a/mc/orm/clusterinst.mc2.go
+++ b/mc/orm/clusterinst.mc2.go
@@ -119,6 +119,7 @@ func CreateClusterInst(c echo.Context) error {
 }
 
 func CreateClusterInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.ClusterInst, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authzCreateClusterInst(ctx, rc.region, rc.username, obj,
 			ResourceClusterInsts, ActionManage); err != nil {
@@ -207,6 +208,7 @@ func DeleteClusterInst(c echo.Context) error {
 }
 
 func DeleteClusterInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.ClusterInst, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceClusterInsts, ActionManage); err != nil {
@@ -295,6 +297,7 @@ func UpdateClusterInst(c echo.Context) error {
 }
 
 func UpdateClusterInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.ClusterInst, cb func(res *edgeproto.Result)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceClusterInsts, ActionManage); err != nil {

--- a/mc/orm/debug.mc2.go
+++ b/mc/orm/debug.mc2.go
@@ -7,6 +7,7 @@ import edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 import "github.com/labstack/echo"
 import "context"
 import "io"
+import "github.com/mobiledgex/edge-cloud/log"
 import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
@@ -51,6 +52,7 @@ func EnableDebugLevels(c echo.Context) error {
 }
 
 func EnableDebugLevelsStream(ctx context.Context, rc *RegionContext, obj *edgeproto.DebugRequest, cb func(res *edgeproto.DebugReply)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionManage); err != nil {
@@ -124,6 +126,7 @@ func DisableDebugLevels(c echo.Context) error {
 }
 
 func DisableDebugLevelsStream(ctx context.Context, rc *RegionContext, obj *edgeproto.DebugRequest, cb func(res *edgeproto.DebugReply)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionManage); err != nil {
@@ -197,6 +200,7 @@ func ShowDebugLevels(c echo.Context) error {
 }
 
 func ShowDebugLevelsStream(ctx context.Context, rc *RegionContext, obj *edgeproto.DebugRequest, cb func(res *edgeproto.DebugReply)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionView); err != nil {
@@ -270,6 +274,7 @@ func RunDebug(c echo.Context) error {
 }
 
 func RunDebugStream(ctx context.Context, rc *RegionContext, obj *edgeproto.DebugRequest, cb func(res *edgeproto.DebugReply)) error {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionManage); err != nil {

--- a/mc/orm/device.mc2.go
+++ b/mc/orm/device.mc2.go
@@ -7,6 +7,7 @@ import edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 import "github.com/labstack/echo"
 import "context"
 import "io"
+import "github.com/mobiledgex/edge-cloud/log"
 import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
@@ -48,6 +49,7 @@ func InjectDevice(c echo.Context) error {
 }
 
 func InjectDeviceObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Device) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionManage); err != nil {
@@ -176,6 +178,7 @@ func EvictDevice(c echo.Context) error {
 }
 
 func EvictDeviceObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Device) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionManage); err != nil {

--- a/mc/orm/exec.mc2.go
+++ b/mc/orm/exec.mc2.go
@@ -48,6 +48,7 @@ func RunCommand(c echo.Context) error {
 }
 
 func RunCommandObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ExecRequest) (*edgeproto.ExecRequest, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.AppInstKey.AppKey.Organization,
 			ResourceAppInsts, ActionManage); err != nil {
@@ -95,6 +96,7 @@ func RunConsole(c echo.Context) error {
 }
 
 func RunConsoleObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ExecRequest) (*edgeproto.ExecRequest, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.AppInstKey.AppKey.Organization,
 			ResourceAppInsts, ActionManage); err != nil {
@@ -142,6 +144,7 @@ func ShowLogs(c echo.Context) error {
 }
 
 func ShowLogsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ExecRequest) (*edgeproto.ExecRequest, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.AppInstKey.AppKey.Organization,
 			ResourceAppInsts, ActionView); err != nil {
@@ -187,6 +190,7 @@ func AccessCloudlet(c echo.Context) error {
 }
 
 func AccessCloudletObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ExecRequest) (*edgeproto.ExecRequest, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceCloudlets, ActionManage); err != nil {

--- a/mc/orm/flavor.mc2.go
+++ b/mc/orm/flavor.mc2.go
@@ -7,6 +7,7 @@ import edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 import "github.com/labstack/echo"
 import "context"
 import "io"
+import "github.com/mobiledgex/edge-cloud/log"
 import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
@@ -47,6 +48,7 @@ func CreateFlavor(c echo.Context) error {
 }
 
 func CreateFlavorObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flavor) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceFlavors, ActionManage); err != nil {
@@ -92,6 +94,7 @@ func DeleteFlavor(c echo.Context) error {
 }
 
 func DeleteFlavorObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flavor) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceFlavors, ActionManage); err != nil {
@@ -137,6 +140,7 @@ func UpdateFlavor(c echo.Context) error {
 }
 
 func UpdateFlavorObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flavor) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceFlavors, ActionManage); err != nil {
@@ -249,6 +253,7 @@ func AddFlavorRes(c echo.Context) error {
 }
 
 func AddFlavorResObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flavor) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceFlavors, ActionManage); err != nil {
@@ -294,6 +299,7 @@ func RemoveFlavorRes(c echo.Context) error {
 }
 
 func RemoveFlavorResObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flavor) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceFlavors, ActionManage); err != nil {

--- a/mc/orm/operatorcode.mc2.go
+++ b/mc/orm/operatorcode.mc2.go
@@ -49,6 +49,7 @@ func CreateOperatorCode(c echo.Context) error {
 }
 
 func CreateOperatorCodeObj(ctx context.Context, rc *RegionContext, obj *edgeproto.OperatorCode) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Organization,
 			ResourceCloudlets, ActionManage, withRequiresOrg(obj.Organization)); err != nil {
@@ -96,6 +97,7 @@ func DeleteOperatorCode(c echo.Context) error {
 }
 
 func DeleteOperatorCodeObj(ctx context.Context, rc *RegionContext, obj *edgeproto.OperatorCode) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Organization,
 			ResourceCloudlets, ActionManage); err != nil {

--- a/mc/orm/privacypolicy.mc2.go
+++ b/mc/orm/privacypolicy.mc2.go
@@ -50,6 +50,7 @@ func CreatePrivacyPolicy(c echo.Context) error {
 }
 
 func CreatePrivacyPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.PrivacyPolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceDeveloperPolicy, ActionManage, withRequiresOrg(obj.Key.Organization)); err != nil {
@@ -97,6 +98,7 @@ func DeletePrivacyPolicy(c echo.Context) error {
 }
 
 func DeletePrivacyPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.PrivacyPolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceDeveloperPolicy, ActionManage); err != nil {
@@ -144,6 +146,7 @@ func UpdatePrivacyPolicy(c echo.Context) error {
 }
 
 func UpdatePrivacyPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.PrivacyPolicy) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceDeveloperPolicy, ActionManage); err != nil {

--- a/mc/orm/restagtable.mc2.go
+++ b/mc/orm/restagtable.mc2.go
@@ -50,6 +50,7 @@ func CreateResTagTable(c echo.Context) error {
 }
 
 func CreateResTagTableObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ResTagTable) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceResTagTable, ActionManage, withRequiresOrg(obj.Key.Organization)); err != nil {
@@ -97,6 +98,7 @@ func DeleteResTagTable(c echo.Context) error {
 }
 
 func DeleteResTagTableObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ResTagTable) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceResTagTable, ActionManage); err != nil {
@@ -144,6 +146,7 @@ func UpdateResTagTable(c echo.Context) error {
 }
 
 func UpdateResTagTableObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ResTagTable) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceResTagTable, ActionManage); err != nil {
@@ -276,6 +279,7 @@ func AddResTag(c echo.Context) error {
 }
 
 func AddResTagObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ResTagTable) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceResTagTable, ActionManage); err != nil {
@@ -323,6 +327,7 @@ func RemoveResTag(c echo.Context) error {
 }
 
 func RemoveResTagObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ResTagTable) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceResTagTable, ActionManage); err != nil {
@@ -368,6 +373,7 @@ func GetResTagTable(c echo.Context) error {
 }
 
 func GetResTagTableObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ResTagTableKey) (*edgeproto.ResTagTable, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceResTagTable, ActionManage); err != nil {

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -341,6 +341,7 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	auth.POST("/restricted/user/update", RestrictedUserUpdate)
 	auth.POST("/audit/showself", ShowAuditSelf)
 	auth.POST("/audit/showorg", ShowAuditOrg)
+	auth.POST("/audit/operations", GetAuditOperations)
 	auth.POST("/orgcloudletpool/create", CreateOrgCloudletPool)
 	auth.POST("/orgcloudletpool/delete", DeleteOrgCloudletPool)
 	auth.POST("/orgcloudletpool/show", ShowOrgCloudletPool)

--- a/mc/orm/settings.mc2.go
+++ b/mc/orm/settings.mc2.go
@@ -6,6 +6,7 @@ package orm
 import edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 import "github.com/labstack/echo"
 import "context"
+import "github.com/mobiledgex/edge-cloud/log"
 import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 import "google.golang.org/grpc/status"
 import proto "github.com/gogo/protobuf/proto"
@@ -46,6 +47,7 @@ func UpdateSettings(c echo.Context) error {
 }
 
 func UpdateSettingsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Settings) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionManage); err != nil {
@@ -91,6 +93,7 @@ func ResetSettings(c echo.Context) error {
 }
 
 func ResetSettingsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Settings) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionManage); err != nil {
@@ -136,6 +139,7 @@ func ShowSettings(c echo.Context) error {
 }
 
 func ShowSettingsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Settings) (*edgeproto.Settings, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceConfig, ActionView); err != nil {

--- a/mc/orm/testutil/vmpool_mc2_testutil.go
+++ b/mc/orm/testutil/vmpool_mc2_testutil.go
@@ -12,7 +12,6 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
-import _ "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
 

--- a/mc/orm/vmpool.mc2.go
+++ b/mc/orm/vmpool.mc2.go
@@ -15,7 +15,6 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
-import _ "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
 
@@ -52,6 +51,7 @@ func CreateVMPool(c echo.Context) error {
 }
 
 func CreateVMPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.VMPool) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage, withRequiresOrg(obj.Key.Organization)); err != nil {
@@ -99,6 +99,7 @@ func DeleteVMPool(c echo.Context) error {
 }
 
 func DeleteVMPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.VMPool) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -146,6 +147,7 @@ func UpdateVMPool(c echo.Context) error {
 }
 
 func UpdateVMPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.VMPool) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -278,6 +280,7 @@ func AddVMPoolMember(c echo.Context) error {
 }
 
 func AddVMPoolMemberObj(ctx context.Context, rc *RegionContext, obj *edgeproto.VMPoolMember) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {
@@ -325,6 +328,7 @@ func RemoveVMPoolMember(c echo.Context) error {
 }
 
 func RemoveVMPoolMemberObj(ctx context.Context, rc *RegionContext, obj *edgeproto.VMPoolMember) (*edgeproto.Result, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, obj.Key.Organization,
 			ResourceCloudlets, ActionManage); err != nil {

--- a/mc/orm/vmpool_mc2_test.go
+++ b/mc/orm/vmpool_mc2_test.go
@@ -14,7 +14,6 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
-import _ "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
 

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -122,18 +122,21 @@ type CreateUser struct {
 }
 
 type AuditQuery struct {
-	Username  string        `json:"username"`
-	Org       string        `form:"org" json:"org"`
-	Limit     int           `json:"limit"`
-	StartTime time.Time     `json:"starttime"`
-	EndTime   time.Time     `json:"endtime"`
-	StartAge  time.Duration `json:"startage"`
-	EndAge    time.Duration `json:"endage"`
+	Username  string            `json:"username"`
+	Org       string            `form:"org" json:"org"`
+	Limit     int               `json:"limit"`
+	StartTime time.Time         `json:"starttime"`
+	EndTime   time.Time         `json:"endtime"`
+	StartAge  time.Duration     `json:"startage"`
+	EndAge    time.Duration     `json:"endage"`
+	Operation string            `json:"operation"`
+	Tags      map[string]string `json:"tags"`
 }
 
 type AuditResponse struct {
 	OperationName string               `json:"operationname"`
 	Username      string               `json:"username"`
+	Org           string               `json:"org"`
 	ClientIP      string               `json:"clientip"`
 	Status        int                  `json:"status"`
 	StartTime     TimeMicroseconds     `json:"starttime"`
@@ -142,6 +145,7 @@ type AuditResponse struct {
 	Response      string               `json:"response"`
 	Error         string               `json:"error"`
 	TraceID       string               `json:"traceid"`
+	Tags          map[string]string    `json:"tags"`
 }
 
 // Email request is used for password reset and to resend welcome

--- a/mc/ormapi/vmpool.mc2.go
+++ b/mc/ormapi/vmpool.mc2.go
@@ -9,7 +9,6 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
-import _ "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
 

--- a/mc/ormclient/vmpool_client.go
+++ b/mc/ormclient/vmpool_client.go
@@ -10,7 +10,6 @@ import fmt "fmt"
 import math "math"
 import _ "github.com/gogo/googleapis/google/api"
 import _ "github.com/mobiledgex/edge-cloud/protogen"
-import _ "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 import _ "github.com/gogo/protobuf/gogoproto"
 import _ "github.com/gogo/protobuf/types"
 

--- a/protoc-gen-mc2/genmc2.go
+++ b/protoc-gen-mc2/genmc2.go
@@ -422,7 +422,7 @@ func (g *GenMC2) generateMethod(service string, method *descriptor.MethodDescrip
 		g.importEcho = true
 		g.importContext = true
 		g.importOrmapi = true
-		if args.OrgValid {
+		if args.OrgValid || !args.Show {
 			g.importLog = true
 		}
 		if args.Outstream {
@@ -635,6 +635,10 @@ type {{.MethodName}}Authz interface {
 func {{.MethodName}}Stream(ctx context.Context, rc *RegionContext, obj *edgeproto.{{.InName}}, cb func(res *edgeproto.{{.OutName}})) error {
 {{- else}}
 func {{.MethodName}}Obj(ctx context.Context, rc *RegionContext, obj *edgeproto.{{.InName}}) (*edgeproto.{{.OutName}}, error) {
+{{- end}}
+{{- if (not .Show)}}
+	{{- /* don't set tags for show because create/etc may call shows, which end up adding unnecessary blank tags */}}
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 {{- end}}
 {{- if (not .SkipEnforce)}}
 {{- if and .Show .CustomAuthz}}


### PR DESCRIPTION
This is a set of changes to make it easier to search audit logs.
- The audit logs API can now filter by operation name and tags. The tags is typically the key tags add to the MC API based on the request object, i.e. app=demoapp or apporg=AcmeAppCo. Operation name is something like /api/v1/auth/ctrl/CreateAppInst. Both can be specified at the same time, so one could search for all CreateAppInst commands for app=demoapp.
- The audit log API output now includes the key tags, and the org used for RBAC. This change is easiest to see in the e2e-test expected output file changes.
- There is now also an "operations" MC audit API that outputs the operations that can be searched on.

Examples:
```
 mcctl --addr https://localhost:9900 --skipverify audit operations
- /api/v1/auth/config/update
- /api/v1/auth/controller/create
- /api/v1/auth/ctrl/CreateApp
- /api/v1/auth/ctrl/CreateAppInst
- /api/v1/auth/ctrl/CreateAutoProvPolicy
- /api/v1/auth/ctrl/CreateAutoScalePolicy
- /api/v1/auth/ctrl/CreateCloudlet
- /api/v1/auth/ctrl/CreateCloudletPool
- /api/v1/auth/ctrl/CreateClusterInst
- /api/v1/auth/ctrl/CreateFlavor
- /api/v1/auth/ctrl/CreateOperatorCode
- /api/v1/auth/ctrl/ShowSettings
- /api/v1/auth/ctrl/UpdateSettings
- /api/v1/auth/org/create
- /api/v1/auth/orgcloudletpool/create
- /api/v1/auth/role/adduser
- /api/v1/login
- /api/v1/usercreate
```
```
 mcctl --addr https://localhost:9900 --skipverify audit showorg limit=3 operation="/api/v1/auth/ctrl/CreateAppInst"
- operationname: /api/v1/auth/ctrl/CreateAppInst
  username: user3
  clientip: 127.0.0.1
  status: 200
  starttime: "2020-08-07T09:36:33.739062-07:00"
  duration: 109.231ms
  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"user3org","name":"ep1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"enterprise","name":"enterprise-1"},"organ
ization":"user3org"}},"cloudlet_loc":{"latitude":31,"longitude":-91},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{}}}'
  response: |
    {"data":{"message":"Creating"}}
    {"data":{"message":"Creating App Inst"}}
    {"data":{"message":"Ready"}}
    {"data":{"message":"Created AppInst successfully"}}
  traceid: 537e243346f3377e
  tags:
    app: ep1
    apporg: user3org
    appver: "1.0"
    cloudlet: enterprise-1
    cloudletorg: enterprise
    cluster: SmallCluster
    clusterorg: user3org
```
```
 mcctl --addr https://localhost:9900 --skipverify audit showself limit=1 tags=cloudletorg=azure
- operationname: /api/v1/auth/ctrl/CreateClusterInst
  username: mexadmin
  clientip: 127.0.0.1
  status: 200
  starttime: "2020-08-07T09:36:29.609901-07:00"
  duration: 251.752ms
  request: '{"Region":"local","ClusterInst":{"key":{"cluster_key":{"name":"Reservable3"},"cloudlet_key":{"organization":"azure","name":"azure-cloud-4"},"organization":"MobiledgeX"},"flavor":{"name":"x1.small"},"liveness":1,"ip_access":1,"node_fla
vor":"x1.small","num_masters":1,"num_nodes":1,"status":{},"reservable":true}}'
  response: |
    {"data":{"message":"Creating"}}
    {"data":{"message":"First Create Task"}}
    {"data":{"message":"Second Create Task"}}
    {"data":{"message":"Ready"}}
    {"data":{"message":"Created ClusterInst successfully"}}
  traceid: 4372c75f85c75293
  tags:
    cloudlet: azure-cloud-4
    cloudletorg: azure
    cluster: Reservable3
    clusterorg: MobiledgeX
```