### PR TITLE
Increase cert verification depth in Jaeger mTLS

### DIFF
--- a/ansible/templates/internal/jaeger/nginx-config.j2
+++ b/ansible/templates/internal/jaeger/nginx-config.j2
@@ -54,6 +54,7 @@ server {
         ssl_certificate_key {{ letsencrypt_root }}/{{ inventory_hostname }}/privkey.pem;
         ssl_client_certificate {{ mex_ca_cert_path }};
         ssl_verify_client on;
+        ssl_verify_depth 2;
         ssl_session_cache shared:le_nginx_SSL:1m;
         ssl_session_cache shared:le_nginx_SSL:1m;
         ssl_protocols TLSv1.2;
@@ -81,6 +82,7 @@ server {
         ssl_certificate_key {{ letsencrypt_root }}/{{ inventory_hostname }}/privkey.pem;
         ssl_client_certificate {{ mex_ca_cert_path }};
         ssl_verify_client on;
+        ssl_verify_depth 2;
         ssl_session_cache shared:le_nginx_SSL:1m;
         ssl_session_cache shared:le_nginx_SSL:1m;
         ssl_protocols TLSv1.2;


### PR DESCRIPTION
Allow validation of intermediate CA certificates

To test (using the dev setup):
```
ROLE_ID="role ID of regional controller or CRM"
SECRET_ID="secret ID of regional controller or CRM"

$ export VAULT_ADDR=https://vault-dev.mobiledgex.net
$ TOKEN=$( vault write -field=token \
               auth/approle/login role_id=$ROLE_ID secret_id=$SECRET_ID )
$ vault login $TOKEN

$ vault write -format=json pki-regional-cloudlet/issue/EU \
      common_name=test.mobiledgex.net >cert.json
$ jq -r .data.certificate cert.json >cert
$ jq -r .data.private_key cert.json >key

$ curl -I --cert cert --key key https://jaeger-dev.mobiledgex.net:16686
HTTP/1.1 200 OK
```