### PR TITLE
EDGECLOUD-3763  alertreceiver email should include the port number for the alert

### DIFF
--- a/chef/cookbooks/setup_services/files/prometheus.yml
+++ b/chef/cookbooks/setup_services/files/prometheus.yml
@@ -9,9 +9,9 @@ scrape_configs:
   - files:
     - '/tmp/prom_targets.json'
   metric_relabel_configs:
-    - regex: 'instance|envoy_cluster_name'
-      action: labeldrop
     - source_labels: [envoy_cluster_name]
       target_label: port
       regex: 'backend(.*)'
       replacement: '${1}'
+    - regex: 'instance|envoy_cluster_name'
+      action: labeldrop

--- a/e2e-tests/int-process/services.go
+++ b/e2e-tests/int-process/services.go
@@ -39,12 +39,12 @@ scrape_configs:
   - files:
     - '/tmp/prom_targets.json'
   metric_relabel_configs:
-    - regex: 'instance|envoy_cluster_name'
-      action: labeldrop
     - source_labels: [envoy_cluster_name]
       target_label: port
       regex: 'backend(.*)'
       replacement: '${1}'
+    - regex: 'instance|envoy_cluster_name'
+      action: labeldrop
 `
 
 type prometheusConfigArgs struct {

--- a/shepherd/shepherd_update_test.go
+++ b/shepherd/shepherd_update_test.go
@@ -74,12 +74,12 @@ scrape_configs:
   - files:
     - '/tmp/prom_targets.json'
   metric_relabel_configs:
-    - regex: 'instance|envoy_cluster_name'
-      action: labeldrop
     - source_labels: [envoy_cluster_name]
       target_label: port
       regex: 'backend(.*)'
       replacement: '${1}'
+    - regex: 'instance|envoy_cluster_name'
+      action: labeldrop
 `
 	require.Equal(t, expected, string(fileContents))
 
@@ -142,12 +142,12 @@ scrape_configs:
   - files:
     - '/tmp/prom_targets.json'
   metric_relabel_configs:
-    - regex: 'instance|envoy_cluster_name'
-      action: labeldrop
     - source_labels: [envoy_cluster_name]
       target_label: port
       regex: 'backend(.*)'
       replacement: '${1}'
+    - regex: 'instance|envoy_cluster_name'
+      action: labeldrop
 `
 	require.Equal(t, expected, string(fileContents))
 	// check rules file (new "for" time)


### PR DESCRIPTION
I realized that the order of relabel config rules was wrong and we would drop `envoy_cluster_name` before remapping it to `port` label.

fixed unit-tests as well.