### PR TITLE
edgecloud-3662 persistent ssh connection for vm lbs

### DIFF
--- a/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
+++ b/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
@@ -112,6 +112,13 @@ func (s *ShepherdPlatform) GetClusterPlatformClient(ctx context.Context, cluster
 func (s *ShepherdPlatform) GetVmAppRootLbClient(ctx context.Context, app *edgeproto.AppInstKey) (ssh.Client, error) {
 	rootLBName := cloudcommon.GetVMAppFQDN(app, s.VMPlatform.VMProperties.CommonPf.PlatformConfig.CloudletKey, s.VMPlatform.VMProperties.CommonPf.PlatformConfig.AppDNSRoot)
 	client, err := s.VMPlatform.GetNodePlatformClient(ctx, &edgeproto.CloudletMgmtNode{Name: rootLBName})
+	if err != nil {
+		return nil, err
+	}
+	err = client.StartPersistentConn(shepherd_common.ShepherdSshConnectTimeout)
+	if err != nil {
+		return nil, err
+	}
 	return client, err
 }
 


### PR DESCRIPTION
for shared and dedicated cluster rootlbs, shepherd uses a persistent ssh connection. Made it the same for vm rootlbs