### PR TITLE
EDGECLOUD-3623 stop using hard-coded cert for internal pki

### DIFF
--- a/alertmgr-sidecar/alertmgr-sidecar.go
+++ b/alertmgr-sidecar/alertmgr-sidecar.go
@@ -56,7 +56,7 @@ func getConfigInfo() (*alertmgr.AlertmgrInitInfo, error) {
 func main() {
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer("")
+	log.InitTracer(nil)
 
 	config, err := getConfigInfo()
 	if err != nil {

--- a/autoprov/autoprov_deploy_test.go
+++ b/autoprov/autoprov_deploy_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestDeploy(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi | log.DebugLevelMetrics)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/autoprov/autoprov_minmax_test.go
+++ b/autoprov/autoprov_minmax_test.go
@@ -17,7 +17,7 @@ import (
 // Test Choose order for create/delete
 func TestChoose(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi | log.DebugLevelMetrics)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
@@ -122,8 +122,6 @@ func TestChoose(t *testing.T) {
 
 func TestAppChecker(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi | log.DebugLevelMetrics)
-	log.InitTracer("")
-	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
 	// init

--- a/autoprov/autoprov_test.go
+++ b/autoprov/autoprov_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestAutoProv(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelNotify | log.DebugLevelApi | log.DebugLevelMetrics)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	flag.Parse() // set defaults

--- a/crm-platforms/openstack/openstack_accessvars_test.go
+++ b/crm-platforms/openstack/openstack_accessvars_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestAccessVars(t *testing.T) {
-	log.InitTracer("")
-	defer log.FinishTracer()
 	log.SetDebugLevel(log.DebugLevelInfra)
+	log.InitTracer(nil)
+	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	ckey := edgeproto.CloudletKey{
 		Organization: "MobiledgeX",

--- a/crm-platforms/openstack/openstack_heat_test.go
+++ b/crm-platforms/openstack/openstack_heat_test.go
@@ -2,10 +2,11 @@ package openstack
 
 import (
 	"context"
-	yaml "github.com/mobiledgex/yaml/v2"
 	"io/ioutil"
 	"strings"
 	"testing"
+
+	yaml "github.com/mobiledgex/yaml/v2"
 
 	"github.com/mobiledgex/edge-cloud-infra/chefmgmt"
 	e2esetup "github.com/mobiledgex/edge-cloud-infra/e2e-tests/e2e-setup"
@@ -92,11 +93,11 @@ func validateStack(ctx context.Context, t *testing.T, vmgp *vmlayer.VMGroupOrche
 }
 
 func TestHeatTemplate(t *testing.T) {
-	log.InitTracer("")
-	defer log.FinishTracer()
 	log.SetDebugLevel(log.DebugLevelInfra)
 	infracommon.SetTestMode(true)
 
+	log.InitTracer(nil)
+	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	vaultServer, vaultConfig := vault.DummyServer()
 	defer vaultServer.Close()

--- a/crm-platforms/vmpool/vmpool-vmspec_test.go
+++ b/crm-platforms/vmpool/vmpool-vmspec_test.go
@@ -51,7 +51,7 @@ func setVMState(vmPool *edgeproto.VMPool, groupName string, markedVMs map[string
 func TestVMSpec(t *testing.T) {
 	var err error
 	log.SetDebugLevel(log.DebugLevelApi | log.DebugLevelNotify | log.DebugLevelInfra)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/e2e-tests/data/mc_shownode.yml
+++ b/e2e-tests/data/mc_shownode.yml
@@ -1,35 +1,35 @@
 nodes:
 - key:
     type: notifyroot
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 
 - key:
     type: mc
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: mc
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 
 - key:
     type: controller
     region: local
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: controller
     region: local
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: controller
     region: locala
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: controller
     region: locala
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 
 - key:
     type: dme
@@ -37,28 +37,28 @@ nodes:
     cloudletkey:
       organization: tmus
       name: tmus-cloud-1
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: dme
     region: local
     cloudletkey:
       organization: tmus
       name: tmus-cloud-2
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: dme
     region: locala
     cloudletkey:
       organization: tmus
       name: tmus-cloud-3
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: dme
     region: locala
     cloudletkey:
       organization: tmus
       name: tmus-cloud-4
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 
 - key:
     type: crm
@@ -67,7 +67,7 @@ nodes:
       organization: enterprise
       name: enterprise-1
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: crm
     region: local
@@ -75,7 +75,7 @@ nodes:
       organization: tmus
       name: tmus-cloud-1
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: crm
     region: local
@@ -83,7 +83,7 @@ nodes:
       organization: tmus
       name: tmus-cloud-2
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: crm
     region: local
@@ -91,7 +91,7 @@ nodes:
       organization: azure
       name: azure-cloud-4
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: crm
     region: local
@@ -99,7 +99,7 @@ nodes:
       organization: gcp
       name: gcp-cloud-5
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs
+  internalpki: useVaultCAs,useVaultCerts
 
 - key:
     type: crm
@@ -108,7 +108,7 @@ nodes:
       organization: tmus
       name: tmus-cloud-3
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: crm
     region: locala
@@ -116,7 +116,7 @@ nodes:
       organization: tmus
       name: tmus-cloud-4
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: crm
     region: locala
@@ -124,7 +124,7 @@ nodes:
       organization: enterprise
       name: enterprise-2
   containerversion: "2019-10-24"
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 
 - key:
     type: shepherd
@@ -132,30 +132,30 @@ nodes:
     cloudletkey:
       organization: tmus
       name: tmus-cloud-1
-  internalpki: from-file,useVaultCAs
+  internalpki: useVaultCAs,useVaultCerts
   
 - key:
     type: cluster-svc
     region: local
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: cluster-svc
     region: local
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: cluster-svc
     region: locala
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: cluster-svc
     region: locala
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 
 - key:
     type: autoprov
     region: local
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts
 - key:
     type: autoprov
     region: locala
-  internalpki: from-file,useVaultCAs,useVaultCerts
+  internalpki: useVaultCAs,useVaultCerts

--- a/e2e-tests/e2e-setup/mcapi.go
+++ b/e2e-tests/e2e-setup/mcapi.go
@@ -134,7 +134,7 @@ func runMcUsersAPI(api, uri, apiFile, curUserFile, outputDir string, mods []stri
 }
 
 func runMcConfig(api, uri, apiFile, curUserFile, outputDir string, mods []string, vars map[string]string) bool {
-	log.Printf("Applying MC users via APIs for %s\n", apiFile)
+	log.Printf("Applying MC config via APIs for %s\n", apiFile)
 
 	token, rc := loginCurUser(uri, curUserFile, vars)
 	if !rc {

--- a/e2e-tests/int-process/process_defs.go
+++ b/e2e-tests/int-process/process_defs.go
@@ -21,6 +21,8 @@ type MC struct {
 	BillingPath             string
 	UsageCollectionInterval string
 	AlertMgrApiAddr         string
+	ApiTlsCert              string
+	ApiTlsKey               string
 	TLS                     process.TLSCerts
 	cmd                     *exec.Cmd
 }

--- a/e2e-tests/int-process/process_local.go
+++ b/e2e-tests/int-process/process_local.go
@@ -47,6 +47,12 @@ func (p *MC) StartLocal(logfile string, opts ...process.StartOp) error {
 		args = append(args, "--clientCert")
 		args = append(args, p.TLS.ClientCert)
 	}
+	if p.ApiTlsCert != "" {
+		args = append(args, "--apiTlsCert", p.ApiTlsCert)
+	}
+	if p.ApiTlsKey != "" {
+		args = append(args, "--apiTlsKey", p.ApiTlsKey)
+	}
 	if p.LdapAddr != "" {
 		args = append(args, "--ldapAddr")
 		args = append(args, p.LdapAddr)
@@ -110,7 +116,7 @@ func (p *MC) StartLocal(logfile string, opts ...process.StartOp) error {
 	if err == nil {
 		// wait until server is online
 		online := false
-		for ii := 0; ii < 40; ii++ {
+		for ii := 0; ii < 90; ii++ {
 			resp, serr := http.Get("http://" + p.Addr)
 			if serr == nil {
 				resp.Body.Close()

--- a/e2e-tests/setups/local_multi.yml
+++ b/e2e-tests/setups/local_multi.yml
@@ -90,15 +90,12 @@ controllers:
   httpaddr: "0.0.0.0:36001"
   notifyaddr: "127.0.0.1:37001"
   vaultaddr: "http://127.0.0.1:8200"
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
   notifyparentaddrs: "127.0.0.1:52001"
   notifyrootaddrs: "127.0.0.1:53001"
-  usevaultcas: true
+  usevaultcerts: true
   edgeturnaddr: "127.0.0.1:8080"
   appdnsroot: mobiledgex.net
   deploymenttag: dev
@@ -112,9 +109,6 @@ controllers:
   httpaddr: "0.0.0.0:36002"
   notifyaddr: "127.0.0.1:37002"
   vaultaddr: "http://127.0.0.1:8200"
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
@@ -134,9 +128,6 @@ controllers:
   httpaddr: "0.0.0.0:36011"
   notifyaddr: "127.0.0.1:37011"
   vaultaddr: "http://127.0.0.1:8200"
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
@@ -158,9 +149,6 @@ controllers:
   httpaddr: "0.0.0.0:36012"
   notifyaddr: "127.0.0.1:37012"
   vaultaddr: "http://127.0.0.1:8200"
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   versiontag: "2019-10-24"
   testmode: true
@@ -183,9 +171,6 @@ clustersvcs:
   vaultaddr: "http://127.0.0.1:8200"
   pluginrequired: true
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -196,9 +181,6 @@ clustersvcs:
   ctrladdrs: "127.0.0.1:55002"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -211,9 +193,6 @@ clustersvcs:
   pluginrequired: true
   usevaultcerts: true
   region: locala
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -225,9 +204,6 @@ clustersvcs:
   vaultaddr: "http://127.0.0.1:8200"
   usevaultcerts: true
   region: locala
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -244,10 +220,6 @@ dmes:
   cloudletkey: '{"organization":"tmus","name":"tmus-cloud-1"}'
   vaultaddr: "http://127.0.0.1:8200"
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     LOCAPI_USER: mexserver
@@ -265,10 +237,6 @@ dmes:
   cloudletkey: '{"organization":"tmus","name":"tmus-cloud-2"}'
   vaultaddr: "http://127.0.0.1:8200"
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     LOCAPI_USER: mexserver
@@ -287,10 +255,6 @@ dmes:
   vaultaddr: "http://127.0.0.1:8200"
   region: locala
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     LOCAPI_USER: mexserver
@@ -309,10 +273,6 @@ dmes:
   vaultaddr: "http://127.0.0.1:8200"
   region: locala
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     LOCAPI_USER: mexserver
@@ -326,10 +286,6 @@ mcs:
   sqladdr: "127.0.0.1:5432"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   ldapaddr: "127.0.0.1:9389"
   notifysrvaddr: "127.0.0.1:52001"
@@ -337,6 +293,8 @@ mcs:
   alertresolvetimeout: "{{alertmgrresolvetimeout}}"
   alertmgrapiaddr: "https://127.0.0.1:9094"
   billingpath: "fake"
+  apitlscert: "{{tlsoutdir}}/mex-server.crt"
+  apitlskey: "{{tlsoutdir}}/mex-server.key"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
@@ -346,16 +304,14 @@ mcs:
   sqladdr: "127.0.0.1:5432"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   ldapaddr: "127.0.0.1:9390"
   notifysrvaddr: "127.0.0.1:52002"
   consoleproxyaddr: "127.0.0.1:6081"
   alertmgrapiaddr: "https://127.0.0.1:9094"
   alertresolvetimeout: "{{alertmgrresolvetimeout}}"
+  apitlscert: "{{tlsoutdir}}/mex-server.crt"
+  apitlskey: "{{tlsoutdir}}/mex-server.key"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
@@ -366,18 +322,14 @@ sqls:
   httpaddr: "127.0.0.1:5432"
   username: mcuser
   dbname: mcdb
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    serverkey: "{{tlsoutdir}}/mex-server.key"
   hostname: "127.0.0.1"
 
 traefiks:
 - name: traefik-e2e
+  hostname: "127.0.0.1"
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
-    cacert: "{{tlsoutdir}}/mex-ca.crt"
-  hostname: "127.0.0.1"
 
 elasticsearchs:
 - name: elasticsearch-e2e
@@ -394,7 +346,6 @@ elasticsearchs:
   tls:
     servercert: "{{tlsoutdir}}/mex-server.crt"
     serverkey: "{{tlsoutdir}}/mex-server.key"
-    cacert: "{{tlsoutdir}}/mex-ca.crt"
   hostname: "127.0.0.1"
 
 jaegers:
@@ -408,9 +359,6 @@ autoprovs:
   vaultaddr: "http://127.0.0.1:8200"
   influxaddr: "http://127.0.0.1:8086"
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -423,9 +371,6 @@ autoprovs:
   influxaddr: "http://127.0.0.1:8087"
   region: locala
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
-    clientcert: "{{tlsoutdir}}/mex-client.crt"
   hostname: "127.0.0.1"
   envvars:
     ES_SERVER_URLS: https://localhost:9201
@@ -447,31 +392,25 @@ notifyroots:
   hostname: "127.0.0.1"
   vaultaddr: "http://127.0.0.1:8200"
   usevaultcerts: true
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
 
 edgeturns:
 - name: edgeturn
   region: local
   hostname: "127.0.0.1"
   testmode: true
-  usevaultcas: true
+  usevaultcerts: true
   vaultaddr: "http://127.0.0.1:8200"
   listenaddr: "127.0.0.1:8080"
   proxyaddr: "127.0.0.1:8443"
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
 
 - name: edgeturna
   region: locala
   hostname: "127.0.0.1"
   testmode: true
-  usevaultcas: true
+  usevaultcerts: true
   vaultaddr: "http://127.0.0.1:8200"
   listenaddr: "127.0.0.1:8081"
   proxyaddr: "127.0.0.1:9443"
-  tls:
-    servercert: "{{tlsoutdir}}/mex-server.crt"
 
 alertmanagers:
 - name: alertmanager

--- a/e2e-tests/test-mex-infra/test-mex-infra.go
+++ b/e2e-tests/test-mex-infra/test-mex-infra.go
@@ -34,7 +34,7 @@ func init() {
 
 func main() {
 	flag.Parse()
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	util.SetLogFormat()

--- a/mc/mc.go
+++ b/mc/mc.go
@@ -21,7 +21,8 @@ var localSql = flag.Bool("localSql", false, "Run local postgres db")
 var consoleProxyAddr = flag.String("consoleproxyaddr", "127.0.0.1:6080", "Console proxy address")
 var initSql = flag.Bool("initSql", false, "Init db when using localSql")
 var debugLevels = flag.String("d", "", fmt.Sprintf("comma separated list of %v", log.DebugLevelStrings))
-var tlsKeyFile = flag.String("tlskey", "", "server tls key file")
+var apiTlsCertFile = flag.String("apiTlsCert", "", "API server tls cert file")
+var apiTlsKeyFile = flag.String("apiTlsKey", "", "API server tls key file")
 var clientCert = flag.String("clientCert", "", "internal tls client cert file")
 var localVault = flag.Bool("localVault", false, "Run local Vault")
 var ldapAddr = flag.String("ldapAddr", "127.0.0.1:9389", "LDAP listener address")
@@ -48,8 +49,7 @@ func main() {
 	nodeMgr.InitFlags()
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer(nodeMgr.TlsCertFile)
-	defer log.FinishTracer()
+	defer nodeMgr.Finish()
 
 	sigChan = make(chan os.Signal, 1)
 
@@ -66,8 +66,8 @@ func main() {
 		RunLocal:              *localSql,
 		InitLocal:             *initSql,
 		LocalVault:            *localVault,
-		TlsCertFile:           nodeMgr.TlsCertFile,
-		TlsKeyFile:            *tlsKeyFile,
+		ApiTlsCertFile:        *apiTlsCertFile,
+		ApiTlsKeyFile:         *apiTlsKeyFile,
 		LDAPAddr:              *ldapAddr,
 		GitlabAddr:            *gitlabAddr,
 		ArtifactoryAddr:       *artifactoryAddr,

--- a/mc/orm/alertmgr/alertmgr_test.go
+++ b/mc/orm/alertmgr/alertmgr_test.go
@@ -267,7 +267,7 @@ func (s *AlertmanagerMock) resetCounters() {
 }
 
 func TestAlertMgrServer(t *testing.T) {
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	// mock http to redirect requests

--- a/mc/orm/appstore_sync_test.go
+++ b/mc/orm/appstore_sync_test.go
@@ -113,7 +113,7 @@ func TestAppStoreApi(t *testing.T) {
 	var status int
 
 	log.SetDebugLevel(log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 
 	ctx := log.StartTestSpan(context.Background())

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -27,7 +27,7 @@ var Fail = false
 
 func TestController(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	addr := "127.0.0.1:9999"

--- a/mc/orm/ldap_test.go
+++ b/mc/orm/ldap_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestLDAPServer(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	addr := "127.0.0.1:9999"
 	uri := "http://" + addr + "/api/v1"

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -58,8 +58,8 @@ type ServerConfig struct {
 	RunLocal              bool
 	InitLocal             bool
 	IgnoreEnv             bool
-	TlsCertFile           string
-	TlsKeyFile            string
+	ApiTlsCertFile        string
+	ApiTlsKeyFile         string
 	LocalVault            bool
 	LDAPAddr              string
 	LDAPUsername          string
@@ -110,10 +110,6 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	}
 	nodeMgr = config.NodeMgr
 
-	span := log.StartSpan(log.DebugLevelInfo, "main")
-	defer span.Finish()
-	ctx := log.ContextWithSpan(context.Background(), span)
-
 	dbuser := os.Getenv("db_username")
 	dbpass := os.Getenv("db_password")
 	dbname := os.Getenv("db_name")
@@ -142,10 +138,11 @@ func RunServer(config *ServerConfig) (*Server, error) {
 		serverConfig.LDAPPassword = os.Getenv("LDAP_PASSWORD")
 	}
 
-	err := nodeMgr.Init(ctx, "mc", node.CertIssuerGlobal, node.WithName(config.Hostname))
+	ctx, span, err := nodeMgr.Init("mc", node.CertIssuerGlobal, node.WithName(config.Hostname))
 	if err != nil {
 		return nil, err
 	}
+	defer span.Finish()
 
 	if config.LocalVault {
 		vaultProc := process.Vault{
@@ -534,8 +531,8 @@ func RunServer(config *ServerConfig) (*Server, error) {
 
 	go func() {
 		var err error
-		if config.TlsCertFile != "" {
-			err = e.StartTLS(config.ServAddr, config.TlsCertFile, config.TlsKeyFile)
+		if config.ApiTlsCertFile != "" {
+			err = e.StartTLS(config.ServAddr, config.ApiTlsCertFile, config.ApiTlsKeyFile)
 		} else {
 			err = e.Start(config.ServAddr)
 		}
@@ -551,8 +548,8 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	ldapServer.SearchFunc("", handler)
 	go func() {
 		var err error
-		if config.TlsCertFile != "" {
-			err = ldapServer.ListenAndServeTLS(config.LDAPAddr, config.TlsCertFile, config.TlsKeyFile)
+		if config.ApiTlsCertFile != "" {
+			err = ldapServer.ListenAndServeTLS(config.LDAPAddr, config.ApiTlsCertFile, config.ApiTlsKeyFile)
 		} else {
 			err = ldapServer.ListenAndServe(config.LDAPAddr)
 		}
@@ -614,6 +611,7 @@ func (s *Server) Stop() {
 	if AlertManagerServer != nil {
 		AlertManagerServer.Stop()
 	}
+	nodeMgr.Finish()
 }
 
 func ShowVersion(c echo.Context) error {
@@ -839,7 +837,7 @@ func (s *Server) setupConsoleProxy(ctx context.Context) {
 		} else {
 			token = tokenVals[0]
 		}
-		if s.config.TlsCertFile != "" {
+		if s.config.ApiTlsCertFile != "" {
 			req.URL.Scheme = "https"
 		} else {
 			req.URL.Scheme = "http"
@@ -888,8 +886,8 @@ func (s *Server) setupConsoleProxy(ctx context.Context) {
 		proxy.ServeHTTP(w, r)
 	})
 
-	if s.config.TlsCertFile != "" {
-		err = http.ListenAndServeTLS(s.config.ConsoleProxyAddr, s.config.TlsCertFile, s.config.TlsKeyFile, nil)
+	if s.config.ApiTlsCertFile != "" {
+		err = http.ListenAndServeTLS(s.config.ConsoleProxyAddr, s.config.ApiTlsCertFile, s.config.ApiTlsKeyFile, nil)
 	} else {
 		err = http.ListenAndServe(s.config.ConsoleProxyAddr, nil)
 	}

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestServer(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelApi)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	addr := "127.0.0.1:9999"
 	uri := "http://" + addr + "/api/v1"

--- a/openstack-tenant/agent/cloudflare/dns_test.go
+++ b/openstack-tenant/agent/cloudflare/dns_test.go
@@ -55,7 +55,7 @@ func TestGetAPI(t *testing.T) {
 
 func TestGetDNSRecords(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelInfra)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 
@@ -75,7 +75,7 @@ func TestGetDNSRecords(t *testing.T) {
 
 func TestCreateDNSRecord(t *testing.T) {
 	log.SetDebugLevel(log.DebugLevelInfra)
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/plugin/common/cluster-svc-plugin_test.go
+++ b/plugin/common/cluster-svc-plugin_test.go
@@ -14,7 +14,7 @@ import (
 // TestAutoScaleT primarily checks that AutoScale template parsing works, because
 // otherwise cluster-svc could crash during runtime if template has an issue.
 func TestAutoScaleT(t *testing.T) {
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/shepherd/appinst-worker_test.go
+++ b/shepherd/appinst-worker_test.go
@@ -23,7 +23,7 @@ var testVmAppData = shepherd_common.AppMetrics{
 
 func TestVmStats(t *testing.T) {
 	var err error
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/shepherd/cloudlet-worker_test.go
+++ b/shepherd/cloudlet-worker_test.go
@@ -157,7 +157,7 @@ func TestCloudletAlerts(t *testing.T) {
 
 func TestCloudletStats(t *testing.T) {
 	var err error
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/shepherd/docker-stats_test.go
+++ b/shepherd/docker-stats_test.go
@@ -70,7 +70,7 @@ var testDockerClusterData = shepherd_common.ClusterMetrics{
 }
 
 func TestDockerStats(t *testing.T) {
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/shepherd/envoy-stats_test.go
+++ b/shepherd/envoy-stats_test.go
@@ -44,7 +44,7 @@ cluster.udp_backend8765.upstream_cx_overflow: 15
 cluster.udp_backend8765.upstream_cx_none_healthy: 16`
 
 func setupLog() context.Context {
-	log.InitTracer("")
+	log.InitTracer(nil)
 	ctx := log.StartTestSpan(context.Background())
 	return ctx
 }

--- a/shepherd/nginx-stats_test.go
+++ b/shepherd/nginx-stats_test.go
@@ -17,7 +17,7 @@ import (
 var testNginxData = "Active connections: 10\nserver accepts handled requests\n 101 202 303\nReading: 5 Writing: 4 Waiting: 3"
 
 func TestNginxStats(t *testing.T) {
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 

--- a/shepherd/prom-stats_test.go
+++ b/shepherd/prom-stats_test.go
@@ -273,7 +273,7 @@ func testMetricSend(ctx context.Context, metric *edgeproto.Metric) bool {
 }
 
 func TestPromStats(t *testing.T) {
-	log.InitTracer("")
+	log.InitTracer(nil)
 	defer log.FinishTracer()
 	ctx := log.StartTestSpan(context.Background())
 	initAppInstTestData()

--- a/shepherd/shepherd.go
+++ b/shepherd/shepherd.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mobiledgex/edge-cloud/notify"
 	"github.com/mobiledgex/edge-cloud/tls"
 	"github.com/mobiledgex/edge-cloud/util/tasks"
-	opentracing "github.com/opentracing/opentracing-go"
 )
 
 var debugLevels = flag.String("d", "", fmt.Sprintf("comma separated list of %v", log.DebugLevelStrings))
@@ -323,24 +322,17 @@ func main() {
 
 func start() {
 	log.SetDebugLevelStrs(*debugLevels)
-	log.InitTracer(nodeMgr.TlsCertFile)
 
-	var span opentracing.Span
-	if *parentSpan != "" {
-		span = log.NewSpanFromString(log.DebugLevelInfo, *parentSpan, "main")
-	} else {
-		span = log.StartSpan(log.DebugLevelInfo, "main")
-	}
-	defer span.Finish()
-	ctx := log.ContextWithSpan(context.Background(), span)
 	settings = *edgeproto.GetDefaultSettings()
 
 	cloudcommon.ParseMyCloudletKey(false, cloudletKeyStr, &cloudletKey)
 
-	err := nodeMgr.Init(ctx, "shepherd", node.CertIssuerRegionalCloudlet, node.WithCloudletKey(&cloudletKey), node.WithRegion(*region))
+	ctx, span, err := nodeMgr.Init("shepherd", node.CertIssuerRegionalCloudlet, node.WithCloudletKey(&cloudletKey), node.WithRegion(*region), node.WithParentSpan(*parentSpan))
 	if err != nil {
 		log.FatalLog(err.Error())
 	}
+	defer span.Finish()
+
 	clientTlsConfig, err := nodeMgr.InternalPki.GetClientTlsConfig(ctx,
 		nodeMgr.CommonName(),
 		node.CertIssuerRegionalCloudlet,
@@ -494,7 +486,7 @@ func stop() {
 	}
 	// stop cloudlet workers
 	close(stopCh)
-	log.FinishTracer()
+	nodeMgr.Finish()
 }
 
 type sendAllRecv struct{}


### PR DESCRIPTION
Infra changes for https://github.com/mobiledgex/edge-cloud/pull/1081.

The e2e-test removes all dependency on the hard-coded cert, and relies solely upon vault internal pki for communication between internal services. A quick way to check is to run NodeShow, which will show info on all the nodes in the system. The internalpki field should not have "from-file" for any of them.

A second category of "public" services exist, like Jaeger, ElasticSearch, and AlertManger, which use a letsencrypt public cert, but have vault-pki CAs to be able to authenticate vault-pki issued internal certs. For e2e-tests, we use the hard-coded cert in place of the letsencrypt public cert, and turn off verification on our services for those particular connections.

A third category of services exist, which are completely external facing endpoints. The MC API endpoint is I think the only case, whose clients are just the e2e test code and mcctl run from the e2e-test code. Again for e2e-tests, we use the hard-coded cert in place of a letsencrypt public cert. Note that for MC, I've explicitly separated the --tls option (for internal pki) and the --apiTlsCert options for the public API endpoint, so they can be configured separately.

The remaining changes are for ansible to remove use of the --tls option everywhere, and add --useVaultCerts everywhere instead.