### PR TITLE
remove escaped quotes from accessvars

### DIFF
--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -30,6 +30,10 @@ func (o *OpenstackPlatform) SaveCloudletAccessVars(ctx context.Context, cloudlet
 	}
 	accessVars := make(map[string]string)
 	for _, v := range out {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
 		out1 := strings.Split(v, "=")
 		if len(out1) != 2 {
 			return fmt.Errorf("Invalid separator for key-value pair: %v", out1)

--- a/crm-platforms/openstack/openstack_accessvars_test.go
+++ b/crm-platforms/openstack/openstack_accessvars_test.go
@@ -1,0 +1,89 @@
+package openstack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/vault"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccessVars(t *testing.T) {
+	log.InitTracer("")
+	defer log.FinishTracer()
+	log.SetDebugLevel(log.DebugLevelInfra)
+	ctx := log.StartTestSpan(context.Background())
+	ckey := edgeproto.CloudletKey{
+		Organization: "MobiledgeX",
+		Name:         "unit-test",
+	}
+	vaultServer, vaultConfig := vault.DummyServer()
+	defer vaultServer.Close()
+
+	accessVarsTestGood := make(map[string]string)
+	accessVarsTestGood["OPENRC_DATA"] = "OS_AUTH_URL=https://openstacktest.mobiledgex.net:5000/v3\nOS_PROJECT_ID=12345\nOS_PROJECT_NAME=\"mex\"\nOS_USER_DOMAIN_NAME=\"Default\"\nOS_PROJECT_DOMAIN_ID=\"default\"\nOS_USERNAME=\"mexadmin\"\nOS_PASSWORD=password123\nOS_REGION_NAME=\"RegionOne\"\nOS_INTERFACE=public\nOS_IDENTITY_API_VERSION=3"
+	accessVarsTestGood["CACERT_DATA"] = "XXXXXXXX"
+
+	accessVarsTestNoCert := make(map[string]string)
+	accessVarsTestNoCert["OPENRC_DATA"] = "OS_AUTH_URL=https://openstacktest.mobiledgex.net:5000/v3\nOS_PROJECT_ID=12345\nOS_PROJECT_NAME=\"mex\"\nOS_USER_DOMAIN_NAME=\"Default\"\nOS_PROJECT_DOMAIN_ID=\"default\"\nOS_USERNAME=\"mexadmin\"\nOS_PASSWORD=password123\nOS_REGION_NAME=\"RegionOne\"\nOS_INTERFACE=public\nOS_IDENTITY_API_VERSION=3"
+
+	accessVarsTestBadOSVar := make(map[string]string)
+	accessVarsTestBadOSVar["OPENRC_DATA"] = "OS_AUTH_URL=https://openstacktest.mobiledgex.net:5000/v3\nXX_PROJECT_ID=12345\nOS_PROJECT_NAME=\"mex\"\nOS_USER_DOMAIN_NAME=\"Default\"\nOS_PROJECT_DOMAIN_ID=\"default\"\nOS_USERNAME=\"mexadmin\"\nOS_PASSWORD=password123\nOS_REGION_NAME=\"RegionOne\"\nOS_INTERFACE=public\nOS_IDENTITY_API_VERSION=3"
+	accessVarsTestBadOSVar["CACERT_DATA"] = "XXXXXXXX"
+
+	accessVarsTestBlankLines := make(map[string]string)
+	accessVarsTestBlankLines["OPENRC_DATA"] = "\n\nOS_AUTH_URL=https://openstacktest.mobiledgex.net:5000/v3\n\n\n\nOS_PROJECT_ID=12345\nOS_PROJECT_NAME=\"mex\"\n\n\nOS_USER_DOMAIN_NAME=\"Default\"\n\nOS_PROJECT_DOMAIN_ID=\"default\"\nOS_USERNAME=\"mexadmin\"\nOS_PASSWORD=password123\nOS_REGION_NAME=\"RegionOne\"\nOS_INTERFACE=public\nOS_IDENTITY_API_VERSION=3"
+	accessVarsTestBlankLines["CACERT_DATA"] = "XXXXXXXX"
+
+	accessVarsTestBlankVars := make(map[string]string)
+	accessVarsTestBlankVars["OPENRC_DATA"] = "OS_AUTH_URL=https://openstacktest.mobiledgex.net:5000/v3\nOS_PROJECT_ID=12345\nOS_PROJECT_NAME=\"\"\nOS_USER_DOMAIN_NAME=\nOS_PROJECT_DOMAIN_ID=\"default\"\n=\"mexadmin\"\nOS_PASSWORD=password123\nOS_REGION_NAME=\"RegionOne\"\nOS_INTERFACE=public\nOS_IDENTITY_API_VERSION=3"
+	accessVarsTestBlankVars["CACERT_DATA"] = "XXXXXXXX"
+
+	accessVarsTestNoAuthURL := make(map[string]string)
+	accessVarsTestNoAuthURL["OPENRC_DATA"] = "OS_PROJECT_ID=12345\nOS_PROJECT_NAME=\"mex\"\nOS_USER_DOMAIN_NAME=\"Default\"\nOS_PROJECT_DOMAIN_ID=\"default\"\nOS_USERNAME=\"mexadmin\"\nOS_PASSWORD=password123\nOS_REGION_NAME=\"RegionOne\"\nOS_INTERFACE=public\nOS_IDENTITY_API_VERSION=3"
+	accessVarsTestNoAuthURL["CACERT_DATA"] = "XXXXXXXX"
+
+	var envvars = make(map[string]string)
+	envvars["VAULT_TOKEN"] = "dummy"
+	pc := edgeproto.PlatformConfig{
+		VaultAddr: vaultConfig.Addr,
+		EnvVar:    envvars,
+	}
+	op := OpenstackPlatform{TestMode: true}
+	o := vmlayer.VMPlatform{
+		Type:       "openstack",
+		VMProvider: &op,
+	}
+	var cloudlet = edgeproto.Cloudlet{
+		Key: ckey,
+	}
+	err := o.SaveCloudletAccessVars(ctx, &cloudlet, accessVarsTestGood, &pc, edgeproto.DummyUpdateCallback)
+	log.SpanLog(ctx, log.DebugLevelInfra, "accessVarsTestGood result", "err", err)
+	require.Nil(t, err)
+
+	err = o.SaveCloudletAccessVars(ctx, &cloudlet, accessVarsTestNoCert, &pc, edgeproto.DummyUpdateCallback)
+	log.SpanLog(ctx, log.DebugLevelInfra, "accessVarsTestNoCert result", "err", err)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "missing CACERT_DATA")
+
+	err = o.SaveCloudletAccessVars(ctx, &cloudlet, accessVarsTestBadOSVar, &pc, edgeproto.DummyUpdateCallback)
+	log.SpanLog(ctx, log.DebugLevelInfra, "accessVarsTestBadOSVar result", "err", err)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "must start with 'OS_' prefix")
+
+	err = o.SaveCloudletAccessVars(ctx, &cloudlet, accessVarsTestBlankLines, &pc, edgeproto.DummyUpdateCallback)
+	log.SpanLog(ctx, log.DebugLevelInfra, "accessVarsTestBlankLines result", "err", err)
+	require.Nil(t, err)
+
+	err = o.SaveCloudletAccessVars(ctx, &cloudlet, accessVarsTestBlankVars, &pc, edgeproto.DummyUpdateCallback)
+	log.SpanLog(ctx, log.DebugLevelInfra, "accessVarsTestBlankVars result", "err", err)
+	require.Nil(t, err)
+
+	err = o.SaveCloudletAccessVars(ctx, &cloudlet, accessVarsTestNoAuthURL, &pc, edgeproto.DummyUpdateCallback)
+	log.SpanLog(ctx, log.DebugLevelInfra, "accessVarsTestNoAuthURL result", "err", err)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "missing OS_AUTH_URL")
+}


### PR DESCRIPTION
EDGECLOUD-3419

When access vars are exported from openstack and input into the UI, they often have quotes, which get escaped and double quoted.   Remove all these escaped quotes as well as escaped-escapes 

