### PR TITLE
EDGECLOUD-3284: CreateCloudlet does not cleanup if using bad accessvars

### DIFF
--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -384,7 +384,7 @@ func (v *VMPlatform) DeleteCloudletAccessVars(ctx context.Context, cloudlet *edg
 	if err != nil {
 		return err
 	}
-	path := GetVaultCloudletAccessPath(&cloudlet.Key, v.Type, pfConfig.Region, cloudlet.PhysicalName, v.VMProvider.GetApiAccessFilename())
+	path := GetVaultCloudletAccessPath(&cloudlet.Key, pfConfig.Region, v.Type, cloudlet.PhysicalName, v.VMProvider.GetApiAccessFilename())
 	err = infracommon.DeleteDataFromVault(vaultConfig, path)
 	if err != nil {
 		return fmt.Errorf("Failed to delete access vars from vault: %v", err)


### PR DESCRIPTION
* Deletion of AccessVars was failing because of incorrectly passing args to fetch vault path