### PR TITLE
EDGECLOUD-3650 access key part 3 cloud-init

### DIFF
--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -686,6 +686,7 @@ func (v *VMPlatform) GetCloudletVMsSpec(ctx context.Context, vaultConfig *vault.
 			pfImageName,
 			true, //connect external
 			WithChefParams(chefParams),
+			WithAccessKey(pfConfig.CrmAccessPrivateKey),
 		)
 		if err != nil {
 			return nil, err
@@ -708,6 +709,7 @@ func (v *VMPlatform) GetCloudletVMsSpec(ctx context.Context, vaultConfig *vault.
 					true, //connect external
 					WithSubnetConnection(subnetName),
 					WithChefParams(chefParams),
+					WithAccessKey(pfConfig.CrmAccessPrivateKey),
 				)
 			} else {
 				nodeAttributes := make(map[string]interface{})
@@ -721,6 +723,7 @@ func (v *VMPlatform) GetCloudletVMsSpec(ctx context.Context, vaultConfig *vault.
 					true, //connect external
 					WithSubnetConnection(subnetName),
 					WithChefParams(chefParams),
+					WithAccessKey(pfConfig.CrmAccessPrivateKey),
 				)
 			}
 			if err != nil {

--- a/vmlayer/vmconfig.go
+++ b/vmlayer/vmconfig.go
@@ -28,6 +28,13 @@ write_files:
   - path: /etc/ssh/trusted-user-ca-keys.pem
     content: {{ .CACert }}
     append: true
+{{- if .AccessKey }}
+  - path: /root/accesskey/accesskey.pem
+    content: |
+{{ Indent .AccessKey 10 }}
+    owner: root:root
+    permissions: '0600'
+{{- end}}
 chpasswd: { expire: False }
 ssh_pwauth: False
 timezone: UTC

--- a/vmlayer/vmparams.go
+++ b/vmlayer/vmparams.go
@@ -123,6 +123,7 @@ type VMRequestSpec struct {
 	ConnectToSubnet         string
 	ChefParams              *chefmgmt.VMChefParams
 	OptionalResource        string
+	AccessKey               string
 }
 
 type VMReqOp func(vmp *VMRequestSpec) error
@@ -198,6 +199,12 @@ func WithChefParams(chefParams *chefmgmt.VMChefParams) VMReqOp {
 func WithOptionalResource(optRes string) VMReqOp {
 	return func(s *VMRequestSpec) error {
 		s.OptionalResource = optRes
+		return nil
+	}
+}
+func WithAccessKey(accessKey string) VMReqOp {
+	return func(s *VMRequestSpec) error {
+		s.AccessKey = accessKey
 		return nil
 	}
 }
@@ -403,6 +410,7 @@ type VMCloudConfigParams struct {
 	ExtraBootCommands []string
 	ChefParams        *chefmgmt.VMChefParams
 	CACert            string
+	AccessKey         string
 }
 
 // VMOrchestrationParams contains all details  that are needed by the orchestator
@@ -837,6 +845,7 @@ func (v *VMPlatform) getVMGroupOrchestrationParamsFromGroupSpec(ctx context.Cont
 				vccp.ChefParams = vm.ChefParams
 			}
 			vccp.CACert = vaultSSHCert
+			vccp.AccessKey = vm.AccessKey
 			// gpu
 			if vm.OptionalResource == "gpu" {
 				gpuCmds := getGpuExtraCommands()


### PR DESCRIPTION
Changes to include the access key in cloud-init. This writes the access key to the VM after creation. It also puts the access key in the Heat stack manifest for GetCloudletManifest.