### PR TITLE
EDGECLOUD-3481 autoscale span logs not linked

### DIFF
--- a/autoprov/autoscale.go
+++ b/autoprov/autoscale.go
@@ -49,7 +49,10 @@ func autoScale(ctx context.Context, name string, alert *edgeproto.Alert) error {
 	}
 	inst.Fields = []string{edgeproto.ClusterInstFieldNumNodes}
 
-	conn, err := grpc.Dial(*ctrlAddr, dialOpts, grpc.WithBlock(), grpc.WithWaitForHandshake())
+	conn, err := grpc.Dial(*ctrlAddr, dialOpts, grpc.WithBlock(),
+		grpc.WithWaitForHandshake(),
+		grpc.WithUnaryInterceptor(log.UnaryClientTraceGrpc),
+		grpc.WithStreamInterceptor(log.StreamClientTraceGrpc))
 	if err != nil {
 		return fmt.Errorf("Connect to controller %s failed, %v", *ctrlAddr, err)
 	}


### PR DESCRIPTION
Autoscaling calls from AutoProv to Controller were missing interceptors that forward and link Jaeger span.