### PR TITLE
EDGECLOUD-3939 change zxcvbn package to match javascript results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/codeskyblue/go-sh v0.0.0-20170112005953-b097669b1569
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/go-chef/chef v0.23.1
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-openapi/errors v0.19.7
@@ -41,7 +42,6 @@ require (
 	github.com/mobiledgex/golang-ssh v0.0.10
 	github.com/mobiledgex/yaml/v2 v2.2.5
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
-	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d
 	github.com/nmcclain/asn1-ber v0.0.0-20170104154839-2661553a0484
 	github.com/nmcclain/ldap v0.0.0-20160601145537-6e14e8271933
 	github.com/opentracing/opentracing-go v1.1.0
@@ -51,7 +51,9 @@ require (
 	github.com/shirou/gopsutil v2.20.4+incompatible
 	github.com/spf13/cobra v0.0.4
 	github.com/stretchr/testify v1.6.1
+	github.com/test-go/testify v1.1.4 // indirect
 	github.com/tmc/scp v0.0.0-20170824174625-f7b48647feef
+	github.com/trustelem/zxcvbn v1.0.1
 	github.com/xanzy/go-gitlab v0.16.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/net v0.0.0-20201010224723-4f7140c49acb

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20190905012053-7920e8ef8898/go.mod h1:xb
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
+github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
@@ -836,6 +838,8 @@ github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgh
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
+github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/tideland/golib v4.24.2+incompatible/go.mod h1:HPHOmtCdCHUQiGAVZnlOH5eNTAEmM7R9oCFXdgvkB+Y=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -844,6 +848,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/scp v0.0.0-20170824174625-f7b48647feef h1:7D6Nm4D6f0ci9yttWaKjM1TMAXrH5Su72dojqYGntFY=
 github.com/tmc/scp v0.0.0-20170824174625-f7b48647feef/go.mod h1:WLFStEdnJXpjK8kd4qKLwQKX/1vrDzp5BcDyiZJBHJM=
+github.com/trustelem/zxcvbn v1.0.1 h1:mp4JFtzdDYGj9WYSD3KQSkwwUumWNFzXaAjckaTYpsc=
+github.com/trustelem/zxcvbn v1.0.1/go.mod h1:zonUyKeh7sw6psPf/e3DtRqkRyZvAbOfjNz/aO7YQ5s=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=
 github.com/uber-go/atomic v1.4.0/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -676,7 +676,7 @@ func testRoleOrgCombos(t *testing.T, uri, token string, mcClient *ormclient.Clie
 func testPasswordStrength(t *testing.T, ctx context.Context, mcClient *ormclient.Client, uri, token string) {
 	// Create user in db to simulate old user with existing weak password
 	db := loggedDB(ctx)
-	adminOldPw := "oldpw"
+	adminOldPw := "oldpwd1"
 	passhash, salt, iter := NewPasshash(adminOldPw)
 	adminOld := ormapi.User{
 		Name:          "oldadmin",
@@ -711,7 +711,7 @@ func testPasswordStrength(t *testing.T, ctx context.Context, mcClient *ormclient
 	user1 := ormapi.User{
 		Name:     "MisterX",
 		Email:    "misterx@gmail.com",
-		Passhash: "misterx-password-super",
+		Passhash: "misterx-password-supe",
 	}
 	status, err = mcClient.CreateUser(uri, &user1)
 	require.Nil(t, err, "create user")

--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/util"
-	"github.com/nbutton23/zxcvbn-go"
+	"github.com/trustelem/zxcvbn"
 )
 
 // Init admin creates the admin user and adds the admin role.
@@ -475,8 +475,7 @@ func setPassword(c echo.Context, username, password string) error {
 
 func calcPasswordStrength(ctx context.Context, user *ormapi.User, password string) {
 	pwscore := zxcvbn.PasswordStrength(password, []string{})
-	user.PassEntropy = pwscore.Entropy
-	user.PassCrackTimeSec = pwscore.CrackTime
+	user.PassCrackTimeSec = pwscore.Guesses / float64(BruteForceGuessesPerSecond)
 }
 
 func checkPasswordStrength(ctx context.Context, user *ormapi.User, config *ormapi.Config, isAdmin bool) error {
@@ -722,9 +721,6 @@ func UpdateUser(c echo.Context) error {
 	}
 	if old.Locked != user.Locked {
 		return c.JSON(http.StatusBadRequest, Msg("Cannot change locked"))
-	}
-	if old.PassEntropy != user.PassEntropy {
-		return c.JSON(http.StatusBadRequest, Msg("Cannot change passentropy"))
 	}
 	if old.PassCrackTimeSec != user.PassCrackTimeSec {
 		return c.JSON(http.StatusBadRequest, Msg("Cannot change passcracktimesec"))

--- a/mc/orm/userauth.go
+++ b/mc/orm/userauth.go
@@ -28,6 +28,7 @@ var PasswordMaxLength = 4096
 var PasshashIter = 10000
 var PasshashKeyBytes = 32
 var PasshashSaltBytes = 8
+var BruteForceGuessesPerSecond = 1000000
 
 var Jwks vault.JWKS
 

--- a/mc/orm/userauth_test.go
+++ b/mc/orm/userauth_test.go
@@ -3,21 +3,23 @@ package orm
 import (
 	"testing"
 
-	"github.com/nbutton23/zxcvbn-go"
 	"github.com/stretchr/testify/require"
+	"github.com/trustelem/zxcvbn"
 )
 
 func TestPassword(t *testing.T) {
-	testpassword(t, "somerandompassword", "instant")
-	testpassword(t, "mexadmin123", "instant")
-	testpassword(t, "mexadmin123456789", "3.0 minutes")
-	testpassword(t, "1orangefoxquickhandlebrush1", "2.0 years")
-	testpassword(t, "yzdF8!aw", "2.0 years")
+	testpassword(t, "somerandompassword", "3.0 minutes")
+	testpassword(t, "mexadmin123", "16.0 seconds")
+	testpassword(t, "mexadmin123456789", "7.0 minutes")
+	testpassword(t, "1orangefoxquickhandlebrush1", "centuries")
+	testpassword(t, "yzdF8!aw", "3.0 minutes")
 	testpassword(t, "mexadminfastedgecloudinfra", "centuries")
 	testpassword(t, "thequickbrownfoxjumpedoverthelazydog9$", "centuries")
+	testpassword(t, "misterx-password-supe", "6.0 months")
+	testpassword(t, "oldpwd1", "5.0 seconds")
 }
 
 func testpassword(t *testing.T, pw, cracktime string) {
-	score := zxcvbn.PasswordStrength(pw, []string{})
-	require.Equal(t, cracktime, score.CrackTimeDisplay)
+	result := zxcvbn.PasswordStrength(pw, []string{})
+	require.Equal(t, cracktime, secDisplayTime(result.Guesses/float64(BruteForceGuessesPerSecond)))
 }

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -38,8 +38,6 @@ type User struct {
 	// read only: true
 	Locked bool
 	// read only: true
-	PassEntropy float64
-	// read only: true
 	PassCrackTimeSec float64
 }
 


### PR DESCRIPTION
The officially linked golang zxcvbn port does not return the same results as the original javascript implementation. There were a couple of issues filed as such against the port, but the port has been inactive for 2 years. Thankfully one kind (or perhaps frustrated) soul did another golang port of zxcvbn with the explicit intent of replicating the behavior of the javascript package. So this change moves to using that library instead of the officially linked one. I've verified it behaves the same as the javascript one.

The new package doesn't have an "entropy" score, so I've just removed it because we weren't using it anyway. Also there's not a lot of info online, but it seems like 1,000,000 attempts per second for PBKDF2 encryption using 10000 iterations is a reasonable amount for an offline password attack. So that's what I'm using to calculate the crack time. Ideally our sql database doesn't get compromised, so an online attack would be more like 0.33 attempts per second.

Note that crack time results are different from before, so some regression tests may need to be adjusted accordingly.