### PR TITLE
mfa support for aws 

### DIFF
--- a/crm-platforms/aws/aws-ec2/aws-ec2-cli.go
+++ b/crm-platforms/aws/aws-ec2/aws-ec2-cli.go
@@ -34,8 +34,6 @@ const MainRouteTable string = "mainRouteTable"
 const MatchAnyVmName string = "anyvm"
 const MatchAnyGroupName string = "anygroup"
 
-const ArnAccountIdIdx = 4
-
 type AwsIamUser struct {
 	UserId string
 	Arn    string

--- a/crm-platforms/aws/aws-ec2/aws-ec2-cloudlet.go
+++ b/crm-platforms/aws/aws-ec2/aws-ec2-cloudlet.go
@@ -82,6 +82,10 @@ func (a *AwsEc2Platform) GetRouterDetail(ctx context.Context, routerName string)
 func (a *AwsEc2Platform) InitProvider(ctx context.Context, caches *platform.Caches, stage vmlayer.ProviderInitStage, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "InitProvider", "stage", stage)
 	a.InitData(ctx, caches)
+	err := a.awsGenPf.GetAwsSessionToken(ctx, a.VMProperties.CommonPf.VaultConfig)
+	if err != nil {
+		return err
+	}
 	vpcName := a.GetVpcName()
 
 	acct, err := a.GetIamAccountForImage(ctx)
@@ -177,6 +181,8 @@ func (a *AwsEc2Platform) InitProvider(ctx context.Context, caches *platform.Cach
 			return err
 		}
 	}
+
+	go a.awsGenPf.RefreshAwsSessionToken(a.VMProperties.CommonPf.PlatformConfig, a.VMProperties.CommonPf.VaultConfig)
 
 	return nil
 

--- a/crm-platforms/aws/aws-ec2/aws-ec2-security.go
+++ b/crm-platforms/aws/aws-ec2/aws-ec2-security.go
@@ -230,10 +230,5 @@ func (a *AwsEc2Platform) GetIamAccountForImage(ctx context.Context) (string, err
 		err = fmt.Errorf("cannot unmarshal, %v", err)
 		return "", err
 	}
-	arns := strings.Split(iamResult.User.Arn, ":")
-	if len(arns) <= ArnAccountIdIdx {
-		log.SpanLog(ctx, log.DebugLevelInfra, "Wrong number of fields in ARN", "iamResult.User.Arn", iamResult.User.Arn)
-		return "", fmt.Errorf("Cannot parse IAM ARN: %s", iamResult.User.Arn)
-	}
-	return arns[ArnAccountIdIdx], nil
+	return a.awsGenPf.GetUserAccountIdFromArn(ctx, iamResult.User.Arn)
 }

--- a/crm-platforms/aws/aws-generic/aws-auth.go
+++ b/crm-platforms/aws/aws-generic/aws-auth.go
@@ -1,0 +1,135 @@
+package awsgeneric
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	pf "github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
+	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/vault"
+)
+
+const SessionTokenDurationSecs = 60 * 60 * 24 // 24 hours
+const AwsSessionTokenRefreshInterval = 12 * time.Hour
+
+type AwsSessionCredentials struct {
+	AccessKeyId     string
+	SecretAccessKey string
+	SessionToken    string
+	Expiration      string
+}
+
+type AwsSessionData struct {
+	Credentials AwsSessionCredentials
+}
+
+// GetAwsSessionToken gets a totp code from the vault and then gets an AWS session token
+func (a *AwsGenericPlatform) GetAwsSessionToken(ctx context.Context, vaultConfig *vault.Config) error {
+	user, err := a.GetUserAccountIdFromArn(ctx, a.GetAwsUserArn())
+	code, err := a.GetAwsTotpToken(ctx, vaultConfig, user)
+	if err != nil {
+		return err
+	}
+	return a.GetAwsSessionTokenWithCode(ctx, code)
+}
+
+// GetAwsTotpToken gets a totp token from the vault
+func (a *AwsGenericPlatform) GetAwsTotpToken(ctx context.Context, vaultConfig *vault.Config, account string) (string, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetAwsTotpToken", "account", account)
+	path := "totp/code/aws-" + account
+	client, err := vaultConfig.Login()
+	if err != nil {
+		return "", err
+	}
+	vdat, err := vault.GetKV(client, path, 0)
+	if err != nil {
+		return "", err
+	}
+	code, ok := vdat["code"]
+	if !ok {
+		return "", fmt.Errorf("no totp code received from vault")
+	}
+	return code.(string), nil
+}
+
+// GetAwsSessionTokenWithCode uses the provided code to get session token details from AWS
+func (a *AwsGenericPlatform) GetAwsSessionTokenWithCode(ctx context.Context, code string) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetAwsSessionTokenWithCode", "code", code)
+	arn := a.GetAwsUserArn()
+	mfaSerial := strings.Replace(arn, ":user/", ":mfa/", 1)
+	out, err := a.TimedAwsCommand(ctx, "aws",
+		"sts",
+		"get-session-token",
+		"--serial-number", mfaSerial,
+		"--token-code", code,
+		"--duration-seconds", fmt.Sprintf("%d", SessionTokenDurationSecs))
+
+	if err != nil {
+		return fmt.Errorf("Error in get-session-token: %s - %v", string(out), err)
+	}
+	var sessionData AwsSessionData
+	err = json.Unmarshal(out, &sessionData)
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfra, "aws get-session-token unmarshal fail", "out", string(out), "err", err)
+		err = fmt.Errorf("cannot unmarshal, %v", err)
+		return err
+	}
+	// now set envvars
+	err = os.Setenv("AWS_ACCESS_KEY_ID", sessionData.Credentials.AccessKeyId)
+	if err != nil {
+		return err
+	}
+	err = os.Setenv("AWS_SECRET_ACCESS_KEY", sessionData.Credentials.SecretAccessKey)
+	if err != nil {
+		return err
+	}
+	err = os.Setenv("AWS_SESSION_TOKEN", sessionData.Credentials.SessionToken)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RefreshAwsSessionToken periodically gets a new session token
+func (a *AwsGenericPlatform) RefreshAwsSessionToken(pfconfig *pf.PlatformConfig, vaultConfig *vault.Config) {
+	interval := AwsSessionTokenRefreshInterval
+	for {
+		select {
+		case <-time.After(interval):
+		}
+		span := log.StartSpan(log.DebugLevelInfra, "refresh aws session token")
+		ctx := log.ContextWithSpan(context.Background(), span)
+
+		// save the old values in case we fail to get a new token
+		oldAccessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+		oldSecretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+		oldSessionToken := os.Getenv("AWS_SESSION_TOKEN")
+		os.Unsetenv("AWS_ACCESS_KEY_ID")
+		os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+		os.Unsetenv("AWS_SESSION_TOKEN")
+
+		// Call GetProviderSpecificProps which will reset the login credentials as we cannot use the
+		// session credentials to get a session token
+		_, err := a.GetProviderSpecificProps(ctx, pfconfig, vaultConfig)
+		if err == nil {
+
+			err = a.GetAwsSessionToken(ctx, vaultConfig)
+		}
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfra, "refresh aws session error", "err", err)
+			// retry again soon
+			interval = time.Hour
+			// reset the old values
+			os.Setenv("AWS_ACCESS_KEY_ID", oldAccessKey)
+			os.Setenv("AWS_SECRET_ACCESS_KEY", oldSecretAccessKey)
+			os.Setenv("AWS_SESSION_TOKEN", oldSessionToken)
+		} else {
+			interval = AwsSessionTokenRefreshInterval
+		}
+		span.Finish()
+	}
+}

