### PR TITLE
Add overrides as part of policyfile for main setup

### DIFF
--- a/chef/policyfiles/docker_crm.lock.json
+++ b/chef/policyfiles/docker_crm.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "d5c7bd6b82c74eb53a7a01fdc566955362a576cbe97ff0b8096b9cb6e64a1c51",
+  "revision_id": "85804fcb6fcf8c2672aa2fc0000d067b7c88708e4994d1f6269017ea460616c3",
   "name": "docker_crm",
   "run_list": [
     "recipe[runstatus_handler::default]",
@@ -71,7 +71,14 @@
 
   },
   "override_attributes": {
-
+    "main": {
+      "edgeCloudVersion": "2020-08-11",
+      "crmserver": {
+        "args": {
+          "commercialCerts": ""
+        }
+      }
+    }
   },
   "solution_dependencies": {
     "Policyfile": [

--- a/chef/policyfiles/docker_crm.rb
+++ b/chef/policyfiles/docker_crm.rb
@@ -15,3 +15,8 @@ cookbook 'setup_infra', '= 1.0.0'
 cookbook 'preflight_crm_checks', '= 1.0.0'
 cookbook 'setup_services', '= 1.0.10'
 cookbook 'docker', '= 6.0.3'
+
+# Set edgeCloudVersion (i.e. edge-cloud docker base image version) for all the cloudlets
+override['main']['edgeCloudVersion'] = '2020-08-11'
+# By default, commercialCerts is not on. Hence add override to turn it on for all the cloudlets
+override['main']['crmserver']['args']['commercialCerts'] = ""


### PR DESCRIPTION
* Added overrides as part of PolicyFile, so that none should accidentally push policyfiles with no overrides. This might lead to reverting crmservers to old version. Hence better to push overrides for main setup. Also, we can track the versions pushed as part of policyFiles.
* By default commercialCerts is not enabled. Added override to enable it for all main setups.

NOTE: I haven't pushed this policyFile as it will restart crmservers with no commericalCerts flag. Have listed them below:
```
❯ knife exec -E 'nodes.search("tags:deploytag/main AND tags:vmtype/platform") {|n| if !n.normal[:crmserver][:args].attribute?(:commercialCerts); puts "#{n.name}"; end}'
main-JP-kddilab-kddi-ope-pf
main-EU-O2-Germany-Telefonica-pf
main-JP-jp-west01-kddi-ope-pf
main-JP-ntt-oi-ntt-pf
main-JP-ntt-kw-ntt-pf
main-JP-kddilab-public-kddi-ope-pf
main-EU-edge2-madrid-tde-Telefonica-pf
main-EU-edge1-madrid-tde-Telefonica-pf
```
* Will let @bibingeorge1986 push this policyFile so that it doesn't affect developers using these cloudlets