### PR TITLE
EDGECLOUD-3717 Update Artifactory version, set strong password policy

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -38,7 +38,7 @@ vault_root_ca_cert_path: secret/certs/root-ca
 mc_creds_vault_path: "secret/ansible/{{ deploy_environ }}/accounts/mc"
 vouch_hostname: vouch.mobiledgex.net
 influxdb_vm_hostname: influxdb.internal.mobiledgex.net
-artifactory_version: 6.14.1
+artifactory_version: 6.22.0
 mex_ca_cert_dir: /etc/ssl/local
 mex_ca_cert_der: "{{ mex_ca_cert_dir }}/mex-ca.der"
 mex_ca_cert_pem: "{{ mex_ca_cert_dir }}/mex-ca.crt"


### PR DESCRIPTION
- Bump up Artifactory to version 6.22
- Password policy set (manually) to this:
  ```  
  password-policy:
    uppercase: "1"
    lowercase: "1"
    digit: "1"
    length: "10"
    not-match-old: "true"
  user-lock-policy:
    attempts: 5
    seconds-to-unlock: 900
  ```