### PR TITLE
Revert base image version

### DIFF
--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -28,7 +28,7 @@ type VMProperties struct {
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "3.1.7"
+var MEXInfraVersion = "3.1.6"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
* Reverting image version, because i'm unable to build new one. This is because Berlin setup has some issues. Just so that regressions should not fail, i'm reverting the version change. Once berlin setup is up, will move this version back to 3.1.7.