### PR TITLE
set project and zone

### DIFF
--- a/crm-platforms/gcp/gcp.go
+++ b/crm-platforms/gcp/gcp.go
@@ -128,6 +128,14 @@ func (g *GCPPlatform) Login(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	err = g.SetProject(ctx, g.GetGcpProject())
+	if err != nil {
+		return err
+	}
+	err = g.SetZone(ctx, g.GetGcpZone())
+	if err != nil {
+		return err
+	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "GCP login OK")
 	return nil
 }


### PR DESCRIPTION
EDGECLOUD-3326

GCP project and zone were not being set; still works local mac test but not in the actual k8s CRM deployment without setting these.