### PR TITLE
vSphere server ready

### DIFF
--- a/crm-platforms/openstack/openstack-server.go
+++ b/crm-platforms/openstack/openstack-server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
+	ssh "github.com/mobiledgex/golang-ssh"
 )
 
 func (o *OpenstackPlatform) GetServerDetail(ctx context.Context, serverName string) (*vmlayer.ServerDetail, error) {
@@ -335,5 +336,10 @@ func (s *OpenstackPlatform) GetPlatformResourceInfo(ctx context.Context) (*vmlay
 }
 
 func (s *OpenstackPlatform) VerifyVMs(ctx context.Context, vms []edgeproto.VM) error {
+	return nil
+}
+
+func (s *OpenstackPlatform) CheckServerReady(ctx context.Context, client ssh.Client, serverName string) error {
+	// no special checks to be done
 	return nil
 }

--- a/crm-platforms/vmpool/vmpool-provider.go
+++ b/crm-platforms/vmpool/vmpool-provider.go
@@ -599,3 +599,8 @@ func (s *VMPoolPlatform) VerifyVMs(ctx context.Context, vms []edgeproto.VM) erro
 
 	return nil
 }
+
+func (s *VMPoolPlatform) CheckServerReady(ctx context.Context, client ssh.Client, serverName string) error {
+	// no special checks to be done
+	return nil
+}

--- a/crm-platforms/vsphere/vsphere-security.go
+++ b/crm-platforms/vsphere/vsphere-security.go
@@ -13,13 +13,11 @@ import (
 
 func (v *VSpherePlatform) WhitelistSecurityRules(ctx context.Context, client ssh.Client, secGrpName, serverName, label string, allowedCIDR string, ports []dme.AppPort) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "WhitelistSecurityRules", "secGrpName", secGrpName, "allowedCIDR", allowedCIDR, "ports", ports)
-
 	// this can be called during LB init so we need to ensure we can reach the server before trying iptables commands
-	err := vmlayer.WaitServerSSHReachable(ctx, client, serverName, vmlayer.SSHReachableDefaultTimeout)
+	err := vmlayer.WaitServerReady(ctx, v, client, serverName, vmlayer.MaxRootLBWait)
 	if err != nil {
 		return err
 	}
-
 	return vmlayer.AddIngressIptablesRules(ctx, client, label, allowedCIDR, ports)
 }
 

--- a/crm-platforms/vsphere/vsphere.go
+++ b/crm-platforms/vsphere/vsphere.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
+	ssh "github.com/mobiledgex/golang-ssh"
 )
 
 type VSpherePlatform struct {
@@ -206,4 +207,15 @@ func (v *VSpherePlatform) GetPlatformResourceInfo(ctx context.Context) (*vmlayer
 	platformRes.NetRecv = mets.BytesRxAverage * mets.Interval
 	platformRes.NetSent = mets.BytesTxAverage * mets.Interval
 	return &platformRes, nil
+}
+
+func (s *VSpherePlatform) CheckServerReady(ctx context.Context, client ssh.Client, serverName string) error {
+	// for vSphere in the current baseimage, there is a second reboot performed by vCenter after the initial
+	// guest customization.  This generally happens a few seconds after the VM is reachable so just checking that
+	// the VM is up is not sufficient as it may go back down.  Checking that the VM is ready relies on the fact that the
+	// mobiledgex init script will be executed a second time after it has finished its job with the init-done flag set.  When
+	// this happens, the mobiledgex service exits with exitcode = 2
+	out, err := client.Output("systemctl status mobiledgex.service|grep status=2")
+	log.SpanLog(ctx, log.DebugLevelInfra, "CheckServerReady Mobiledgex service status", "serverName", serverName, "out", out, "err", err)
+	return err
 }

--- a/vmlayer/server.go
+++ b/vmlayer/server.go
@@ -3,10 +3,12 @@ package vmlayer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
+	ssh "github.com/mobiledgex/golang-ssh"
 )
 
 type NetworkType string
@@ -171,5 +173,35 @@ func (v *VMPlatform) SetPowerState(ctx context.Context, app *edgeproto.App, appI
 	default:
 		return fmt.Errorf("unsupported deployment type %s", deployment)
 	}
