### PR TITLE
EDGECLOUD-3584  mcctl alert receiver create

### DIFF
--- a/mc/mcctl/ormctl/alert_receiver.go
+++ b/mc/mcctl/ormctl/alert_receiver.go
@@ -24,7 +24,7 @@ func GetAlertReceiverCommand() *cobra.Command {
 	cmds := []*cli.Command{&cli.Command{
 		Use:          "create",
 		RequiredArgs: strings.Join(AlertReceiverRequiredArgs, " "),
-		OptionalArgs: strings.Join(AlertReceiverOptionaldArgs, " "),
+		OptionalArgs: strings.Join(AlertReceiverOptionalArgs, " "),
 		AliasArgs:    strings.Join(AlertReceiverAliasArgs, " "),
 		Comments:     AlertReceiverArgsComments,
 		ReqData:      &ormapi.AlertReceiver{},
@@ -32,7 +32,7 @@ func GetAlertReceiverCommand() *cobra.Command {
 	}, &cli.Command{
 		Use:          "delete",
 		RequiredArgs: strings.Join(AlertReceiverRequiredArgs, " "),
-		OptionalArgs: strings.Join(AlertReceiverOptionaldArgs, " "),
+		OptionalArgs: strings.Join(AlertReceiverOptionalArgs, " "),
 		ReqData:      &ormapi.AlertReceiver{},
 		AliasArgs:    strings.Join(AlertReceiverAliasArgs, " "),
 		Comments:     AlertReceiverArgsComments,
@@ -51,7 +51,7 @@ var AlertReceiverRequiredArgs = []string{
 	"severity",
 }
 
-var AlertReceiverOptionaldArgs = []string{
+var AlertReceiverOptionalArgs = []string{
 	"appname",
 	"appvers",
 	"app-org",
@@ -68,9 +68,9 @@ var AlertReceiverArgsComments = map[string]string{
 	"appname":          "App Instance name",
 	"appvers":          "App Instance version",
 	"app-cloudlet":     "Cloudlet name where app instance is deployed",
-	"app-cloudlet-org": "Cloudlet organization that owns the cloudlet",
+	"app-cloudlet-org": "Company, or Organization that owns the cloudlet",
 	"cluster":          "App Instance Cluster name",
-	"cluster-org":      "Organization or Company Name that a Cluster is owned by",
-	"cloudlet-org":     "Company or Organization name of the cloudlet",
+	"cluster-org":      "Company, or Organization Name that a Cluster is owned by",
+	"cloudlet-org":     "Company, or Organization name of the cloudlet",
 	"cloudlet":         "Name of the cloudlet",
 }

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -349,7 +349,7 @@ type AlertReceiver struct {
 	Name string
 	// Receiver type. Eg. email, slack, pagerduty
 	Type string
-	// Alert severify filter
+	// Alert severity filter
 	Severity string
 	// User string, hidden from API
 	User string `json:"-"`


### PR DESCRIPTION
Add help strings and list of optional args for alertreceiver cmd.
below is an example output:

```
$ mcctl --addr https://0.0.0.0:9900 --skipverify alertreceiver create
Error: missing required args: name type severity
Usage: mcctl alertreceiver create [flags] [args]

Required Args:
  name
  type
  severity

Optional Args:
  appname           App Instance name
  appvers           App Instance version
  app-org           Organization or Company name of the App Instance
  app-cloudlet      Cloudlet name where app instance is deployed
  app-cloudlet-org  Cloudlet organization that owns the cloudlet
  cluster           App Instance Cluster name
  cluster-org       Organization or Company Name that a Cluster is owned by
  cloudlet          Name of the cloudlet
  cloudlet-org      Company or Organization name of the cloudlet

Flags:
  -h, --help   help for create

Global Flags:
      --addr string            MC address (default "http://127.0.0.1:9900")
      --data string            json formatted input data, alternative to name=val args list
      --datafile string        file containing json/yaml formatted input data, alternative to name=val args list
      --debug                  debug
      --output-format string   output format: yaml, json, or json-compact (default "yaml")
      --output-stream          stream output incrementally if supported by command (default true)
      --parsable               generate parsable output
      --silence-usage          silence-usage
      --skipverify             don't verify cert for TLS connections
      --token string           JWT token
```