### PR TITLE
EDGECLOUD-3243 [mcctl] Want More Descriptive Error When Using http instead of https

### DIFF
--- a/ansible/templates/mexplat/console-nginx-config.j2
+++ b/ansible/templates/mexplat/console-nginx-config.j2
@@ -2,6 +2,18 @@ server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
+	server_name {{ inventory_hostname }};
+
+	error_page 400 /400.html;
+	location /400.html{
+		return 400 '{"message": "Protocol error; $host needs HTTPS"}';
+	}
+
+	location /api/ { return 400; }
+	location / { return 301 https://$host$request_uri; }
+}
+
+server {
 	root /var/www/html;
 	index index.html index.htm index.nginx-debian.html;
 


### PR DESCRIPTION
In our regular deployments, MC is fronted by nginx, which returns a
generic 301 response to redirect HTTP to HTTPS. However, this breaks the
POST requests mcctl makes.

Handling this by returning an error message that mcctl can interpret.

```
  $ mcctl --addr http://console-dev.mobiledgex.net login name=foo password=bar
  Error: login error, Protocol error; console-dev.mobiledgex.net needs HTTPS

  $ mcctl --addr http://console-dev.mobiledgex.net user show
  Error: Bad Request (400), Protocol error; console-dev.mobiledgex.net needs HTTPS
```