### PR TITLE
fix broken unit-tests

### DIFF
--- a/mc/orm/appstore_sync_test.go
+++ b/mc/orm/appstore_sync_test.go
@@ -131,15 +131,16 @@ func TestAppStoreApi(t *testing.T) {
 	uri := "http://" + addr + "/api/v1"
 
 	config := ServerConfig{
-		ServAddr:        addr,
-		SqlAddr:         "127.0.0.1:5445",
-		RunLocal:        true,
-		InitLocal:       true,
-		IgnoreEnv:       true,
-		ArtifactoryAddr: artifactoryAddr,
-		GitlabAddr:      gitlabAddr,
-		SkipVerifyEmail: true,
-		LocalVault:      true,
+		ServAddr:                addr,
+		SqlAddr:                 "127.0.0.1:5445",
+		RunLocal:                true,
+		InitLocal:               true,
+		IgnoreEnv:               true,
+		ArtifactoryAddr:         artifactoryAddr,
+		GitlabAddr:              gitlabAddr,
+		SkipVerifyEmail:         true,
+		LocalVault:              true,
+		UsageCheckpointInterval: "MONTH",
 	}
 
 	server, err := RunServer(&config)

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -37,13 +37,14 @@ func TestController(t *testing.T) {
 	defer vaultServer.Close()
 
 	config := ServerConfig{
-		ServAddr:        addr,
-		SqlAddr:         "127.0.0.1:5445",
-		RunLocal:        true,
-		InitLocal:       true,
-		IgnoreEnv:       true,
-		SkipVerifyEmail: true,
-		vaultConfig:     vaultConfig,
+		ServAddr:                addr,
+		SqlAddr:                 "127.0.0.1:5445",
+		RunLocal:                true,
+		InitLocal:               true,
+		IgnoreEnv:               true,
+		SkipVerifyEmail:         true,
+		vaultConfig:             vaultConfig,
+		UsageCheckpointInterval: "MONTH",
 	}
 	server, err := RunServer(&config)
 	require.Nil(t, err, "run server")

--- a/mc/orm/ldap_test.go
+++ b/mc/orm/ldap_test.go
@@ -23,16 +23,17 @@ func TestLDAPServer(t *testing.T) {
 	defer vaultServer.Close()
 
 	config := ServerConfig{
-		ServAddr:        addr,
-		SqlAddr:         "127.0.0.1:5445",
-		RunLocal:        true,
-		InitLocal:       true,
-		IgnoreEnv:       true,
-		LDAPAddr:        "127.0.0.1:9389",
-		SkipVerifyEmail: true,
-		vaultConfig:     vaultConfig,
-		LDAPUsername:    "gitlab",
-		LDAPPassword:    "gitlab",
+		ServAddr:                addr,
+		SqlAddr:                 "127.0.0.1:5445",
+		RunLocal:                true,
+		InitLocal:               true,
+		IgnoreEnv:               true,
+		LDAPAddr:                "127.0.0.1:9389",
+		SkipVerifyEmail:         true,
+		vaultConfig:             vaultConfig,
+		LDAPUsername:            "gitlab",
+		LDAPPassword:            "gitlab",
+		UsageCheckpointInterval: "MONTH",
 	}
 	server, err := RunServer(&config)
 	require.Nil(t, err, "run server")

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -32,13 +32,14 @@ func TestServer(t *testing.T) {
 	BadAuthDelay = time.Millisecond
 
 	config := ServerConfig{
-		ServAddr:        addr,
-		SqlAddr:         "127.0.0.1:5445",
-		RunLocal:        true,
-		InitLocal:       true,
-		IgnoreEnv:       true,
-		SkipVerifyEmail: true,
-		vaultConfig:     vaultConfig,
+		ServAddr:                addr,
+		SqlAddr:                 "127.0.0.1:5445",
+		RunLocal:                true,
+		InitLocal:               true,
+		IgnoreEnv:               true,
+		SkipVerifyEmail:         true,
+		vaultConfig:             vaultConfig,
+		UsageCheckpointInterval: "MONTH",
 	}
 	server, err := RunServer(&config)
 	require.Nil(t, err, "run server")


### PR DESCRIPTION
Unit tests were failing because of a UsageCheckpointInterval parse error.