### PR TITLE
kubernetes token expire time

### DIFF
--- a/openstack-tenant/packages/mobiledgex/dependencies.common
+++ b/openstack-tenant/packages/mobiledgex/dependencies.common
@@ -14,7 +14,7 @@ kubeadm                         1.16.3-00
 kubectl                         1.16.3-00
 kubelet                         1.16.3-00
 nfs-kernel-server               1:1.3.4-2.1ubuntu5.3
-nvidia-440                      440.100-1
+nvidia-440                      440.100-4.15.0-122-generic-1
 nvidia-container-runtime        3.3.0-1
 nvidia-container-toolkit        1.2.1-1
 python                          2.7.15~rc1-1

--- a/openstack-tenant/packages/mobiledgex/install-k8s-master.sh
+++ b/openstack-tenant/packages/mobiledgex/install-k8s-master.sh
@@ -80,7 +80,7 @@ if [ $? -ne 0 ]; then
     echo kubectl exited with error doing get nodes
     exit 1
 fi
-kubeadm token create --print-join-command  | tee /tmp/k8s-join-cmd.tmp
+kubeadm token create --ttl 0 --print-join-command | tee /tmp/k8s-join-cmd.tmp
 cat /tmp/k8s-join-cmd.tmp
 mv /tmp/k8s-join-cmd.tmp /var/tmp/k8s-join/k8s-join-cmd
 chown ubuntu:ubuntu /var/tmp/k8s-join/k8s-join-cmd


### PR DESCRIPTION
EDGECLOUD-3845

A problem was detected in autoscaling tests in which the new k8s nodes do not ever come online.   The problem is not specific to autoscaling, but can happen for any existing cluster that is > 24 hours old and new nodes are added to it.

The issue is that the k8s join token generated by the master has a time to live that defaults to 24 hours.   The fix is to set the TTL to 0 (indefinite) when generating the join token

@venkytv as I know you have a PR pending for baseimage changes, should we combine this with https://github.com/mobiledgex/edge-cloud-infra/pull/1124?   You would just need to pull in the install-k8s-master.sh change, the dependencies change you have already covered.   I didn't increment the baseimage version here because we have 2 fixes going on in parallel.   The 4.1.2 image in Berlin can be deleted if we decide to do this. 