### PR TITLE
Close alertmgr-sidecar connection when done

### DIFF
--- a/mc/orm/alertmgr/alertmgr.go
+++ b/mc/orm/alertmgr/alertmgr.go
@@ -447,6 +447,8 @@ func alertMgrApi(ctx context.Context, addr, method, api, options string, payload
 		log.SpanLog(ctx, log.DebugLevelInfo, "Failed to create a new alerts request", "err", err, "url", apiUrl)
 		return nil, err
 	}
+	// Make sure that the connection is closed after we are done with it.
+	req.Close = true
 	req.Header.Set("User-Agent", getAgentName())
 	if method == http.MethodPost || method == http.MethodDelete {
 		req.Header.Set("Content-Type", "application/json")

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -262,7 +262,6 @@ func ConnectInfluxDB(ctx context.Context, region string) (influxdb.Client, error
 		return nil, err
 	}
 	return client, nil
-
 }
 
 func getInfluxDBAddrForRegion(ctx context.Context, region string) (string, error) {

--- a/shepherd/cloudlet-prom_test.go
+++ b/shepherd/cloudlet-prom_test.go
@@ -124,7 +124,8 @@ func genAppInstances(ctx context.Context, cnt int) ([]edgeproto.AppInst, map[str
 	list := []edgeproto.AppInst{}
 	keys := map[string]struct{}{}
 	for ii := 1; ii < cnt+1; ii++ {
-		ports, _ := edgeproto.ParseAppPorts(fmt.Sprintf("tcp:%d", ii))
+		// Start with port 1000, since some of the lower ports are not allowed(example - 22)
+		ports, _ := edgeproto.ParseAppPorts(fmt.Sprintf("tcp:%d", 1000+ii))
 		inst := edgeproto.AppInst{
 			Key: edgeproto.AppInstKey{
 				AppKey: edgeproto.AppKey{

--- a/shepherd/proxy-stats.go
+++ b/shepherd/proxy-stats.go
@@ -102,7 +102,7 @@ func getProxyContainerName(ctx context.Context, scrapePoint ProxyScrapePoint) (s
 }
 
 func CollectProxyStats(ctx context.Context, appInst *edgeproto.AppInst) string {
-	// ignore apps not exposed to the outside world as they dont have a envoy/nginx proxy
+	// ignore apps not exposed to the outside world as they don't have a envoy/nginx proxy
 	app := edgeproto.App{}
 	found := AppCache.Get(&appInst.Key.AppKey, &app)
 	if !found {


### PR DESCRIPTION
Golang htp library keeps keepalives going for connection reuse. Since we don't reuse the connection in alertMgrApi we should signal req to be closed when request has been completed. Without this fix e2e-test could actually exhaust max fds per process pretty quickly.

Also fixed shepherd unit-test that was failing because we disallow port 22 now.