### PR TITLE
EDGECLOUD-3401 disallow cloudetpool delete if in use

### DIFF
--- a/mc/orm/authz_cloudletpool.go
+++ b/mc/orm/authz_cloudletpool.go
@@ -9,7 +9,7 @@ import (
 )
 
 func authzDeleteCloudletPool(ctx context.Context, region, username string, obj *edgeproto.CloudletPool, resource, action string) error {
-	if err := authorized(ctx, username, "", resource, action); err != nil {
+	if err := authorized(ctx, username, obj.Key.Organization, resource, action); err != nil {
 		return err
 	}
 
@@ -17,7 +17,7 @@ func authzDeleteCloudletPool(ctx context.Context, region, username string, obj *
 	pools := make([]ormapi.OrgCloudletPool, 0)
 	db := loggedDB(ctx)
 	// explicitly list fields to avoid being ignored if 0 or emtpy string
-	res := db.Where(map[string]interface{}{"region": region, "cloudlet_pool": obj.Key.Name}).Find(&pools)
+	res := db.Where(map[string]interface{}{"region": region, "cloudlet_pool": obj.Key.Name, "cloudlet_pool_org": obj.Key.Organization}).Find(&pools)
 	if res.Error != nil {
 		return res.Error
 	}

--- a/mc/orm/cloudletpool.mc2.go
+++ b/mc/orm/cloudletpool.mc2.go
@@ -98,7 +98,7 @@ func DeleteCloudletPool(c echo.Context) error {
 
 func DeleteCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletPool) (*edgeproto.Result, error) {
 	if !rc.skipAuthz {
-		if err := authorized(ctx, rc.username, obj.Key.Organization,
+		if err := authzDeleteCloudletPool(ctx, rc.region, rc.username, obj,
 			ResourceCloudletPools, ActionManage); err != nil {
 			return nil, err
 		}

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -421,6 +421,12 @@ func TestController(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 
+	// trying to delete cloudletpool should fail because it's in use by orgcloudletpool
+	_, status, err = mcClient.DeleteCloudletPool(uri, tokenOper, &pool)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, err.Error(), "because it is in use by OrgCloudletPool")
+
 	// add tc3 to pool1, so it's accessible for org1
 	member := ormapi.RegionCloudletPoolMember{
 		Region:             ctrl.Region,


### PR DESCRIPTION
Regression fix: disallow CloudletPool delete if it is in use by OrgCloudletPool. Restore use of custom authz for delete and include new CloudletPoolOrg field in search. Also add unit test.