### PR TITLE
EDGECLOUD-3613 LDAP Port(9389) Open to Internet

### DIFF
--- a/terraform/mexplat/dev/main.tf
+++ b/terraform/mexplat/dev/main.tf
@@ -100,7 +100,9 @@ module "console" {
     "http-server",
     "https-server",
     "console-debug",
-    "mc",
+    "mc-artifactory",
+    "mc-ldap-${var.environ_tag}",
+    "mc-notify-${var.environ_tag}",
     "jaeger",
     "alt-https",
     "vault-ac",
@@ -186,4 +188,34 @@ module "fw_vault_gcp" {
   source                        = "../../modules/fw_vault_gcp"
   firewall_name                 = "${var.environ_tag}-vault-fw-hc-and-proxy"
   target_tag                    = "${var.environ_tag}-vault-hc-and-proxy"
+}
+
+resource "google_compute_firewall" mc_ldap {
+  name                          = "mc-ldap-${var.environ_tag}"
+  network                       = "default"
+
+  allow {
+    protocol                    = "tcp"
+    ports                       = [ "9389" ]
+  }
+
+  target_tags                   = [ "mc-ldap-${var.environ_tag}" ]
+  source_ranges                 = [
+    "${module.gitlab.external_ip}/32"
+  ]
+}
+
+resource "google_compute_firewall" mc_notify {
+  name                          = "mc-notify-${var.environ_tag}"
+  network                       = "default"
+
+  allow {
+    protocol                    = "tcp"
+    ports                       = [ "52001" ]
+  }
+
+  target_tags                   = [ "mc-notify-${var.environ_tag}" ]
+  source_ranges                 = [
+    "0.0.0.0/0"
+  ]
 }

--- a/terraform/mexplat/global/main.tf
+++ b/terraform/mexplat/global/main.tf
@@ -1,0 +1,42 @@
+provider "azurerm" {
+  version = "=1.24.0"
+
+  client_id       = "${var.azure_terraform_service_principal_id}"
+  client_secret   = "${var.azure_terraform_service_principal_secret}"
+  subscription_id = "${var.azure_subscription_id}"
+  tenant_id       = "${var.azure_tenant_id}"
+
+}
+
+provider "google" {
+  version = "=2.5.1"
+
+  project = "${var.gcp_project}"
+  zone    = "${var.gcp_zone}"
+}
+
+terraform {
+  backend "azurerm" {
+    storage_account_name  = "mexterraformstate"
+    container_name        = "mexplat-tfstate"
+    key                   = "global.tfstate"
+  }
+}
+
+# Firewall rules allowing Artifactory main and QA to talk to MC LDAP
+resource "google_compute_firewall" mc_artifactory {
+  name                    = "mc-artifactory"
+  description             = "Artifactory main and QA access to MC LDAP"
+  network                 = "default"
+
+  allow {
+    protocol              = "tcp"
+    ports                 = [ "9389" ]
+  }
+
+  target_tags             = [ "mc-artifactory" ]
+  source_ranges           = [
+    "35.233.222.88/32",
+    "35.222.133.62/32",
+  ]
+}

--- a/terraform/mexplat/global/variables.tf
+++ b/terraform/mexplat/global/variables.tf
@@ -1,0 +1,27 @@
+variable "azure_terraform_service_principal_id" {
+  description = "Azure service principal client ID"
+  type        = "string"
+}
+
+variable "azure_terraform_service_principal_secret" {
+  description = "Azure service principal client secret"
+  type        = "string"
+}
+
+variable "azure_subscription_id" {
+  description = "Azure subscription ID"
+  type        = "string"
+}
+
+variable "azure_tenant_id" {
+  description = "Azure tenant ID"
+  type        = "string"
+}
+
+variable "gcp_project" {
+  default     = "still-entity-201400"
+}
+
+variable "gcp_zone" {
+  default     = "us-west2-a"
+}

--- a/terraform/mexplat/main/main.tf
+++ b/terraform/mexplat/main/main.tf
@@ -92,7 +92,9 @@ module "console" {
     "http-server",
     "https-server",
     "console-debug",
-    "mc",
+    "mc-artifactory",
+    "mc-ldap-${var.environ_tag}",
+    "mc-notify-${var.environ_tag}",
     "notifyroot",
     "alertmanager",
   ]
@@ -132,4 +134,34 @@ module "fw_vault_gcp" {
   source                        = "../../modules/fw_vault_gcp"
   firewall_name                 = "${var.environ_tag}-vault-fw-hc-and-proxy"
   target_tag                    = "${var.environ_tag}-vault-hc-and-proxy"
+}
+
+resource "google_compute_firewall" mc_ldap {
+  name                          = "mc-ldap-${var.environ_tag}"
+  network                       = "default"
+
+  allow {
+    protocol                    = "tcp"
+    ports                       = [ "9389" ]
+  }
+
+  target_tags                   = [ "mc-ldap-${var.environ_tag}" ]
+  source_ranges                 = [
+    "${module.gitlab.external_ip}/32"
+  ]
+}
+
+resource "google_compute_firewall" mc_notify {
+  name                          = "mc-notify-${var.environ_tag}"
+  network                       = "default"
+
+  allow {
+    protocol                    = "tcp"
+    ports                       = [ "52001" ]
+  }
+
+  target_tags                   = [ "mc-notify-${var.environ_tag}" ]
+  source_ranges                 = [
+    "0.0.0.0/0"
+  ]
 }

--- a/terraform/mexplat/qa/main.tf
+++ b/terraform/mexplat/qa/main.tf
@@ -117,7 +117,9 @@ module "console" {
     "http-server",
     "https-server",
     "console-debug",
-    "mc",
+    "mc-artifactory",
+    "mc-ldap-${var.environ_tag}",
+    "mc-notify-${var.environ_tag}",
     "jaeger",
     "alt-https",
     "notifyroot",
@@ -182,4 +184,34 @@ module "fw_vault_gcp" {
   source                        = "../../modules/fw_vault_gcp"
   firewall_name                 = "${var.environ_tag}-vault-fw-hc-and-proxy"
   target_tag                    = "${var.environ_tag}-vault-hc-and-proxy"
+}
+
+resource "google_compute_firewall" mc_ldap {
+  name                          = "mc-ldap-${var.environ_tag}"
+  network                       = "default"
+
+  allow {
+    protocol                    = "tcp"
+    ports                       = [ "9389" ]
+  }
+
+  target_tags                   = [ "mc-ldap-${var.environ_tag}" ]
+  source_ranges                 = [
+    "${module.gitlab.external_ip}/32"
+  ]
+}
+
+resource "google_compute_firewall" mc_notify {
+  name                          = "mc-notify-${var.environ_tag}"
+  network                       = "default"
+
+  allow {
+    protocol                    = "tcp"
+    ports                       = [ "52001" ]
+  }
+
+  target_tags                   = [ "mc-notify-${var.environ_tag}" ]
+  source_ranges                 = [
+    "0.0.0.0/0"
+  ]
 }

--- a/terraform/mexplat/stage/main.tf
+++ b/terraform/mexplat/stage/main.tf
@@ -110,14 +110,16 @@ module "console" {
 
   instance_name       = "${var.console_instance_name}"
   environ_tag         = "${var.environ_tag}"
-  instance_size       = "n1-standard-4"
+  instance_size       = "custom-2-15360-ext"
   zone                = "${var.gcp_zone}"
   boot_disk_size      = 100
   tags                = [
     "http-server",
     "https-server",
     "console-debug",
-    "mc",
+    "mc-artifactory",
+    "mc-ldap-${var.environ_tag}",
+    "mc-notify-${var.environ_tag}",
     "jaeger",
     "alt-https",
     "notifyroot",
@@ -182,4 +184,34 @@ module "fw_vault_gcp" {
   source                        = "../../modules/fw_vault_gcp"
   firewall_name                 = "${var.environ_tag}-vault-fw-hc-and-proxy"
   target_tag                    = "${var.environ_tag}-vault-hc-and-proxy"
+}
+
+resource "google_compute_firewall" mc_ldap {
+  name                          = "mc-ldap-${var.environ_tag}"
+  network                       = "default"
+
+  allow {
+    protocol                    = "tcp"
+    ports                       = [ "9389" ]
+  }
+
+  target_tags                   = [ "mc-ldap-${var.environ_tag}" ]
+  source_ranges                 = [
+    "${module.gitlab.external_ip}/32"
+  ]
+}
+
+resource "google_compute_firewall" mc_notify {
+  name                          = "mc-notify-${var.environ_tag}"
+  network                       = "default"
+
+  allow {
+    protocol                    = "tcp"
+    ports                       = [ "52001" ]
+  }
+
+  target_tags                   = [ "mc-notify-${var.environ_tag}" ]
+  source_ranges                 = [
+    "0.0.0.0/0"
+  ]
 }


### PR DESCRIPTION
Replace global firewall rules with setup-specific rules managed by
Terraform. Each setup now installs a new firewall rule which allows
access from its Gitlab to its own MC LDAP.

There is still one global rule allowing access from all Artifactory
instances to MC LDAP on all setups.