### PR TITLE
EDGECLOUD-3827 OWASP ZAP: Cross-Domain Misconfiguration

### DIFF
--- a/ansible/roles/crm/tasks/main.yml
+++ b/ansible/roles/crm/tasks/main.yml
@@ -119,7 +119,7 @@
   wait_for:
     host: "{{ (ansible_ssh_host|default(ansible_host))|default(inventory_hostname) }}"
     port: "{{ notify_srv_port }}"
-    timeout: 60
+    timeout: 180
   vars:
     ansible_connection: local
 

--- a/ansible/templates/mexplat/console-nginx-config.j2
+++ b/ansible/templates/mexplat/console-nginx-config.j2
@@ -7,11 +7,6 @@ server {
 
 	server_name {{ inventory_hostname }};
 
-	add_header 'Access-Control-Allow-Origin' '*';
-	add_header 'Access-Control-Allow-Credentials' 'true';
-	add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-	add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS';
-
 	add_header 'Cache-Control' 'no-cache, no-store, must-revalidate' always;
 	add_header 'X-Frame-Options' 'sameorigin' always;
 	add_header 'X-Content-Type-Options' 'nosniff' always;
@@ -61,29 +56,6 @@ server {
 	}
 
 	location ~ /(api|ws)/ {
-
-                if ($request_method ~ ^(HEAD|OPTIONS)$) {
-                        add_header 'Access-Control-Allow-Origin' '*';
-                        add_header 'Access-Control-Allow-Credentials' 'true';
-                        add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-                        add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS';
-                        add_header 'Access-Control-Max-Age' 1728000;
-                        add_header 'Content-Type' 'text/plain charset=UTF-8';
-                        add_header 'Content-Length' 0;
-                        return 204;
-                }
-		if ($request_method = 'POST') {
-			add_header 'Access-Control-Allow-Origin' '*';
-			add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-			add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Accept,Origin,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range';
-			add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-		}
-		if ($request_method = 'GET') {
-			add_header 'Access-Control-Allow-Origin' '*';
-			add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-			add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Accept,Origin,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range';
-			add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
-		}
 
 		proxy_pass http://127.0.0.1:{{ mc_api_port }};
 		proxy_http_version 1.1;


### PR DESCRIPTION
We don't need CORS headers anymore now that MC and console are
co-located behind the same reverse proxy.

Unrelated: Bumping up the timeout for the activation of the CRM notify
server port.  60 seconds seems to break deployments every so often from
last week.