### PR TITLE
Allow Github swdev users to sign SSH keys using the machine key

### DIFF
--- a/ansible/development/group_vars/all
+++ b/ansible/development/group_vars/all
@@ -22,6 +22,7 @@ vault_github_teams:
       - mexenv.read.v1
       - registry.read.v1
       - ssh-ansible-user.sign.v1
+      - ssh-machine.sign.v1
       - ssh-user.sign.v1
       - sys-auth.read.v1
       - sys-policies.read.v1

--- a/ansible/mexdemo/group_vars/all
+++ b/ansible/mexdemo/group_vars/all
@@ -10,6 +10,7 @@ vault_github_teams:
   - name: edge-cloud-development-team
     policies:
       - ssh-ansible-user.sign.v1
+      - ssh-machine.sign.v1
       - ssh-user.sign.v1
 
 vault_github_users:

--- a/ansible/qa/group_vars/all
+++ b/ansible/qa/group_vars/all
@@ -12,6 +12,7 @@ vault_github_teams:
   - name: edge-cloud-development-team
     policies:
       - ssh-ansible-user.sign.v1
+      - ssh-machine.sign.v1
       - ssh-user.sign.v1
 
 vault_github_users:

--- a/ansible/staging/group_vars/all
+++ b/ansible/staging/group_vars/all
@@ -16,6 +16,7 @@ vault_github_teams:
   - name: edge-cloud-development-team
     policies:
       - ssh-ansible-user.sign.v1
+      - ssh-machine.sign.v1
       - ssh-user.sign.v1
 
 vault_github_users:


### PR DESCRIPTION
This is necessary to allow developers to run CRMs locally using their
GITHUB_IDs.