### PR TITLE
Fix GetCloudletManifest for RestrictedAccess

### DIFF
--- a/crm-platforms/openstack/openstack-secrule.go
+++ b/crm-platforms/openstack/openstack-secrule.go
@@ -230,6 +230,7 @@ func (s *OpenstackPlatform) GetSecurityGroupIDForProject(ctx context.Context, gr
 	if err != nil {
 		return "", err
 	}
+	grpId := ""
 	for _, g := range grps {
 		if g.Name == grpname {
 			if g.Project == projectID {
@@ -239,10 +240,14 @@ func (s *OpenstackPlatform) GetSecurityGroupIDForProject(ctx context.Context, gr
 			if g.Project == "" {
 				// This is an openstack bug in some environments in which it may not show the project ids when listing the group
 				// all we can do is hope for no conflicts in this case
-				log.SpanLog(ctx, log.DebugLevelInfra, "Warning: no project id returned for security group", "group", grpname)
-				return g.ID, nil
+				// Use this group ID, if no other ID found
+				grpId = g.ID
 			}
 		}
+	}
+	if grpId != "" {
+		log.SpanLog(ctx, log.DebugLevelInfra, "Warning: no project id returned for security group", "group", grpname)
+		return grpId, nil
 	}
 	return "", fmt.Errorf("%s: %s project %s", SecgrpDoesNotExist, grpname, projectID)
 }

--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -654,9 +654,12 @@ func (v *VMPlatform) GetCloudletVMsSpec(ctx context.Context, vaultConfig *vault.
 	}
 
 	platformVmName := v.GetPlatformVMName(&cloudlet.Key)
-	pfImageName, err := v.GetCloudletImageToUse(ctx, updateCallback)
-	if err != nil {
-		return nil, err
+	pfImageName := v.VMProperties.GetCloudletOSImage()
+	if cloudlet.InfraApiAccess == edgeproto.InfraApiAccess_DIRECT_ACCESS {
+		pfImageName, err = v.GetCloudletImageToUse(ctx, updateCallback)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Setup Chef parameters

--- a/vmlayer/vmparams.go
+++ b/vmlayer/vmparams.go
@@ -500,10 +500,15 @@ func (v *VMPlatform) getVMGroupOrchestrationParamsFromGroupSpec(ctx context.Cont
 	internalNetId := v.VMProvider.NameSanitize(internalNetName)
 	externalNetName := v.VMProperties.GetCloudletExternalNetwork()
 
+	var err error
+
 	// DNS is applied either at the subnet or VM level
 	vmDns := ""
 	subnetDns := []string{}
-	cloudletSecGrpID, err := v.VMProvider.GetResourceID(ctx, ResourceTypeSecurityGroup, v.VMProperties.GetCloudletSecurityGroupName())
+	cloudletSecGrpID := v.VMProperties.GetCloudletSecurityGroupName()
+	if !spec.SkipDefaultSecGrp {
+		cloudletSecGrpID, err = v.VMProvider.GetResourceID(ctx, ResourceTypeSecurityGroup, v.VMProperties.GetCloudletSecurityGroupName())
+	}
 	internalSecgrpID := ""
 	internalSecgrpPreexisting := false
 


### PR DESCRIPTION
* GetCloudletManifest was failing because we were calling Infra specific calls. I found this after testing it with BT's Ipswich openRC file. It was not caught till now because QA team was testing with TDG setup (and so did I).
* This is a regression, it was working before and works fine in 2.1

* Also, fixed the code to get security group ID. Use group ID with no project ID ONLY if there is no other group ID.