### PR TITLE
Include C# SDK Doxygen docs in the API docs portal

### DIFF
--- a/ansible/apidocs.yml
+++ b/ansible/apidocs.yml
@@ -40,6 +40,11 @@
         account_api_token: "{{ cloudflare_account_api_token }}"
       tags: setup
 
+    - name: Load artifactory token
+      import_role:
+        name: load-vault-creds
+        tasks_from: artifactory-apidocs
+
     - include_role:
         name: apidocs
       vars:

--- a/ansible/files/apidocs/apidocs-massage.py
+++ b/ansible/files/apidocs/apidocs-massage.py
@@ -48,6 +48,11 @@ def set_version(sw, vers):
     if sw['info']['version'] == "version not set":
         sw['info']['version'] = vers
 
+def set_environ(sw, environ):
+    if 'description' in sw['info']:
+        sw['info']['description'] = re.sub(r'{{ENVIRON}}', environ,
+                                           sw['info']['description'])
+
 def splice_samples(sw, samples):
     if samples:
         api_eps = set([d for d in os.listdir(samples) if os.path.isdir(os.path.join(samples, d))])
@@ -148,6 +153,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--samples", "-s", help="Code samples directory")
     parser.add_argument("--logo", "-l", help="Logo URL", default="/swagger/logo.svg")
+    parser.add_argument("--environ", "-e", help="Deployment environment", default="mexdemo")
     parser.add_argument("--version", "-v", help="Version string, if not present in swagger",
                         default="1.0")
     parser.add_argument("--host", help="API host")
@@ -166,6 +172,8 @@ def main():
     set_version(sw, args.version)
     if args.host:
         set_host(sw, args.host)
+    if args.environ:
+        set_environ(sw, args.environ)
 
     print(json.dumps(sw, indent=2))
 

--- a/ansible/roles/load-vault-creds/defaults/main.yml
+++ b/ansible/roles/load-vault-creds/defaults/main.yml
@@ -1,3 +1,4 @@
+artifactory_apidocs_account_path: secret/ansible/common/accounts/artifactory_apidocs
 artifactory_publish_account_path: secret/ansible/common/accounts/artifactory_publish
 azure_account_path: secret/ansible/common/accounts/azure
 cloudflare_account_path: secret/ansible/common/accounts/cloudflare

--- a/ansible/roles/load-vault-creds/tasks/artifactory-apidocs.yml
+++ b/ansible/roles/load-vault-creds/tasks/artifactory-apidocs.yml
@@ -1,0 +1,6 @@
+- name: Look up artifactory apidocs token in vault
+  set_fact:
+    vault_lookup: "{{ lookup('vault', artifactory_apidocs_account_path) }}"
+
+- set_fact:
+    artifactory_apidocs_token: "{{ vault_lookup.artifactory_apidocs.data.token }}"

--- a/ansible/templates/apidocs/swagger-gen.j2
+++ b/ansible/templates/apidocs/swagger-gen.j2
@@ -8,6 +8,7 @@ TAG=$( date +'%Y-%m-%d' )
 
 EDGECLOUD="registry.mobiledgex.net:5000/mobiledgex/edge-cloud:$TAG"
 APIDOCS_MASSAGE="{{ apidocs_script_dir }}/apidocs-massage.py"
+ARTF_TOKEN="{{ artifactory_apidocs_token }}"
 
 sudo docker run --rm "$EDGECLOUD" version >/dev/null
 if [[ $? -ne 0 ]]; then
@@ -18,10 +19,25 @@ fi
 download_doc() {
 	local doctype="$1"; shift
 	sudo docker run --rm "$EDGECLOUD" dump-docs "$doctype" \
-		| ${APIDOCS_MASSAGE} -v "$TAG" --logo "{{ logo_url }}" "$@" >"{{ swagger_base_dir }}/${doctype}.swagger.json"
+		| ${APIDOCS_MASSAGE} -v "$TAG" --logo "{{ logo_url }}" \
+			--environ "{{ deploy_environ }}" "$@" \
+			>"{{ swagger_base_dir }}/${doctype}.swagger.json"
+}
+
+download_doxygen_doc() {
+	local repo="$1"; shift
+	curl -sf -H "Authorization: Bearer $ARTF_TOKEN" \
+		"https://artifactory.mobiledgex.net/artifactory/apidocs/${repo}/${TAG}/html.zip" \
+		>"/tmp/html.zip"
+	mkdir -p "{{ swagger_base_dir }}/${repo}"
+	cd "{{ swagger_base_dir }}/${repo}"
+	rm -rf html
+	unzip /tmp/html.zip >/dev/null
 }
 
 download_doc external
 download_doc internal
 download_doc client --samples "{{ swagger_base_dir }}/code-samples"
 download_doc mc --host "{{ console_vm_hostname }}"
+
+download_doxygen_doc edge-cloud-sdk-csharp

--- a/jenkins/apidocs-sdk-csharp.Jenkinsfile
+++ b/jenkins/apidocs-sdk-csharp.Jenkinsfile
@@ -1,0 +1,53 @@
+pipeline {
+
+    options {
+        timeout(time: 5, unit: 'MINUTES')
+    }
+    agent any
+
+    environment {
+        BUILD_TAG = sh(returnStdout: true, script: 'date +"%Y-%m-%d" | tr -d "\n"')
+    }
+
+    stages {
+        stage('Set up build tag') {
+            steps {
+                script {
+                    currentBuild.displayName = "${BUILD_TAG}"
+                }
+            }
+        }
+        stage('Checkout') {
+            steps {
+                dir(path: 'edge-cloud-sdk-csharp') {
+                    git url: 'git@github.com:mobiledgex/edge-cloud-sdk-csharp.git'
+                }
+            }
+        }
+        stage('Generate docs') {
+            steps {
+                dir(path: 'edge-cloud-sdk-csharp/rest') {
+                    sh 'make generate-doxygen'
+                }
+            }
+        }
+        stage('Upload to Artifactory') {
+            steps {
+                dir(path: 'edge-cloud-sdk-csharp/rest/Doxygen') {
+                    rtUpload (
+                        serverId: "artifactory",
+                        spec:
+                            """{
+                                "files": [
+                                    {
+                                        "pattern": "html.zip",
+                                        "target": "apidocs/edge-cloud-sdk-csharp/${BUILD_TAG}/html.zip"
+                                    }
+                                ]
+                            }"""
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
If the description section of the API docs contains the string "{{ENVIRON}}", it will get replaced by the environment string (stage, mexdemo, etc.).  This allows for managing separate release- and staging- API docs.

Also includes a jenkins job to generate the API docs bundle and publish it to Artifactory.