### PR TITLE
EDGECLOUD-3643 VMPool : CreateCloudlet fails with error 'missing cloudlet private key'

### DIFF
--- a/crm-platforms/vmpool/vmpool-provider.go
+++ b/crm-platforms/vmpool/vmpool-provider.go
@@ -658,7 +658,7 @@ func (s *VMPoolPlatform) VerifyVMs(ctx context.Context, vms []edgeproto.VM) erro
 	case <-wgDone:
 		break
 	case err := <-wgError:
-		close(wgError)
+		// note: do not close wgError, let gc clean it
 		return err
 	case <-time.After(AllVMAccessTimeout):
 		return fmt.Errorf("Timed out verifying VMs")

--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -167,6 +167,11 @@ func (v *VMPlatform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 		return err
 	}
 
+	err = v.InitCloudletSSHKeys(ctx, vaultConfig)
+	if err != nil {
+		return err
+	}
+
 	// Source OpenRC file to access openstack API endpoint
 	updateCallback(edgeproto.UpdateTask, "Sourcing access variables")
 	log.SpanLog(ctx, log.DebugLevelInfra, "Sourcing access variables", "region", pfConfig.Region, "cloudletKey", cloudlet.Key, "PhysicalName", cloudlet.PhysicalName)
@@ -305,6 +310,11 @@ func (v *VMPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 	updateCallback(edgeproto.UpdateTask, "Deleting cloudlet")
 
 	vaultConfig, err := vault.BestConfig(pfConfig.VaultAddr, vault.WithEnvMap(pfConfig.EnvVar))
+	if err != nil {
+		return err
+	}
+
+	err = v.InitCloudletSSHKeys(ctx, vaultConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* Create/DeleteCloudlet were missing cloudlet keys. Added them
* Also fixed a race issue, goroutines were writing to a closed wgError. Let GC handle cleanup of wgError chan