### PR TITLE
fix forwarding iptables security

### DIFF
--- a/crm-platforms/vsphere/vsphere.go
+++ b/crm-platforms/vsphere/vsphere.go
@@ -29,6 +29,7 @@ func (v *VSpherePlatform) GetType() string {
 
 func (v *VSpherePlatform) SetVMProperties(vmProperties *vmlayer.VMProperties) {
 	v.vmProperties = vmProperties
+	vmProperties.IptablesBasedFirewall = true
 }
 
 func (v *VSpherePlatform) SetCaches(ctx context.Context, caches *platform.Caches) {

--- a/vmlayer/lb.go
+++ b/vmlayer/lb.go
@@ -192,7 +192,7 @@ func (v *VMPlatform) configureInternalInterfaceAndExternalForwarding(ctx context
 		}
 		if action.createIptables || action.deleteIptables {
 			if externalIfname != "" {
-				err = setupForwardingIptables(ctx, client, externalIfname, internalIfname, action)
+				err = v.setupForwardingIptables(ctx, client, externalIfname, internalIfname, action)
 				if err != nil {
 					log.SpanLog(ctx, log.DebugLevelInfra, "setupForwardingIptables failed", "err", err)
 				}

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -16,11 +16,12 @@ import (
 )
 
 type VMProperties struct {
-	CommonPf           infracommon.CommonPlatform
-	SharedRootLBName   string
-	sharedRootLB       *MEXRootLB
-	Domain             VMDomain
-	PlatformSecgrpName string
+	CommonPf              infracommon.CommonPlatform
+	SharedRootLBName      string
+	sharedRootLB          *MEXRootLB
+	Domain                VMDomain
+	PlatformSecgrpName    string
+	IptablesBasedFirewall bool
 }
 
 // note that qcow2 must be understood by vsphere and vmdk must


### PR DESCRIPTION
EDGECLOUD-3563

iptables security is not working for egress privacy policy based connections through the load balancer.  The reason is that the rules are created for the OUTPUT chain, but when routing egress traffic via the LB, the FORWARD chain applies.

The following changes are needed:
1) for iptables providers, do not open all FORWARD traffic when setting up the LB, for non-iptables providers, avoid changing anything by checking new IptablesBasedFirewall bool
2) for all egress rules, apply them to both the OUTPUT and FORWARD chains
