### PR TITLE
e2e-test fixes

### DIFF
--- a/e2e-tests/data/mc_shownode.yml
+++ b/e2e-tests/data/mc_shownode.yml
@@ -1,20 +1,35 @@
 nodes:
 - key:
     type: notifyroot
+  internalpki: from-file,useVaultCAs,useVaultCerts
 
 - key:
     type: mc
+  internalpki: from-file,useVaultCAs,useVaultCerts
 - key:
     type: mc
+  internalpki: from-file,useVaultCAs,useVaultCerts
 
 - key:
     type: controller
     region: local
   containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs
 - key:
     type: controller
     region: local
   containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: controller
+    region: locala
+  containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: controller
+    region: locala
+  containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs,useVaultCerts
 
 - key:
     type: dme
@@ -22,12 +37,28 @@ nodes:
     cloudletkey:
       organization: tmus
       name: tmus-cloud-1
+  internalpki: from-file,useVaultCAs,useVaultCerts
 - key:
     type: dme
     region: local
     cloudletkey:
       organization: tmus
       name: tmus-cloud-2
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: dme
+    region: locala
+    cloudletkey:
+      organization: tmus
+      name: tmus-cloud-3
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: dme
+    region: locala
+    cloudletkey:
+      organization: tmus
+      name: tmus-cloud-4
+  internalpki: from-file,useVaultCAs,useVaultCerts
 
 - key:
     type: crm
@@ -36,6 +67,7 @@ nodes:
       organization: enterprise
       name: enterprise-1
   containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs
 - key:
     type: crm
     region: local
@@ -43,6 +75,7 @@ nodes:
       organization: tmus
       name: tmus-cloud-1
   containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs
 - key:
     type: crm
     region: local
@@ -50,6 +83,7 @@ nodes:
       organization: tmus
       name: tmus-cloud-2
   containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs
 - key:
     type: crm
     region: local
@@ -57,6 +91,7 @@ nodes:
       organization: azure
       name: azure-cloud-4
   containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs
 - key:
     type: crm
     region: local
@@ -64,6 +99,32 @@ nodes:
       organization: gcp
       name: gcp-cloud-5
   containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs
+
+- key:
+    type: crm
+    region: locala
+    cloudletkey:
+      organization: tmus
+      name: tmus-cloud-3
+  containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: crm
+    region: locala
+    cloudletkey:
+      organization: tmus
+      name: tmus-cloud-4
+  containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: crm
+    region: locala
+    cloudletkey:
+      organization: enterprise
+      name: enterprise-2
+  containerversion: "2019-10-24"
+  internalpki: from-file,useVaultCAs,useVaultCerts
 
 - key:
     type: shepherd
@@ -71,14 +132,30 @@ nodes:
     cloudletkey:
       organization: tmus
       name: tmus-cloud-1
+  internalpki: from-file,useVaultCAs
   
 - key:
     type: cluster-svc
     region: local
+  internalpki: from-file,useVaultCAs,useVaultCerts
 - key:
     type: cluster-svc
     region: local
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: cluster-svc
+    region: locala
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: cluster-svc
+    region: locala
+  internalpki: from-file,useVaultCAs,useVaultCerts
 
 - key:
     type: autoprov
     region: local
+  internalpki: from-file,useVaultCAs,useVaultCerts
+- key:
+    type: autoprov
+    region: locala
+  internalpki: from-file,useVaultCAs,useVaultCerts

--- a/e2e-tests/setups/local_multi.yml
+++ b/e2e-tests/setups/local_multi.yml
@@ -30,12 +30,14 @@ vaults:
 influxs:
 - name: influx1
   datadir: /var/tmp/edge-cloud-local-influx/influx1
-  httpaddr: "http://127.0.0.1:8086"
+  httpaddr: "127.0.0.1:8086"
+  bindaddr: "127.0.0.1:8088"
   hostname: "127.0.0.1"
 
 - name: influxa1
   datadir: /var/tmp/edge-cloud-local-influx/influx2
-  httpaddr: "http://127.0.0.1:8087"
+  httpaddr: "127.0.0.1:8087"
+  bindaddr: "127.0.0.1:8089"
   hostname: "127.0.0.1"
 
 etcds:
@@ -96,6 +98,7 @@ controllers:
   testmode: true
   notifyparentaddrs: "127.0.0.1:52001"
   notifyrootaddrs: "127.0.0.1:53001"
+  usevaultcas: true
   edgeturnaddr: "127.0.0.1:8080"
   appdnsroot: mobiledgex.net
 
