### PR TITLE
Clean up expired certs in vault

### DIFF
--- a/ansible/roles/vault/tasks/policies.yml
+++ b/ansible/roles/vault/tasks/policies.yml
@@ -39,6 +39,7 @@
     - policies/pki-regional-config.read.v1.hcl.j2
     - policies/pki-regional-roles.read.v1.hcl.j2
     - policies/pki-root-config.read.v1.hcl.j2
+    - policies/pki-tidy.v1.hcl.j2
     - policies/registry.read.v1.hcl.j2
     - policies/root-ca.read.v1.hcl.j2
     - policies/ssh-ansible-user.read.v1.hcl.j2

--- a/ansible/roles/vault/tasks/roles.yml
+++ b/ansible/roles/vault/tasks/roles.yml
@@ -67,6 +67,12 @@
       - approle.login.v1
       - pki-global.issue.v1
 
+- name: pki-tidy.v1 role
+  vault_role:
+    name: pki-tidy.v1
+    policies:
+      - pki-tidy.v1
+
 - include_role:
     name: vault
     tasks_from: region-roles

--- a/ansible/roles/vault/templates/policies/pki-tidy.v1.hcl.j2
+++ b/ansible/roles/vault/templates/policies/pki-tidy.v1.hcl.j2
@@ -1,0 +1,15 @@
+path "pki/tidy" {
+  capabilities = [ "create", "update" ]
+}
+
+path "pki-global/tidy" {
+  capabilities = [ "create", "update" ]
+}
+
+path "pki-regional/tidy" {
+  capabilities = [ "create", "update" ]
+}
+
+path "pki-regional-cloudlet/tidy" {
+  capabilities = [ "create", "update" ]
+}

--- a/jenkins/vault-pki-tidy.Jenkinsfile
+++ b/jenkins/vault-pki-tidy.Jenkinsfile
@@ -1,0 +1,39 @@
+pipeline {
+    options {
+        timeout(time: 10, unit: 'MINUTES')
+    }
+    agent any
+    environment {
+        stage_VAULT_ROLE = credentials('staging-vault-pki-tidy-role')
+        qa_VAULT_ROLE = credentials('qa-vault-pki-tidy-role')
+        dev_VAULT_ROLE = credentials('dev-vault-pki-tidy-role')
+    }
+    stages {
+        stage('Backup') {
+            steps {
+                dir(path: 'ansible') {
+                    ansiColor('xterm') {
+                        sh label: 'Run ansible playbook', script: '''$!/bin/bash
+set -e
+export ANSIBLE_FORCE_COLOR=true
+for DEPLOY_ENVIRON in stage; do
+    eval "VAULT_ROLE_ID=\\\$${DEPLOY_ENVIRON}_VAULT_ROLE_USR"
+    eval "VAULT_SECRET_ID=\\\$${DEPLOY_ENVIRON}_VAULT_ROLE_PSW"
+    export VAULT_ADDR="https://vault-${DEPLOY_ENVIRON}.mobiledgex.net"
+    VAULT_TOKEN=$( vault write -format=json auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID" \
+	    | jq -r .auth.client_token )
+    export VAULT_TOKEN
+
+    for PKI in pki pki-global pki-regional pki-regional-cloudlet; do
+        vault write ${PKI}/tidy tidy_cert_store=true tidy_revoked_certs=true
+    done
+
+    unset VAULT_TOKEN
+done
+                        '''
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Turns out vault does not automatically clean up expired PKI certs. And we have over 500k certs in the staging setup, and about 200k certs in main and QA. This is making the vault migration in the staging setup take over 24 hours.

Setting up periodic cleanup jobs in Jenkins to fix this.