### PR TITLE
Elasticsearch mTLS proxy using vault internal PKI

### DIFF
--- a/ansible/main/group_vars/all
+++ b/ansible/main/group_vars/all
@@ -1,6 +1,7 @@
 mc_artifactory_address: https://artifactory.mobiledgex.net/artifactory
 jaeger_hostname: jaeger.mobiledgex.net
 jaeger_endpoint: "https://{{ jaeger_hostname }}:14268/api/traces"
+events_elasticsearch_url: https://3dd88757c3df44ac8960e53fc6a9a2d5.us-central1.gcp.cloud.es.io:9243
 console_vnc_hostname: console-vnc.mobiledgex.net
 notifyroot_hostname: notifyroot.mobiledgex.net
 vault_address: https://vault-main.mobiledgex.net

--- a/ansible/main/list
+++ b/ansible/main/list
@@ -38,3 +38,6 @@ vault-main-b.mobiledgex.net
 
 [jaeger]
 jaeger.mobiledgex.net		es_instance=main
+
+[esproxy]
+es.mobiledgex.net

--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -245,3 +245,14 @@
 
     - import_role:
         name: jaeger
+
+- hosts: esproxy
+  tasks:
+    - import_role:
+        name: telegraf
+      tags:
+        - monitoring
+        - setup
+
+    - import_role:
+        name: esproxy

--- a/ansible/roles/esproxy/README.md
+++ b/ansible/roles/esproxy/README.md
@@ -1,0 +1,26 @@
+## Creating an API key for esproxy
+
+```
+http --auth elastic POST https://3dd88757c3df44ac8960e53fc6a9a2d5.us-central1.gcp.cloud.es.io:9243/_security/api_key <<EOT
+{
+  "name": "esproxy",
+  "role_descriptors": {
+    "esproxy": {
+      "cluster": [ "monitor" ],
+      "index": [
+        {
+          "names": [ "events-*" ],
+          "privileges": [
+            "create",
+            "create_index",
+            "write",
+            "read",
+            "monitor"
+          ]
+        }
+      ]
+    }
+  }
+}
+EOT
+```

--- a/ansible/roles/esproxy/tasks/main.yml
+++ b/ansible/roles/esproxy/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Load esproxy creds
+  import_role:
+    name: load-vault-creds
+    tasks_from: esproxy
+
+- name: Load CA certs
+  import_role:
+    name: vault
+    tasks_from: ca-certs
+  tags: setup
+
+- name: Set up reverse proxy
+  import_role:
+    name: web
+  vars:
+    nginx_config_template: nginx-config.j2
+    nginx_config_filename: esproxy
+    cert_domains:
+      - "{{ inventory_hostname }}"
+  tags: setup
+
+- name: Copy CA cert
+  copy:
+    dest: "{{ mex_ca_cert_path }}"
+    content: "{{ ca_certs | join('\n') }}"
+    backup: yes
+  become: yes
+  tags: setup

--- a/ansible/roles/esproxy/templates/nginx-config.j2
+++ b/ansible/roles/esproxy/templates/nginx-config.j2
@@ -1,0 +1,25 @@
+## Elasticsearch proxy, mTLS
+server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        ssl_certificate {{ letsencrypt_root }}/{{ inventory_hostname }}/fullchain.pem;
+        ssl_certificate_key {{ letsencrypt_root }}/{{ inventory_hostname }}/privkey.pem;
+        ssl_client_certificate {{ mex_ca_cert_path }};
+        ssl_verify_client on;
+        ssl_verify_depth 2;
+        ssl_session_cache shared:le_nginx_SSL:1m;
+        ssl_session_cache shared:le_nginx_SSL:1m;
+        ssl_protocols TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS";
+
+        server_name {{ inventory_hostname }};
+
+        proxy_buffering off;
+        proxy_read_timeout 30m;
+
+        location / {
+                proxy_pass         {{ events_elasticsearch_url }};
+                proxy_set_header   Authorization "ApiKey {{ esproxy_apikey }}";
+        }
+}

--- a/ansible/roles/esproxy/vars/main.yml
+++ b/ansible/roles/esproxy/vars/main.yml
@@ -1,0 +1,2 @@
+---
+mex_ca_cert_path: /etc/nginx/mex-ca.crt

--- a/ansible/roles/load-vault-creds/defaults/main.yml
+++ b/ansible/roles/load-vault-creds/defaults/main.yml
@@ -1,6 +1,7 @@
 artifactory_publish_account_path: secret/ansible/common/accounts/artifactory_publish
 azure_account_path: secret/ansible/common/accounts/azure
 cloudflare_account_path: secret/ansible/common/accounts/cloudflare
+esproxy_account_path: secret/ansible/common/accounts/esproxy
 gcp_account_path: secret/ansible/common/accounts/gcp
 locapi_account_path: secret/ansible/common/accounts/locapi
 mex_docker_account_path: secret/ansible/common/accounts/mex_docker

--- a/ansible/roles/load-vault-creds/tasks/esproxy.yml
+++ b/ansible/roles/load-vault-creds/tasks/esproxy.yml
@@ -1,0 +1,6 @@
+- name: Look up esproxy creds in vault
+  set_fact:
+    vault_lookup: "{{ lookup('vault', esproxy_account_path) }}"
+
+- set_fact:
+    esproxy_apikey: "{{ vault_lookup.esproxy.data.apikey }}"

--- a/ansible/roles/web/tasks/main.yml
+++ b/ansible/roles/web/tasks/main.yml
@@ -44,4 +44,4 @@
   become: yes
 
 - import_tasks: certs.yml
-  when: cert_domains|bool
+  when: cert_domains is defined and cert_domains|length > 0

--- a/terraform/internal/main.tf
+++ b/terraform/internal/main.tf
@@ -71,6 +71,12 @@ module "jaeger_dns" {
   ip                            = "${module.jaeger.external_ip}"
 }
 
+module "esproxy_dns" {
+  source                        = "../modules/cloudflare_record"
+  hostname                      = "${var.esproxy_domain_name}"
+  ip                            = "${module.jaeger.external_ip}"
+}
+
 module "apt" {
   source                        = "../modules/vm_gcp"
 

--- a/terraform/internal/variables.tf
+++ b/terraform/internal/variables.tf
@@ -71,20 +71,8 @@ variable "jaeger_domain_name" {
   default     = "jaeger.mobiledgex.net"
 }
 
-variable "elasticsearch_instance_name" {
-  default     = "elasticsearch"
-}
-
-variable "elasticsearch_gcp_zone" {
-  default     = "us-central1-a"
-}
-
-variable "elasticsearch_domain_name" {
-  default     = "es01.es.mobiledgex.net"
-}
-
-variable "kibana_domain_name" {
-  default     = "kibana.es.mobiledgex.net"
+variable "esproxy_domain_name" {
+  default     = "es.mobiledgex.net"
 }
 
 variable "infra_domain_name" {


### PR DESCRIPTION
The proxy is only set up in the main setup right now and is co-located with jaeger, though it has its own domain name -- es.mobiledgex.net.