### PR TITLE
EDGECLOUD-3540 autoprov deploy helm

### DIFF
--- a/autoprov/autoprov_aggr.go
+++ b/autoprov/autoprov_aggr.go
@@ -280,7 +280,7 @@ func (s *AutoProvAggr) deploy(ctx context.Context, app *edgeproto.App, cloudletK
 	log.SpanLog(ctx, log.DebugLevelApi, "auto-prov deploy App", "app", app.Key, "cloudlet", *cloudletKey)
 
 	// find free reservable ClusterInst
-	cinstKey := s.caches.frClusterInsts.GetForCloudlet(cloudletKey, app.Deployment)
+	cinstKey := s.caches.frClusterInsts.GetForCloudlet(cloudletKey, app.Deployment, cloudcommon.AppInstToClusterDeployment)
 	if cinstKey == nil {
 		log.SpanLog(ctx, log.DebugLevelApi, "auto-prov no free ClusterInst")
 		return

--- a/autoprov/autoprov_minmax.go
+++ b/autoprov/autoprov_minmax.go
@@ -403,7 +403,7 @@ func (s *AppChecker) checkPolicy(ctx context.Context, app *edgeproto.App, pname 
 				continue
 			}
 			// see if free reservable ClusterInst exists
-			freeClustKey := s.caches.frClusterInsts.GetForCloudlet(&apCloudlet.Key, app.Deployment)
+			freeClustKey := s.caches.frClusterInsts.GetForCloudlet(&apCloudlet.Key, app.Deployment, cloudcommon.AppInstToClusterDeployment)
 			if freeClustKey != nil {
 				appInstKey := edgeproto.AppInstKey{
 					AppKey:         s.appKey,


### PR DESCRIPTION
Allows AutoProv to find a reservable ClusterInst for a helm App. See https://github.com/mobiledgex/edge-cloud/pull/1074