### PR TITLE
Clean up old events indexes in Elasticsearch

### DIFF
--- a/ansible/main/list
+++ b/ansible/main/list
@@ -17,6 +17,7 @@ letsencrypt_env=production
 console_vm_hostname=console.mobiledgex.net
 console_prod=yes
 alertmanager_hostname=alertmanager.mobiledgex.net
+events_elasticsearch_cleanup_age=183
 
 [notifyroot]
 notifyroot.mobiledgex.net

--- a/ansible/mexdemo/list
+++ b/ansible/mexdemo/list
@@ -22,6 +22,7 @@ gitlab_docker_hostname="docker.mobiledgex.net"
 azure_volume_storage_class=managed-premium
 influxdb_volume_size=10Gi
 console_prod=yes
+events_elasticsearch_cleanup_age=183
 
 [platform]
 localhost	ansible_connection=local

--- a/ansible/roles/esproxy/README.md
+++ b/ansible/roles/esproxy/README.md
@@ -30,3 +30,33 @@ API_KEY=...
 AUTH=$( echo -n "${ID}:${API_KEY}" | base64 )
 vault kv put secret/ansible/common/accounts/esproxy apikey="$AUTH"
 ```
+
+## Creating an API key for esproxy index management and cleanup
+
+```
+TAG=dev
+http --auth elastic POST https://3dd88757c3df44ac8960e53fc6a9a2d5.us-central1.gcp.cloud.es.io:9243/_security/api_key <<EOT
+{
+  "name": "esproxy-cleanup-${TAG}",
+  "role_descriptors": {
+    "esproxy-cleanup-${TAG}": {
+      "cluster": [],
+      "index": [
+        {
+          "names": [ "events-log-${TAG}-*" ],
+          "privileges": [
+            "delete_index",
+            "view_index_metadata"
+          ]
+        }
+      ]
+    }
+  }
+}
+EOT
+
+ID=...
+API_KEY=...
+AUTH=$( echo -n "${ID}:${API_KEY}" | base64 )
+vault kv put secret/ansible/common/accounts/esproxy_cleanup apikey="$AUTH"
+```

--- a/ansible/roles/esproxy/defaults/main.yml
+++ b/ansible/roles/esproxy/defaults/main.yml
@@ -1,0 +1,1 @@
+events_elasticsearch_cleanup_age: 30

--- a/ansible/roles/esproxy/tasks/main.yml
+++ b/ansible/roles/esproxy/tasks/main.yml
@@ -27,3 +27,24 @@
     backup: yes
   become: yes
   tags: setup
+
+- name: Load esproxy cleanup creds
+  import_role:
+    name: load-vault-creds
+    tasks_from:  esproxy_cleanup
+
+- name: Install index cleanup cron script
+  template:
+    src: index-cleanup.py.j2
+    dest: "{{ index_cleanup_script }}"
+    mode: 0500
+  become: yes
+
+- name: Install index cleanup cronjob
+  cron:
+    name: Events index cleanup
+    minute: 2
+    hour: 2
+    user: root
+    job: '{{ index_cleanup_script }} >>/var/log/index-cleanup.log'
+  become: yes

--- a/ansible/roles/esproxy/templates/index-cleanup.py.j2
+++ b/ansible/roles/esproxy/templates/index-cleanup.py.j2
@@ -1,0 +1,40 @@
+#!/usr/bin/python3
+
+from datetime import datetime, timedelta
+import logging
+import json
+import os
+import requests
+
+loglevel = logging.DEBUG if os.environ.get("DEBUG") == "true" else logging.INFO
+
+logging.basicConfig(format="%(asctime)s [%(levelname)s] %(msg)s", level=loglevel)
+
+ES = "{{ events_elasticsearch_url }}"
+ENVIRON = "{{ deploy_environ }}"
+APIKEY = "{{ esproxy_cleanup_apikey }}"
+CLEANUP_AGE = {{ events_elasticsearch_cleanup_age }}
+
+headers = {
+    "Authorization": "ApiKey {0}".format(APIKEY),
+}
+
+index_pattern = f"events-log-{ENVIRON}"
+indexes_url = f"{ES}/{index_pattern}-*"
+
+r = requests.get(indexes_url, headers=headers)
+if r.status_code != requests.codes.ok:
+    raise Exception(f"Failed to get index list: {r.status_code} {r.text}")
+
+limit = (datetime.today() - timedelta(days=CLEANUP_AGE)).strftime("%Y-%m-%d")
+oldest_index = f"{index_pattern}-{limit}"
+logging.debug(f"Deleting indexes older than {oldest_index}: {CLEANUP_AGE} days")
+
+indexes = r.json().keys()
+delete = [ x for x in indexes if x < oldest_index ]
+
+for index in delete:
+    logging.info(f"Deleting index: {index}")
+    r = requests.delete(f"{ES}/{index}", headers=headers)
+    if r.status_code != requests.codes.ok:
+        raise Exception(f"Failed to delete index: {index}: {r.status_code} {r.text}")

--- a/ansible/roles/esproxy/vars/main.yml
+++ b/ansible/roles/esproxy/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 mex_ca_cert_path: /etc/nginx/mex-ca.crt
+index_cleanup_script: /usr/local/bin/index-cleanup.py

--- a/ansible/roles/load-vault-creds/defaults/main.yml
+++ b/ansible/roles/load-vault-creds/defaults/main.yml
@@ -3,6 +3,7 @@ artifactory_publish_account_path: secret/ansible/common/accounts/artifactory_pub
 azure_account_path: secret/ansible/common/accounts/azure
 cloudflare_account_path: secret/ansible/common/accounts/cloudflare
 esproxy_account_path: secret/ansible/common/accounts/esproxy
+esproxy_cleanup_account_path: secret/ansible/common/accounts/esproxy_cleanup
 gcp_account_path: secret/ansible/common/accounts/gcp
 locapi_account_path: secret/ansible/common/accounts/locapi
 mc_ldap_vault_path: "secret/ansible/{{ deploy_environ }}/accounts/mc_ldap"

--- a/ansible/roles/load-vault-creds/tasks/esproxy_cleanup.yml
+++ b/ansible/roles/load-vault-creds/tasks/esproxy_cleanup.yml
@@ -1,0 +1,6 @@
+- name: Look up esproxy cleanup creds in vault
+  set_fact:
+    vault_lookup: "{{ lookup('vault', esproxy_cleanup_account_path) }}"
+
+- set_fact:
+    esproxy_cleanup_apikey: "{{ vault_lookup.esproxy_cleanup.data.apikey }}"


### PR DESCRIPTION
The default is to clean up events older than 30 days in all setups
other than main, and retain main for 6 months.