### PR TITLE
Multi datastore fix

### DIFF
--- a/crm-platforms/vsphere/vsphere-orch.go
+++ b/crm-platforms/vsphere/vsphere-orch.go
@@ -366,6 +366,7 @@ func (v *VSpherePlatform) CreateVM(ctx context.Context, vm *vmlayer.VMOrchestrat
 	log.SpanLog(ctx, log.DebugLevelInfra, "CreateVM", "vmName", vm.Name, "poolName", poolName)
 
 	dcName := v.GetDatacenterName(ctx)
+	dsName := v.GetDataStore()
 	computeCluster := v.GetComputeCluster()
 	pathPrefix := fmt.Sprintf("/%s/host/%s/Resources/", dcName, computeCluster)
 	poolPath := pathPrefix + poolName
@@ -398,6 +399,7 @@ func (v *VSpherePlatform) CreateVM(ctx context.Context, vm *vmlayer.VMOrchestrat
 		}
 		out, err := v.TimedGovcCommand(ctx, "govc", "vm.clone",
 			"-dc", dcName,
+			"-ds", dsName,
 			"-on=false",
 			"-vm", vm.ImageName,
 			"-pool", poolPath,


### PR DESCRIPTION
EDGECLOUD-3387

If there are multiple datastores in the vSphere VDC, VM clone fails because one must be specified and cannot be defaulted.