### PR TITLE
fix heat unit test for vault keys

### DIFF
--- a/crm-platforms/openstack/openstack-fip-test-heat-expected.yaml
+++ b/crm-platforms/openstack/openstack-fip-test-heat-expected.yaml
@@ -129,6 +129,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -178,6 +183,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -217,6 +227,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -256,6 +271,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC

--- a/crm-platforms/openstack/openstack-fip-test-heat.yaml
+++ b/crm-platforms/openstack/openstack-fip-test-heat.yaml
@@ -129,6 +129,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -178,6 +183,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -217,6 +227,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -256,6 +271,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC

--- a/crm-platforms/openstack/openstack-test-heat-expected.yaml
+++ b/crm-platforms/openstack/openstack-test-heat-expected.yaml
@@ -121,6 +121,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -170,6 +175,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -209,6 +219,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -248,6 +263,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC

--- a/crm-platforms/openstack/openstack-test-heat.yaml
+++ b/crm-platforms/openstack/openstack-test-heat.yaml
@@ -121,6 +121,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -170,6 +175,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -209,6 +219,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC
@@ -248,6 +263,11 @@ resources:
                  - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
                  - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
                  - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
                 chpasswd: { expire: False }
                 ssh_pwauth: False
                 timezone: UTC

--- a/crm-platforms/openstack/openstack.go
+++ b/crm-platforms/openstack/openstack.go
@@ -15,7 +15,6 @@ import (
 type OpenstackPlatform struct {
 	openRCVars   map[string]string
 	VMProperties *vmlayer.VMProperties
-	TestMode     bool
 }
 
 func (o *OpenstackPlatform) GetType() string {
@@ -76,7 +75,7 @@ func (o *OpenstackPlatform) GetResourceID(ctx context.Context, resourceType vmla
 	switch resourceType {
 	case vmlayer.ResourceTypeSecurityGroup:
 		// for testing mode, don't try to run APIs just fake a value
-		if o.TestMode {
+		if o.VMProperties.CommonPf.PlatformConfig.TestMode {
 			return resourceName + "-testingID", nil
 		}
 		return o.GetSecurityGroupIDForName(ctx, resourceName)

--- a/crm-platforms/openstack/openstack_accessvars_test.go
+++ b/crm-platforms/openstack/openstack_accessvars_test.go
@@ -52,7 +52,7 @@ func TestAccessVars(t *testing.T) {
 		VaultAddr: vaultConfig.Addr,
 		EnvVar:    envvars,
 	}
-	op := OpenstackPlatform{TestMode: true}
+	op := OpenstackPlatform{}
 	o := vmlayer.VMPlatform{
 		Type:       "openstack",
 		VMProvider: &op,

--- a/crm-platforms/openstack/openstack_heat_test.go
+++ b/crm-platforms/openstack/openstack_heat_test.go
@@ -126,7 +126,7 @@ func TestHeatTemplate(t *testing.T) {
 	pc := pf.PlatformConfig{}
 	pc.CloudletKey = &ckey
 
-	op := OpenstackPlatform{TestMode: true}
+	op := OpenstackPlatform{}
 	var vmp = vmlayer.VMPlatform{
 		Type:       "openstack",
 		VMProvider: &op,
@@ -135,7 +135,7 @@ func TestHeatTemplate(t *testing.T) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "init props done", "err", err)
 	require.Nil(t, err)
 	op.VMProperties.CommonPf.Properties.SetValue("MEX_EXT_NETWORK", "external-network-shared")
-
+	op.VMProperties.CommonPf.PlatformConfig.TestMode = true
 	// Add chef params
 	for _, vm := range vms {
 		vm.ChefParams = &chefmgmt.VMChefParams{


### PR DESCRIPTION
Fix the heat unit-test.  

Use the PlatformConfig.TestMode to bypass pulling the cacert from the vault and use a dummy instead.  Because we need a test flag visible within the vmlayer, get rid of the openstack specific test mode flag and just use the platform one.