+	return nil
+}
+
+// WaitServerReady waits up to the specified duration for the server to be reachable via SSH
+// and pass any additional checks from the provider
+func WaitServerReady(ctx context.Context, provider VMProvider, client ssh.Client, server string, timeout time.Duration) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "WaitServerReady", "server", server)
+	start := time.Now()
+	for {
+		out, err := client.Output("sudo grep 'Finished mobiledgex init' /var/log/mobiledgex.log")
+		log.SpanLog(ctx, log.DebugLevelInfra, "grep Finished mobiledgex init result", "out", out, "err", err)
+		if err == nil {
+			log.SpanLog(ctx, log.DebugLevelInfra, "Server has completed mobiledgex init", "server", server)
+			// perform any additional checks from the provider
+			err = provider.CheckServerReady(ctx, client, server)
+			log.SpanLog(ctx, log.DebugLevelInfra, "CheckServerReady result", "err", err)
+			if err == nil {
+				break
+			}
+		}
+		log.SpanLog(ctx, log.DebugLevelInfra, "server not ready", "err", err)
+		elapsed := time.Since(start)
+		if elapsed > timeout {
+			return fmt.Errorf("timed out waiting for VM %s", server)
+		}
+		log.SpanLog(ctx, log.DebugLevelInfra, "sleeping 10 seconds before retry", "elapsed", elapsed, "timeout", timeout)
+		time.Sleep(10 * time.Second)
+
+	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "WaitServerReady OK", "server", server)
 	return nil
 }

--- a/vmlayer/ssh.go
+++ b/vmlayer/ssh.go
@@ -15,8 +15,6 @@ import (
 	"github.com/tmc/scp"
 )
 
-const SSHReachableDefaultTimeout = 2 * time.Minute
-
 type SSHOptions struct {
 	Timeout time.Duration
 	User    string
@@ -157,29 +155,4 @@ func SCPFilePath(sshClient ssh.Client, srcPath, dstPath string) error {
 	defer sessionInfo.CloseAll()
 	err = scp.CopyPath(srcPath, dstPath, session)
 	return err
-}
-
-// WaitServerSSHReachable waits up to the specified duration for the server to be reachable via
-// SSH. The server passed here is just for logging it can be an ip or a name
-func WaitServerSSHReachable(ctx context.Context, client ssh.Client, server string, timeout time.Duration) error {
-	log.SpanLog(ctx, log.DebugLevelInfra, "WaitServerSSHReachable", "server", server)
-	start := time.Now()
-	for {
-		out, err := client.Output(fmt.Sprintf("whoami"))
-		if err == nil {
-			break
-		} else {
-			log.SpanLog(ctx, log.DebugLevelInfra, "error waiting for server", "out", out, "error", err)
-			// errors received when trying to reach a server which is is coming up vary from OS version to version.
-			// Keep trying until the timeout period for any error
-			elapsed := time.Since(start)
-			if elapsed > timeout {
-				return fmt.Errorf("timed out connecting to VM %s", server)
-			}
-			log.SpanLog(ctx, log.DebugLevelInfra, "sleeping 10 seconds before retry", "elapsed", elapsed, "timeout", timeout)
-			time.Sleep(10 * time.Second)
-		}
-	}
-	log.SpanLog(ctx, log.DebugLevelInfra, "WaitServerSSHReachable OK", "server", server)
-	return nil
 }

--- a/vmlayer/vmprovider.go
+++ b/vmlayer/vmprovider.go
@@ -55,6 +55,7 @@ type VMProvider interface {
 	GetVMStats(ctx context.Context, key *edgeproto.AppInstKey) (*VMMetrics, error)
 	GetPlatformResourceInfo(ctx context.Context) (*PlatformResources, error)
 	VerifyVMs(ctx context.Context, vms []edgeproto.VM) error
+	CheckServerReady(ctx context.Context, client ssh.Client, serverName string) error
 }
 
 // VMPlatform contains the needed by all VM based platforms


### PR DESCRIPTION
EDGECLOUD-3504

In the new baseimage, an intermittent issue is seen with dedicated rootLBs as follows:
- A few seconds after the server comes online, vCenter reboots it again to complete the customization process.  The server is briefly reachable before this reboot, but then becomes unreachable again.  This causes the existing WaitServerSSHReachable check to be unreliable because VM is reachable one moment and not reachable a little later on.  Prior to 1804 the reboot still happened, but the server was not reachable beforehand so it did not cause an issue.

It's tricky to know when this reboot has been done because it's initiated by vCenter aside from just waiting some fixed amount of time.   The best method I could come up with to detect that this last reboot has been performed is rely on the behavior of the mobiledgex-init.sh script which will exit with a code=2 when it is executed a second time. 

OpenStack and other platforms do not perform this additional reboot, so I created a means for the provider to indicate that some special check must be performed for readiness, "CheckServerReady".   If no special handling is done, this function can just return.

Also consolidated the server wait code from WaitForRootLB into the new function called  WaitServerReady, which performs the original check for "Finished mobiledgex init" plus any provider-specific check.

