### PR TITLE
EDGECLOUD-3665 token missing in mcctl password reset email

### DIFF
--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -474,6 +474,7 @@ func PasswordResetRequest(c echo.Context) error {
 			arg.URL = req.CallbackURL + "?token=" + cookie
 		}
 		arg.Name = user.Name
+		arg.Token = cookie
 		tmpl = passwordResetTmpl
 	}
 	buf := bytes.Buffer{}


### PR DESCRIPTION
Fix for missing token in password reset email when generated from mcctl request.