### PR TITLE
remove dns hardcoding from init script

### DIFF
--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.1.1
+VERSION = 4.1.2
 DISTRIBUTION = cirrus
 COMPONENT = main
 

--- a/openstack-tenant/packages/mobiledgex/mobiledgex-init.sh
+++ b/openstack-tenant/packages/mobiledgex/mobiledgex-init.sh
@@ -40,11 +40,6 @@ else
 	log "ROLE: $ROLE"
 fi
 
-if ! dig google.com | grep 'status: NOERROR' >/dev/null; then
-	log "Setting 1.1.1.1 as nameserver"
-	echo "nameserver 1.1.1.1" >/etc/resolv.conf
-fi
-
 MCONF=/mnt/mobiledgex-config
 METADIR="$MCONF/openstack/latest"
 METADATA="$METADIR/meta_data.json"

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -45,7 +45,7 @@ type VMProperties struct {
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.1.1"
+var MEXInfraVersion = "4.1.2"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
The mobiledgex-init.sh script makes hardcoded DNS setting of 1.1.1.1 into the resolv.conf which is a day-one holdover.   Depending on the init sequence this entry may or may not take effect leading to unpredictable results.   It is preferable to allow the value received from the networking setup to be used each time.

