### PR TITLE
fix icmp privacy policy and vcores metrics

### DIFF
--- a/crm-platforms/vsphere/vsphere.go
+++ b/crm-platforms/vsphere/vsphere.go
@@ -152,7 +152,7 @@ func (v *VSpherePlatform) GetPlatformResourceInfo(ctx context.Context) (*vmlayer
 
 	for _, hs := range hosts.HostSystems {
 		platformRes.MemMax = platformRes.MemMax + hs.Hardware.MemorySize
-		platformRes.VCpuMax = platformRes.VCpuMax + hs.Hardware.CpuInfo.NumCpuCores
+		platformRes.VCpuMax = platformRes.VCpuMax + hs.Hardware.CpuInfo.NumCpuThreads
 	}
 	// convert to MB
 	if platformRes.MemMax > 0 {

--- a/vmlayer/iptables.go
+++ b/vmlayer/iptables.go
@@ -154,7 +154,7 @@ func getIpTablesEntryForRule(ctx context.Context, direction string, label string
 		}
 	}
 	portStr := ""
-	if rule.PortRange != "" {
+	if rule.PortRange != "" && rule.PortRange != "0" {
 		portStr = "--" + string(rule.PortEndpoint) + " " + rule.PortRange
 	}
 	icmpType := ""

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -126,12 +126,11 @@ var VMProviderProps = map[string]*edgeproto.PropertyInfo{
 	"MEX_CLOUDLET_FIREWALL_WHITELIST_EGRESS": {
 		Name:        "Cloudlet Firewall Whitelist Egress",
 		Description: "Firewall rule to whitelist egress traffic",
-		Value:       "protocol=tcp,portrange=1:65535,remotecidr=0.0.0.0/0;protocol=udp,portrange=1:65535,remotecidr=0.0.0.0/0;protocol=icmp,remotecidr=0.0.0.0/0",
+		Value:       "protocol=tcp,portrange=443,remotecidr=0.0.0.0/0;protocol=udp,portrange=53,remotecidr=0.0.0.0/0;protocol=icmp,remotecidr=0.0.0.0/0",
 	},
 	"MEX_CLOUDLET_FIREWALL_WHITELIST_INGRESS": {
 		Name:        "Cloudlet Firewall Whitelist Ingress",
 		Description: "Firewall rule to whitelist ingress traffic",
-		Value:       "remotecidr=0.0.0.0/0,protocol=udp,portrange=53",
 	},
 }
 


### PR DESCRIPTION
- EDGECLOUD-3507: ICMP privacy policy rules creates an error because there is no destination port.  Also related to Privacy Policy: change the default cloudlet-wide rule to only allow HTTPS and DNS by default
- EDGECLOUD-3186: vSphere cloudlet stats show physical cores instead of logical cores.
