### PR TITLE
configurable ntp servers

### DIFF
--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -162,6 +162,10 @@ var VMProviderProps = map[string]*edgeproto.PropertyInfo{
 		Name:        "Additional RootLB Networks",
 		Description: "Optional comma separated list of networks to add to rootLB VMs",
 	},
+	"MEX_NTP_SERVERS": {
+		Name:        "NTP Servers",
+		Description: "Optional comma separated list of NTP servers to override default of ntp.ubuntu.com",
+	},
 }
 
 func GetSupportedRouterTypes() string {
@@ -263,6 +267,13 @@ func (vp *VMProperties) GetCloudletAdditionalPlatformNetworks() []string {
 
 func (vp *VMProperties) GetCloudletAdditionalRootLbNetworks() []string {
 	value, _ := vp.CommonPf.Properties.GetValue("MEX_ADDITIONAL_ROOTLB_NETWORKS")
+	if value == "" {
+		return []string{}
+	}
+	return strings.Split(value, ",")
+}
+func (vp *VMProperties) GetNtpServers() []string {
+	value, _ := vp.CommonPf.Properties.GetValue("MEX_NTP_SERVERS")
 	if value == "" {
 		return []string{}
 	}

--- a/vmlayer/vmconfig.go
+++ b/vmlayer/vmconfig.go
@@ -35,6 +35,12 @@ write_files:
        {{- if .FallbackDNS}}
        FallbackDNS={{.FallbackDNS}}
        {{- end}}
+  {{- if .NtpServers}}
+  - path:  /etc/systemd/timesyncd.conf
+    content: |
+       [Time]
+       NTP={{.NtpServers}}
+  {{- end}}
 {{- if .AccessKey }}
   - path: /root/accesskey/accesskey.pem
     content: |
@@ -47,6 +53,9 @@ ssh_pwauth: False
 timezone: UTC
 runcmd:
  - systemctl restart systemd-resolved
+ {{- if .NtpServers}}
+ - systemctl restart systemd-timesyncd
+ {{- end}} 
  - echo MOBILEDGEX doing ifconfig
  - ifconfig -a`
 

--- a/vmlayer/vmparams.go
+++ b/vmlayer/vmparams.go
@@ -434,6 +434,7 @@ type VMCloudConfigParams struct {
 	AccessKey         string
 	PrimaryDNS        string
 	FallbackDNS       string
+	NtpServers        string
 }
 
 // VMOrchestrationParams contains all details  that are needed by the orchestator
@@ -547,6 +548,7 @@ func (v *VMPlatform) getVMGroupOrchestrationParamsFromGroupSpec(ctx context.Cont
 	internalNetName := v.VMProperties.GetCloudletMexNetwork()
 	internalNetId := v.VMProvider.NameSanitize(internalNetName)
 	externalNetName := v.VMProperties.GetCloudletExternalNetwork()
+	ntpServers := strings.Join(v.VMProperties.GetNtpServers(), " ")
 
 	var err error
 	vmDns := strings.Split(v.VMProperties.GetCloudletDNS(), ",")
@@ -883,6 +885,7 @@ func (v *VMPlatform) getVMGroupOrchestrationParamsFromGroupSpec(ctx context.Cont
 					vccp.FallbackDNS = vmDns[1]
 				}
 			}
+			vccp.NtpServers = ntpServers
 			// gpu
 			if vm.OptionalResource == "gpu" {
 				gpuCmds := getGpuExtraCommands()


### PR DESCRIPTION
EDGECLOUD-3713

TEF requires that we be able to configure what NTP server(s) to use so they can open the firewall as needed, or use an internal NTP server.

This adds MEX_NTP_SERVERS as an optional list of server IPs.  If present, the default NTP servers are overridden within cloud-init