@@ -113,6 +116,7 @@ controllers:
   testmode: true
   notifyparentaddrs: "127.0.0.1:52002"
   notifyrootaddrs: "127.0.0.1:53001"
+  usevaultcerts: true
   edgeturnaddr: "127.0.0.1:8080"
   appdnsroot: mobiledgex.net
 
@@ -131,6 +135,7 @@ controllers:
   notifyparentaddrs: "127.0.0.1:52001"
   notifyrootaddrs: "127.0.0.1:53001"
   region: locala
+  usevaultcerts: true
   edgeturnaddr: "127.0.0.1:8081"
   appdnsroot: mobiledgex.net
 
@@ -149,6 +154,7 @@ controllers:
   notifyparentaddrs: "127.0.0.1:52002"
   notifyrootaddrs: "127.0.0.1:53001"
   region: locala
+  usevaultcerts: true
   edgeturnaddr: "127.0.0.1:8081"
   appdnsroot: mobiledgex.net
 
@@ -156,7 +162,9 @@ clustersvcs:
 - name: cluster-svc1
   notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
   ctrladdrs: "127.0.0.1:55001"
+  vaultaddr: "http://127.0.0.1:8200"
   pluginrequired: true
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -165,6 +173,8 @@ clustersvcs:
 - name: cluster-svc2
   notifyaddrs: "127.0.0.1:37001,127.0.0.1:37002"
   ctrladdrs: "127.0.0.1:55002"
+  vaultaddr: "http://127.0.0.1:8200"
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -173,7 +183,10 @@ clustersvcs:
 - name: cluster-svca1
   notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
   ctrladdrs: "127.0.0.1:55011"
+  vaultaddr: "http://127.0.0.1:8200"
   pluginrequired: true
+  usevaultcerts: true
+  region: locala
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -182,6 +195,9 @@ clustersvcs:
 - name: cluster-svca2
   notifyaddrs: "127.0.0.1:37011,127.0.0.1:37012"
   ctrladdrs: "127.0.0.1:55012"
+  vaultaddr: "http://127.0.0.1:8200"
+  usevaultcerts: true
+  region: locala
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -197,6 +213,7 @@ dmes:
   carrier: TDG
   cloudletkey: '{"organization":"tmus","name":"tmus-cloud-1"}'
   vaultaddr: "http://127.0.0.1:8200"
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
@@ -215,6 +232,7 @@ dmes:
   carrier: TDG
   cloudletkey: '{"organization":"tmus","name":"tmus-cloud-2"}'
   vaultaddr: "http://127.0.0.1:8200"
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
@@ -234,6 +252,7 @@ dmes:
   cloudletkey: '{"organization":"tmus","name":"tmus-cloud-3"}'
   vaultaddr: "http://127.0.0.1:8200"
   region: locala
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
@@ -253,6 +272,7 @@ dmes:
   cloudletkey: '{"organization":"tmus","name":"tmus-cloud-4"}'
   vaultaddr: "http://127.0.0.1:8200"
   region: locala
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
@@ -267,6 +287,7 @@ mcs:
   addr: "127.0.0.1:9900"
   sqladdr: "127.0.0.1:5432"
   vaultaddr: "http://127.0.0.1:8200"
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
@@ -283,6 +304,7 @@ mcs:
   addr: "127.0.0.1:9901"
   sqladdr: "127.0.0.1:5432"
   vaultaddr: "http://127.0.0.1:8200"
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
@@ -323,6 +345,7 @@ autoprovs:
   ctrladdrs: "127.0.0.1:55001"
   vaultaddr: "http://127.0.0.1:8200"
   influxaddr: "http://127.0.0.1:8086"
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -334,6 +357,7 @@ autoprovs:
   vaultaddr: "http://127.0.0.1:8200"
   influxaddr: "http://127.0.0.1:8087"
   region: locala
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     clientcert: "{{tlsoutdir}}/mex-client.crt"
@@ -353,6 +377,8 @@ exporter:
 notifyroots:
 - name: notifyroot
   hostname: "127.0.0.1"
+  vaultaddr: "http://127.0.0.1:8200"
+  usevaultcerts: true
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
 

--- a/e2e-tests/testfiles/mc_add_delete.yml
+++ b/e2e-tests/testfiles/mc_add_delete.yml
@@ -99,7 +99,7 @@ tests:
   compareyaml:
     yaml1: '{{outputdir}}/show-commands.yml'
     yaml2: '{{datadir2}}/mc_shownode.yml'
-    filetype: appdata
+    filetype: nodedata
 
 - name: test orgs in use
   actions: [mcapi-delete-expecterr]

