### PR TITLE
backwards compatible fix for vsphere resources

### DIFF
--- a/crm-platforms/vsphere/vsphere-tags.go
+++ b/crm-platforms/vsphere/vsphere-tags.go
@@ -202,7 +202,7 @@ func (v *VSpherePlatform) ParseVMDomainTag(ctx context.Context, tag string) (*VM
 	flavor, ok := fm[TagFieldFlavor]
 	if !ok {
 		// optional
-		return nil, fmt.Errorf("No flavor in vmdomain tag")
+		log.SpanLog(ctx, log.DebugLevelInfra, "No flavor in vmdomain tag", "tag", tag)
 	} else {
 		contents.Flavor = flavor
 	}

--- a/vmlayer/vmprovider.go
+++ b/vmlayer/vmprovider.go
@@ -428,10 +428,14 @@ func (v *VMPlatform) GetCloudletInfraResources(ctx context.Context) (*edgeproto.
 	platResources, err := v.VMProvider.GetServerGroupResources(ctx, v.GetPlatformVMName(&v.VMProperties.CommonPf.PlatformConfig.NodeMgr.MyNode.Key.CloudletKey))
 	if err == nil {
 		resources.Vms = append(resources.Vms, platResources.Vms...)
+	} else {
+		log.SpanLog(ctx, log.DebugLevelInfra, "Failed to get platform VM resources", "err", err)
 	}
 	rootlbResources, err := v.VMProvider.GetServerGroupResources(ctx, v.VMProperties.SharedRootLBName)
 	if err == nil {
 		resources.Vms = append(resources.Vms, rootlbResources.Vms...)
+	} else {
+		log.SpanLog(ctx, log.DebugLevelInfra, "Failed to get root lb resources", "err", err)
 	}
 	return &resources, nil
 }


### PR DESCRIPTION
EDGECLOUD-3063

Resources collection for existing VMs is not working in the QA environment because the new flavor tag is not present.  This should be optional.  Also add some logging for failure cases.