### PR TITLE
SSH key upgrade fixes

### DIFF
--- a/vmlayer/ssh.go
+++ b/vmlayer/ssh.go
@@ -306,10 +306,11 @@ func (v *VMPlatform) GetAllCloudletVMs(ctx context.Context, caches *platform.Cac
 			dockerNodeIP, err := v.GetIPFromServerName(ctx, v.VMProperties.GetCloudletMexNetwork(), GetClusterSubnetName(ctx, clusterInst), dockerNode)
 			if err != nil {
 				log.SpanLog(ctx, log.DebugLevelInfra, "error getting docker node IP", "vm", dockerNode, "err", err)
-			}
-			dockerNodeClient, err = lbClient.AddHop(dockerNodeIP.ExternalAddr, 22)
-			if err != nil {
-				log.SpanLog(ctx, log.DebugLevelInfra, "Fail to addhop to docker node", "dockerNodeIP", dockerNodeIP, "err", err)
+			} else {
+				dockerNodeClient, err = lbClient.AddHop(dockerNodeIP.ExternalAddr, 22)
+				if err != nil {
+					log.SpanLog(ctx, log.DebugLevelInfra, "Fail to addhop to docker node", "dockerNodeIP", dockerNodeIP, "err", err)
+				}
 			}
 			cloudletVMs = append(cloudletVMs, VMAccess{
 				Name:   dockerNode,


### PR DESCRIPTION
EDGECLOUD-3659

Address the following for sshkey upgrade within GetAllCloudletVMs
- code currently exits loop unless ClusterInstCache cache fails (IF stmt reversed)
- need to handle docker nodes
- need to handle VM APPs with LB
- LBs need to be added to the end of the list, not the beginning. Otherwise the upgrade script fails because we use the id_rsa_mex key for that part, and once we've replaced the key on the LB the net hops will not be reachable