--- a/mc/mcctl/ormctl/appinst.mc2.go
+++ b/mc/mcctl/ormctl/appinst.mc2.go
@@ -322,7 +322,7 @@ var AppInstComments = map[string]string{
 	"mappedports:#.proto":            "TCP (L4) or UDP (L4) protocol, one of LProtoUnknown, LProtoTcp, LProtoUdp",
 	"mappedports:#.internalport":     "Container port",
 	"mappedports:#.publicport":       "Public facing port for TCP/UDP (may be mapped on shared LB reverse proxy)",
-	"mappedports:#.fqdnprefix":       "skip 4 to preserve the numbering. 4 was path_prefix but was removed since we dont need it after removed http FQDN prefix to append to base FQDN in FindCloudlet response. May be empty.",
+	"mappedports:#.fqdnprefix":       "FQDN prefix to append to base FQDN in FindCloudlet response. May be empty.",
 	"mappedports:#.endport":          "A non-zero end port indicates a port range from internal port to end port, inclusive.",
 	"mappedports:#.tls":              "TLS termination for this port",
 	"mappedports:#.nginx":            "use nginx proxy for this port if you really need a transparent proxy (udp only)",

--- a/mc/orm/alert.mc2.go
+++ b/mc/orm/alert.mc2.go
@@ -1303,10 +1303,10 @@ func addControllerApis(method string, group *echo.Group) {
 	// MappedPortsProto: 9.1
 	// MappedPortsInternalPort: 9.2
 	// MappedPortsPublicPort: 9.3
-	// MappedPortsFqdnPrefix: 9.5
-	// MappedPortsEndPort: 9.6
-	// MappedPortsTls: 9.7
-	// MappedPortsNginx: 9.8
+	// MappedPortsFqdnPrefix: 9.4
+	// MappedPortsEndPort: 9.5
+	// MappedPortsTls: 9.6
+	// MappedPortsNginx: 9.7
 	// Flavor: 12
 	// FlavorName: 12.1
 	// State: 14

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud-infra/mc/rbac"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
+	"github.com/mobiledgex/edge-cloud/cloudcommon/node"
 	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -416,7 +417,7 @@ func orgInUse(ctx context.Context, orgName string) error {
 }
 
 func orgInUseRegion(ctx context.Context, c ormapi.Controller, orgName string) error {
-	conn, err := connectGrpcAddr(c.Address)
+	conn, err := connectGrpcAddr(ctx, c.Address, []node.MatchCA{node.AnyRegionalMatchCA()})
 	if err != nil {
 		return err
 	}

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -135,6 +135,9 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	}
 
 	err := nodeMgr.Init(ctx, "mc", node.WithName(config.Hostname))
+	if err != nil {
+		return nil, err
+	}
 
 	if config.LocalVault {
 		vaultProc := process.Vault{

--- a/vault/setup-region.sh
+++ b/vault/setup-region.sh
@@ -22,15 +22,15 @@ path "secret/data/+/accounts/influxdb" {
   capabilities = [ "read" ]
 }
 
-path "pki-regional/issue/*" {
+path "pki-regional/issue/$REGION" {
   capabilities = [ "read", "update" ]
 }
 EOF
-vault policy write autoprov /tmp/autoprov-pol.hcl
+vault policy write $REGION.autoprov /tmp/autoprov-pol.hcl
 rm /tmp/autoprov-pol.hcl
-vault write auth/approle/role/autoprov period="720h" policies="autoprov"
+vault write auth/approle/role/$REGION.autoprov period="720h" policies="$REGION.autoprov"
 # get autoprov app roleID and generate secretID
-vault read auth/approle/role/autoprov/role-id
-vault write -f auth/approle/role/autoprov/secret-id
+vault read auth/approle/role/$REGION.autoprov/role-id
+vault write -f auth/approle/role/$REGION.autoprov/secret-id
 
 # Note: Shepherd uses CRM's Vault access creds.


### PR DESCRIPTION
Fixes for e2e-test issues. Please also see https://github.com/mobiledgex/edge-cloud/pull/1066

- Enable vault internal pki for e2e-tests
- MC to Controller communication was not using vault internal pki certs
- change ShowNode data type so it is checked properly
- The billing code had a couple of issues.
   - the code to determine the time to wait for the next day was comparing a local time to a UTC time, causing the duration to become negative at certain times of day. This caused the usage loop to spin.
   - The above problem revealed a missing close on the influx client because MC would run out of file descriptions once the loop starting spinning
- missing err check for nodeMgr.Init()