### PR TITLE
EDGECLOUD-3684 EDGECLOUD-3678 Better error messages for alertmanager errors

### DIFF
--- a/mc/orm/alertmgr/sidecar-server.go
+++ b/mc/orm/alertmgr/sidecar-server.go
@@ -250,7 +250,7 @@ func (s *SidecarServer) alertReceiver(w http.ResponseWriter, req *http.Request) 
 		for _, rec := range config.Receivers {
 			if rec.Name == receiverConfig.Receiver.Name {
 				log.SpanLog(ctx, log.DebugLevelInfo, "Receiver Exists - delete it first")
-				http.Error(w, "Receiver Exists - delete it first", http.StatusBadRequest)
+				http.Error(w, "Receiver Exists - delete it first", http.StatusConflict)
 				return
 			}
 		}

--- a/mc/orm/alertmgr_api.go
+++ b/mc/orm/alertmgr_api.go
@@ -26,6 +26,10 @@ func CreateAlertReceiver(c echo.Context) error {
 	if !success {
 		return err
 	}
+	// sanity check
+	if in.Name == "" {
+		return setReply(c, fmt.Errorf("Receiver name has to be specified"), nil)
+	}
 	in.User = claims.Username
 	if in.Cloudlet.Organization == "" && in.AppInst.AppKey.Organization == "" {
 		return setReply(c,


### PR DESCRIPTION
This change addresses bugs EDGECLOUD-3678 and EDGECLOUD-3684
 * decode an actual error message and add it to the error string.
 * disallow creation of an alert receiver without a name
 * change error code to `http.StatusConflict`  for duplicate named alert receiver