### PR TITLE
EDGECLOUD-3265 autoprov failover req always handle

### DIFF
--- a/autoprov/autoprov_minmax_test.go
+++ b/autoprov/autoprov_minmax_test.go
@@ -514,6 +514,17 @@ func TestAppChecker(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "timeout waiting for AutoProvInfo")
 	}
+	// Also make sure reply is received even if state is already in maintenance
+	cacheData.cloudletCache.Update(ctx, &cloudlet0, 0)
+	select {
+	case failover := <-failovers:
+		require.Equal(t, cloudlet0.Key, failover.Key)
+		require.Equal(t, edgeproto.MaintenanceState_FAILOVER_DONE, failover.MaintenanceState)
+		require.Equal(t, 0, len(failover.Errors))
+		require.Equal(t, 0, len(failover.Completed))
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for AutoProvInfo")
+	}
 }
 
 type policyTest struct {

--- a/mc/orm/cloudlet.mc2.go
+++ b/mc/orm/cloudlet.mc2.go
@@ -503,6 +503,7 @@ func GetCloudletProps(c echo.Context) error {
 }
 
 func GetCloudletPropsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.CloudletProps) (*edgeproto.CloudletProps, error) {
+	log.SetContextTags(ctx, edgeproto.GetTags(obj))
 	if !rc.skipAuthz {
 		if err := authorized(ctx, rc.username, "",
 			ResourceCloudlets, ActionView); err != nil {


### PR DESCRIPTION
Some further modifications for failover request handling. I've modified the code to always handle a failover request, even if AutoProv thinks the cloudlet is already in maintenance. The old code ignored FAILOVER_REQUEST if there was no "online" change.