### PR TITLE
Edgecloud-3808: fix shepherd crash

### DIFF
--- a/vmlayer/vmprovider.go
+++ b/vmlayer/vmprovider.go
@@ -250,6 +250,10 @@ func (v *VMPlatform) InitProps(ctx context.Context, platformConfig *platform.Pla
 	for k, v := range providerProps {
 		props[k] = v
 	}
+	// sometimes commonPf might be nil (if coming from shepherd) so initialize it before InitInfraCommon
+	if v.VMProperties.CommonPf == nil {
+		v.VMProperties.CommonPf = &infracommon.CommonPlatform{}
+	}
 	err = v.VMProperties.CommonPf.InitInfraCommon(ctx, platformConfig, props, vaultConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
the problem was that `InitInfraCommon` would be getting called without the `CommonPlatform` actually being initialized, resulting in some nil dereferences