### PR TITLE
EDGECLOUD-3707 require password check if requirements changed

### DIFF
--- a/e2e-tests/e2e-setup/cmp.go
+++ b/e2e-tests/e2e-setup/cmp.go
@@ -59,8 +59,10 @@ var IgnoreAdminUser = cmpopts.AcyclicTransformer("removeAdminUser", func(users [
 var IgnoreTaskStatusMessages = cmpopts.AcyclicTransformer("ignoreTaskStatus", func(ar ormapi.AuditResponse) ormapi.AuditResponse {
 	if !strings.Contains(ar.OperationName, "/data/create") &&
 		!strings.Contains(ar.OperationName, "/ctrl/CreateClusterInst") &&
+		!strings.Contains(ar.OperationName, "/ctrl/DeleteClusterInst") &&
 		!strings.Contains(ar.OperationName, "/ctrl/CreateAppInst") &&
 		!strings.Contains(ar.OperationName, "/ctrl/DeleteAppInst") &&
+		!strings.Contains(ar.OperationName, "/ctrl/DeleteCloudlet") &&
 		!strings.Contains(ar.OperationName, "/ctrl/CreateCloudlet") {
 		return ar
 	}

--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -303,6 +303,9 @@ func AddUserRoleObj(ctx context.Context, claims *UserClaims, role *ormapi.Role) 
 		return dbErr(res.Error)
 	}
 	if adminRole {
+		if targetUser.PassCrackTimeSec == 0 {
+			return fmt.Errorf("Target user password strength not verified, please have user log in to verify password strength")
+		}
 		// more stringent password strength requirements
 		err := checkPasswordStrength(ctx, &targetUser, nil, adminRole)
 		if err != nil {


### PR DESCRIPTION
One issue Leon hit in testing is that if an admin user was created when password strength requirements were configured low, but then later the password strength requirements were made high, the admin could still log in.

One way to fix this is to always check the password strength on login, which I was avoiding because it requires a few extra SQL queries. The other way which I've done here is to reset the saved password strength on all users if the configured requirements change. This triggers a re-check of the password strength only at the next login for every user. Given that changes to password strength requirements will likely be very infrequent, this should be much more performant than having to check every log in.

Changes:
- reset all user's saved password strength on requirement config change (triggers pw strength check at next log in)
- require configuration's admin pw strength to be higher than general users
- better error message for admin role add if user's password strength has not been checked
- unit tests for all of the above
- unrelated fix to intermittent e2e-test failure