--- a/crm-platforms/aws/aws-generic/aws-props.go
+++ b/crm-platforms/aws/aws-generic/aws-props.go
@@ -3,6 +3,7 @@ package awsgeneric
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
@@ -13,6 +14,7 @@ import (
 )
 
 const AwsDefaultVaultPath string = "/secret/data/cloudlet/aws/credentials"
+const ArnAccountIdIdx = 4
 
 var AWSProps = map[string]*edgeproto.PropertyInfo{
 	"AWS_ACCESS_KEY_ID": {
@@ -27,7 +29,6 @@ var AWSProps = map[string]*edgeproto.PropertyInfo{
 		Secret:      true,
 		Mandatory:   true,
 	},
-
 	"AWS_REGION": {
 		Name:        "AWS Region",
 		Description: "AWS Region",
@@ -50,6 +51,10 @@ var AWSProps = map[string]*edgeproto.PropertyInfo{
 	"AWS_OUTPOST_FLAVORS": {
 		Name:        "AWS Outpost Flavors",
 		Description: "AWS Outpost Flavors in format flavor1,vcpu,ram,disk;flavor2.. e.g. c5.large,2,4096,40;c5.xlarge,4,8192,40",
+	},
+	"AWS_USER_ARN": {
+		Name:        "AWS User ARN (Amazon Resource Name)",
+		Description: "AWS User ARN (Amazon Resource Name)",
 	},
 }
 
@@ -87,14 +92,19 @@ func (a *AwsGenericPlatform) GetAwsOutpostFlavors() string {
 	val, _ := a.Properties.GetValue("AWS_OUTPOST_FLAVORS")
 	return val
 }
+func (a *AwsGenericPlatform) GetAwsUserArn() string {
+	val, _ := a.Properties.GetValue("AWS_USER_ARN")
+	return val
+}
 
 func (a *AwsGenericPlatform) GetProviderSpecificProps(ctx context.Context, pfconfig *pf.PlatformConfig, vaultConfig *vault.Config) (map[string]*edgeproto.PropertyInfo, error) {
-	log.SpanLog(ctx, log.DebugLevelInfra, "GetProviderSpecificProps")
 	vaultPath := AwsDefaultVaultPath
 	if pfconfig.CloudletKey.Organization != "aws" {
 		// this is not a public cloud aws cloudlet, use the operator specific path
 		vaultPath = fmt.Sprintf("/secret/data/%s/cloudlet/%s/%s/%s/%s", pfconfig.Region, "aws", pfconfig.CloudletKey.Organization, pfconfig.PhysicalName, "credentials")
 	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetProviderSpecificProps", "vaultPath", vaultPath)
+
 	err := infracommon.InternVaultEnv(ctx, vaultConfig, vaultPath)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "Failed to intern vault data", "err", err)
@@ -102,4 +112,13 @@ func (a *AwsGenericPlatform) GetProviderSpecificProps(ctx context.Context, pfcon
 		return nil, err
 	}
 	return AWSProps, nil
+}
+
+func (a *AwsGenericPlatform) GetUserAccountIdFromArn(ctx context.Context, arn string) (string, error) {
+	arns := strings.Split(arn, ":")
+	if len(arns) <= ArnAccountIdIdx {
+		log.SpanLog(ctx, log.DebugLevelInfra, "Wrong number of fields in ARN", "iamResult.User.Arn", arn)
+		return "", fmt.Errorf("Cannot parse IAM ARN: %s", arn)
+	}
+	return arns[ArnAccountIdIdx], nil
 }


### PR DESCRIPTION
Support for MFA based login for AWS.   The vault TOTP plugin is used to provide a TOTP code which is used to get an AWS session token.  The token is good for 24 hours; after 12 we attempt to refresh it.  Similar logic is used as with SSH keys in that the refresh is sped up to 1 hour if it fails

