### PR TITLE
EDGECLOUD-3733  alertreceiver does not give an error when it cannot delete the receiver

### DIFF
--- a/mc/orm/alertmgr/alertmgr_test.go
+++ b/mc/orm/alertmgr/alertmgr_test.go
@@ -466,9 +466,11 @@ func TestAlertMgrServer(t *testing.T) {
 	// should be empty response
 	require.Len(t, receivers, 0)
 
-	// Delete non-existent receiver - nothing should change
+	// Delete non-existent receiver
 	err = testAlertMgrServer.DeleteReceiver(ctx, &testAlertReceivers[0])
-	require.Nil(t, err)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "No receiver")
+	require.Contains(t, err.Error(), "bad response status 404 Not Found")
 	require.Equal(t, 1, fakeAlertmanager.ConfigReloads)
 	fakeAlertmanager.verifyReceiversCnt(t, 2)
 	// Delete email receiver and verify it's deleted

--- a/mc/orm/alertmgr/sidecar-server.go
+++ b/mc/orm/alertmgr/sidecar-server.go
@@ -290,6 +290,19 @@ func (s *SidecarServer) alertReceiver(w http.ResponseWriter, req *http.Request) 
 				break
 			}
 		}
+		// We did not find the receiver - should return an error
+		if !writeConfig {
+			log.SpanLog(ctx, log.DebugLevelInfo, "Could not find a receiver", "receiver", receiverName)
+			recSent, err := getAlertReceiverFromName(receiverName)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			errStr := fmt.Sprintf("No receiver \"%s\" of type %s and severity %s for user \"%s\"",
+				recSent.Name, recSent.Type, recSent.Severity, recSent.User)
+			http.Error(w, errStr, http.StatusNotFound)
+			return
+		}
 	default:
 		log.SpanLog(ctx, log.DebugLevelInfo, "Unsupported method", "method", req.Method,
 			"url", req.URL)


### PR DESCRIPTION
Deleting non-existent receiver should give an error - added code to respond with an error in this case:

```
$ mcctl --addr https://0.0.0.0:9900 --skipverify alertreceiver delete name=DevOrgReceiver1 type=email email="somebody@nowhere.net" severity=error appname="Face Detection Demo" app-org="DevOrg" appvers="1.0" cluster=AppCluster cluster-org=DevOrg app-cloudlet=localtest app-cloudlet-org=mexdev
Error: Bad Request (400), Unable to delete a receiver - bad response status 404 Not Found[No receiver "DevOrgReceiver1" of type email and severity error for user "mexadmin"]
Usage: mcctl alertreceiver delete [flags] [args]
...

```