### PR TITLE
EDGECLOUD-3500 Creation of docker compose based App Instance fails

### DIFF
--- a/openstack-tenant/packages/docker-compose/Makefile
+++ b/openstack-tenant/packages/docker-compose/Makefile
@@ -1,6 +1,7 @@
 PACKAGE = docker-compose
 VERSION = 1.24.1
 SHA256SUM = cfb3439956216b1248308141f7193776fcf4b9c9b49cbbe2fb07885678e2bb8a
+MEXVERSION = mobiledgex1
 
 DISTRIBUTION = cirrus
 COMPONENT = main
@@ -8,17 +9,19 @@ COMPONENT = main
 PKGURL = https://github.com/docker/compose/releases/download/$(VERSION)/docker-compose-Linux-x86_64
 DOWNLOAD = docker-compose
 
-PKGDIR = $(PACKAGE)_$(VERSION)
+PKGDIR = $(PACKAGE)_$(VERSION)-$(MEXVERSION)
 
 all: setup_files
-	../build.sh $(PACKAGE) $(VERSION) $(DISTRIBUTION) $(COMPONENT)
+	../build.sh $(PACKAGE) $(VERSION)-$(MEXVERSION) $(DISTRIBUTION) $(COMPONENT)
 
 setup_files:
 	mkdir $(PKGDIR)
-	mkdir -p $(PKGDIR)/usr/local/bin
+	mkdir -p $(PKGDIR)/usr/local/bin $(PKGDIR)/usr/local/lib
 	wget -O $(DOWNLOAD) $(PKGURL)
 	test `sha256sum $(DOWNLOAD) | awk '{print $$1}'` == $(SHA256SUM)
-	mv $(DOWNLOAD) $(PKGDIR)/usr/local/bin
+	mv $(DOWNLOAD) $(PKGDIR)/usr/local/lib/$(DOWNLOAD)
+	chmod a+x $(PKGDIR)/usr/local/lib/$(DOWNLOAD)
+	cp docker-compose.wrapper $(PKGDIR)/usr/local/bin/$(DOWNLOAD)
 	chmod a+x $(PKGDIR)/usr/local/bin/$(DOWNLOAD)
 
 clean:

--- a/openstack-tenant/packages/docker-compose/docker-compose.wrapper
+++ b/openstack-tenant/packages/docker-compose/docker-compose.wrapper
@@ -1,0 +1,2 @@
+#!/bin/sh
+TMPDIR=/var/tmp exec /usr/local/lib/docker-compose "$@"

--- a/openstack-tenant/packages/docker-compose/postinst
+++ b/openstack-tenant/packages/docker-compose/postinst
@@ -1,2 +1,4 @@
 #!/bin/bash
-chown root:root /usr/local/bin/docker-compose
+chown root:root \
+	/usr/local/bin/docker-compose \
+	/usr/local/lib/docker-compose

--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.0.3
+VERSION = 4.0.4
 DISTRIBUTION = cirrus
 COMPONENT = main
 

--- a/openstack-tenant/packages/mobiledgex/dependencies.common
+++ b/openstack-tenant/packages/mobiledgex/dependencies.common
@@ -4,7 +4,7 @@ cloud-init                      19.3-41-gc4735dd3-0ubuntu1~18.04.1
 crictl                          1.16.1
 curl                            7.58.0-2ubuntu3.8
 docker-ce                       5:19.03.4~3-0~ubuntu-xenial
-docker-compose                  1.24.1
+docker-compose                  1.24.1-mobiledgex1
 libpam-google-authenticator     20170702-1
 helm                            2.15.2
 iptables-persistent             1.0.4+nmu2ubuntu1

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -28,7 +28,7 @@ type VMProperties struct {
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.0.3"
+var MEXInfraVersion = "4.0.4"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
Docker Compose is packaged using PyInstaller which unpacks its python
runtime in /tmp and executes it there.  However, CIS hardening and
general security recommendations require /tmp to be mounted with the
"noexec" option which disallows executables within that mount point.

Enabling "exec" in /tmp is not recommended, and setting TMPDIR globally
affects all apps which would run on the VM. Hence, wrapping
docker-compose in a script which sets up TMPDIR just for it.  The actual
docker-compose binary is installed in /usr/local/lib.