### PR TITLE
Load alertmanager certs from letsencrypt directly

### DIFF
--- a/ansible/roles/alertmanager/tasks/main.yml
+++ b/ansible/roles/alertmanager/tasks/main.yml
@@ -23,22 +23,18 @@
       tasks_from: certs
   vars:
     cert_domains: [ "{{ inventory_hostname }}" ]
+    post_renewal_hooks:
+      - hook_name: alertmgr_restart
+        hook_content: "{{ lookup('template', 'alertmgr_restart.hook.j2') }}"
   tags: setup
 
-- name: Copy generated alertmanager cert to alertmanager directory
-  copy:
-    src: "{{ letsencrypt_root }}/{{ alertmanager_hostname }}/fullchain.pem"
-    dest: "{{ alertmanager_config_path }}/fullchain.pem"
-    mode: 0644
-    remote_src: yes
-  become: yes
-
-- name: Copy generated alertmanager cert key to alertmanager directory
-  copy:
-    src: "{{ letsencrypt_root }}/{{ alertmanager_hostname }}/privkey.pem"
-    dest: "{{ alertmanager_config_path }}/privkey.pem"
-    mode: 0644
-    remote_src: yes
+- name: Clean out alertmanager cert copies, if any
+  file:
+    path: "{{ alertmanager_config_path }}/{{ item }}"
+    state: absent
+  loop:
+    - fullchain.pem
+    - privkey.pem
   become: yes
 
 - name: Write default alertmanager config if one doesn't exist

--- a/ansible/roles/alertmanager/templates/alertmgr_restart.hook.j2
+++ b/ansible/roles/alertmanager/templates/alertmgr_restart.hook.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "{{ alertmanager_config_path }}"
+docker-compose restart

--- a/ansible/roles/alertmanager/templates/docker-compose.yml.j2
+++ b/ansible/roles/alertmanager/templates/docker-compose.yml.j2
@@ -26,9 +26,9 @@ services:
       - "--configFile"
       - "{{ alertmanager_config_path }}/{{ alertmanager_config_file }}"
       - "--tlsCert"
-      - "{{ alertmanager_config_path }}/fullchain.pem"
+      - "{{ letsencrypt_root }}/{{ alertmanager_hostname }}/fullchain.pem"
       - "--tlsCertKey"
-      - "{{ alertmanager_config_path }}/privkey.pem"
+      - "{{ letsencrypt_root }}/{{ alertmanager_hostname }}/privkey.pem"
       - "--tlsClientCert"
       - "{{ alertmanager_config_path }}/mex-ca.crt"
     environment:
@@ -42,6 +42,9 @@ services:
       - ALERTMANAGER_RESOLVE_TIMEOUT={{ alertmanager_resolve_timeout  }}
     volumes:
       - {{ alertmanager_config_path }}:{{ alertmanager_config_path }}
+      - {{ letsencrypt_root }}/{{ alertmanager_hostname }}/privkey.pem:{{ letsencrypt_root }}/{{ alertmanager_hostname }}/privkey.pem
+      - {{ letsencrypt_root }}/{{ alertmanager_hostname }}/fullchain.pem:{{ letsencrypt_root }}/{{ alertmanager_hostname }}/fullchain.pem
+      - {{ letsencrypt_base }}/archive/{{ alertmanager_hostname }}:{{ letsencrypt_base }}/archive/{{ alertmanager_hostname }}
     ports:
       - 9094:9094
     networks:

--- a/ansible/roles/web/defaults/main.yml
+++ b/ansible/roles/web/defaults/main.yml
@@ -1,4 +1,5 @@
 cert_domains: []
+letsencrypt_base: /etc/letsencrypt
 letsencrypt_root: /etc/letsencrypt/live
 cloudflare_credentials_file: /etc/cloudflare.ini
 nginx_config_filename: default


### PR DESCRIPTION
- Mount letsencrypt certs into container
- Install post-renew hook in letsencrypt to restart alertmanager and load
  new certs when they're renewed.