### PR TITLE
EDGECLOUD-3562  Health Check is not created for an AppInst if VM is powered off right after appInst creation

### DIFF
--- a/shepherd/cloudlet-prom.go
+++ b/shepherd/cloudlet-prom.go
@@ -182,6 +182,11 @@ func metricsProxy(w http.ResponseWriter, r *http.Request) {
 	if app != "" {
 		// Search ProxyMap for the names
 		target := getProxyScrapePoint(app)
+		if target.Client == nil {
+			// if client is not initialized trigger health-check failure
+			http.Error(w, "Client is not initialized", http.StatusInternalServerError)
+			return
+		}
 		if target.ProxyContainer == "nginx" {
 			return
 		}

--- a/shepherd/cluster-worker.go
+++ b/shepherd/cluster-worker.go
@@ -76,11 +76,13 @@ func (p *ClusterWorker) Start(ctx context.Context) {
 	p.stop = make(chan struct{})
 	p.waitGrp.Add(1)
 	go p.RunNotify()
-	log.SpanLog(ctx, log.DebugLevelMetrics, "Started ClusterWorker thread\n")
+	log.SpanLog(ctx, log.DebugLevelMetrics, "Started ClusterWorker thread",
+		"cluster", p.clusterInstKey)
 }
 
 func (p *ClusterWorker) Stop(ctx context.Context) {
-	log.SpanLog(ctx, log.DebugLevelMetrics, "Stopping ClusterWorker thread\n")
+	log.SpanLog(ctx, log.DebugLevelMetrics, "Stopping ClusterWorker thread",
+		"cluster", p.clusterInstKey)
 	close(p.stop)
 	// For dedicated clusters try to clean up ssh client cache
 	cluster := edgeproto.ClusterInst{}

--- a/shepherd/proxy-stats_test.go
+++ b/shepherd/proxy-stats_test.go
@@ -39,7 +39,7 @@ func TestCollectProxyStats(t *testing.T) {
 	for ii, _ := range testutil.AppData {
 		AppCache.Update(ctx, &testutil.AppData[ii], 0)
 	}
-	// Now test each enty in AppInstData
+	// Now test each entry in AppInstData
 	for ii, obj := range testutil.AppInstData {
 		// set mapped ports and state
 		app := edgeproto.App{}
@@ -51,7 +51,7 @@ func TestCollectProxyStats(t *testing.T) {
 		obj.MappedPorts = ports
 		obj.State = edgeproto.TrackedState_READY
 
-		// For each appInst in testutil.AppInstData the reslt might differ
+		// For each appInst in testutil.AppInstData the result might differ
 		switch ii {
 		case 0, 1, 3, 4, 6, 7:
 			// tcp,udp,http ports, load-balancer access
@@ -79,4 +79,66 @@ func TestCollectProxyStats(t *testing.T) {
 		}
 		AppInstCache.Update(ctx, &testutil.AppInstData[ii], 0)
 	}
+	// Test removal of each entry
+	for ii, obj := range testutil.AppInstData {
+		// set mapped ports and state
+		app := edgeproto.App{}
+		found := AppCache.Get(&obj.Key.AppKey, &app)
+		if !found {
+			continue
+		}
+		ports, _ := edgeproto.ParseAppPorts(app.AccessPorts)
+		obj.MappedPorts = ports
+		obj.State = edgeproto.TrackedState_DELETING
+
+		// For each appInst in testutil.AppInstData the result might differ
+		switch ii {
+		case 0, 1, 3, 4, 6, 7:
+			// tcp,udp,http ports, load-balancer access
+			// dedicated access k8s
+			// We should write a targets file and get a scrape point
+			target := CollectProxyStats(ctx, &obj)
+			assert.NotEmpty(t, target)
+			// CollectProxyStats should return empty when running on the same
+			// object that we already have
+			target = CollectProxyStats(ctx, &obj)
+			assert.Empty(t, target)
+		case 2:
+			// Same app, but different cloudlets - map entry is the same
+			target := CollectProxyStats(ctx, &obj)
+			assert.Empty(t, target)
+		case 5:
+			// udp load-balancer
+			// dedicated helm access
+			target := CollectProxyStats(ctx, &obj)
+			assert.NotEmpty(t, target)
+		case 8:
+			// dedicated, no ports
+			target := CollectProxyStats(ctx, &obj)
+			assert.Empty(t, target)
+		}
+		AppInstCache.Delete(ctx, &testutil.AppInstData[ii], 0)
+	}
+	// test an entry that has a failing platform client
+	myPlatform = &shepherd_unittest.Platform{FailPlatformClient: true}
+	appInst := testutil.AppInstData[0]
+	// set mapped ports and state
+	app := edgeproto.App{}
+	found := AppCache.Get(&appInst.Key.AppKey, &app)
+	if !found {
+		assert.Fail(t, "Could not find app for appinst")
+	}
+	ports, _ := edgeproto.ParseAppPorts(app.AccessPorts)
+	appInst.MappedPorts = ports
+	appInst.State = edgeproto.TrackedState_READY
+	// scrape point should still be created
+	target := CollectProxyStats(ctx, &appInst)
+	assert.NotEmpty(t, target)
+	assert.Nil(t, ProxyMap[target].Client)
+	// Set myPlatform to return client now and create appInst again
+	myPlatform = &shepherd_unittest.Platform{FailPlatformClient: false}
+	// Create scrape point again
+	target = CollectProxyStats(ctx, &appInst)
+	assert.NotEmpty(t, target)
+	assert.NotNil(t, ProxyMap[target].Client)
 }

--- a/shepherd/shepherd_common/shepherd-names.go
+++ b/shepherd/shepherd_common/shepherd-names.go
@@ -19,7 +19,7 @@ func ShouldRunEnvoy(app *edgeproto.App, appInst *edgeproto.AppInst) bool {
 		return false
 	}
 	if app.InternalPorts || app.AccessType != edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER {
-		log.DebugLog(log.DebugLevelInfo, "ShouldRunEnvoy", "app", app.Key, "appCheck", false)
+		log.DebugLog(log.DebugLevelInfo, "ShouldRunEnvoy", "app", app, "appCheck", false)
 		return false
 	}
 	log.DebugLog(log.DebugLevelInfo, "ShouldRunEnvoy", "app", app.Key, "ok", true)

--- a/shepherd/shepherd_platform/shepherd_unittest/shepherd_unittest.go
+++ b/shepherd/shepherd_platform/shepherd_unittest/shepherd_unittest.go
@@ -21,8 +21,9 @@ type Platform struct {
 	DockerAppMetrics     string
 	DockerClusterMetrics string
 	// Cloudlet-level test data
-	CloudletMetrics  string
-	VmAppInstMetrics string
+	CloudletMetrics    string
+	VmAppInstMetrics   string
+	FailPlatformClient bool
 	// TODO - add Prometheus/nginx strings here EDGECLOUD-1252
 }
 
@@ -42,6 +43,9 @@ func (s *Platform) GetClusterIP(ctx context.Context, clusterInst *edgeproto.Clus
 }
 
 func (s *Platform) GetClusterPlatformClient(ctx context.Context, clusterInst *edgeproto.ClusterInst, clientType string) (ssh.Client, error) {
+	if s.FailPlatformClient {
+		return nil, fmt.Errorf("Test no client")
+	}
 	return &UTClient{pf: s}, nil
 }
 


### PR DESCRIPTION
The root cause of the bug was that a VM is powered off before appInst if fully created. In this case we were unable to get platform client in  `CollectProxyStats` and not create a health check scrape point for the instance.
To address this - in case rootLB is not reachable in `CollectProxyStats` scrapePoint is still created to trigger health check failure for the appInst.

Added unit-test to exercise  this path.