### PR TITLE
EDGECLOUD-3616 disable LDAP anonymous search

### DIFF
--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -62,6 +62,8 @@ type ServerConfig struct {
 	TlsKeyFile            string
 	LocalVault            bool
 	LDAPAddr              string
+	LDAPUsername          string
+	LDAPPassword          string
 	GitlabAddr            string
 	ArtifactoryAddr       string
 	ClientCert            string
@@ -132,6 +134,12 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	}
 	if superpass == "" || config.IgnoreEnv {
 		superpass = DefaultSuperpass
+	}
+	if serverConfig.LDAPUsername == "" && !config.IgnoreEnv {
+		serverConfig.LDAPUsername = os.Getenv("LDAP_USERNAME")
+	}
+	if serverConfig.LDAPPassword == "" && !config.IgnoreEnv {
+		serverConfig.LDAPPassword = os.Getenv("LDAP_PASSWORD")
 	}
 
 	err := nodeMgr.Init(ctx, "mc", node.CertIssuerGlobal, node.WithName(config.Hostname))

--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -48,7 +48,7 @@ func InitAdmin(ctx context.Context, superuser, superpass string) error {
 	return nil
 }
 
-var BadAuthDelay = time.Second
+var BadAuthDelay = 3 * time.Second
 
 func Login(c echo.Context) error {
 	ctx := GetContext(c)


### PR DESCRIPTION
Disables LDAP anonymous search.

LDAP bind is used to auth the user. Search can either be just a search, or the single request can contain both a bind followed by a search. If the bind succeeds, the boundDN is passed to the search func (boundDN is basically the username that was authenticated). So the fix is really just to disallow search if boundDN is not set, meaning no user was authenticated.

I also changed the LDAP username/password to be env vars instead of hard-coded. Venky will have ansible pull these from Vault during deployment.

Also slightly increased the failed authentication delay from 1 second to 3. More work needs to be done to mitigate brute force password attacks.