### PR TITLE
Alertmanager and autoprov e2e-tests fixes

### DIFF
--- a/e2e-tests/testfiles/autoprov.yml
+++ b/e2e-tests/testfiles/autoprov.yml
@@ -38,13 +38,13 @@ tests:
     apifile: "{{datadir2}}/autoprov_clearactive"
 
   - name: sleep, allow undeploy alert to be visible as pending
-    actions: [sleep=3]
+    actions: [sleep=2]
 
   - name: check undeploy alerts
     actions: [mcapi-showalerts]
     apifile: '{{datadir2}}/show_local_region.yml'
     curuserfile: '{{datadir2}}/mc_admin.yml'
-    retrycount: 10
+    retrycount: 20
     retryintervalsec: 0.5
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'

--- a/mc/orm/alertmgr/sidecar-server.go
+++ b/mc/orm/alertmgr/sidecar-server.go
@@ -13,6 +13,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"text/template"
@@ -24,6 +26,7 @@ import (
 
 	//	alertmanager_config "github.com/prometheus/alertmanager/config"
 	// TODO - below is to replace the above for right now - once we update go and modules we can use prometheus directly
+	intprocess "github.com/mobiledgex/edge-cloud-infra/e2e-tests/int-process"
 	alertmanager_config "github.com/mobiledgex/edge-cloud-infra/mc/orm/alertmgr/prometheus_structs/config"
 )
 
@@ -399,6 +402,16 @@ func (s *SidecarServer) writeAlertmanagerConfigLocked(ctx context.Context, confi
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfo, "Failed to write default alertmanager config", "err", err, "file", s.alertMgrConfigPath)
 		return err
+	}
+	if runtime.GOOS == "darwin" {
+		// probably because of the way docker uses VMs on mac,
+		// the file watch doesn't detect changes done to the targets
+		// file in the host.
+		cmd := exec.Command("docker", "exec", intprocess.PrometheusContainer, "touch", s.alertMgrConfigPath)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfo, "Failed to touch alertmgr file in container to trigger refresh in alertmanager", "out", string(out), "err", err)
+		}
 	}
 
 	// trigger reload of the config


### PR DESCRIPTION
Touch config file to make sure alertmgr file gets propagated - similar to what we have to do for cloudlet prometheus.
Tweak timers for autoprov tests