### PR TITLE
EDGECLOUD 3990: VM-based apps with LB need DHCP in their subnets

### DIFF
--- a/crm-platforms/openstack/openstack-fip-test-heat-expected.yaml
+++ b/crm-platforms/openstack/openstack-fip-test-heat-expected.yaml
@@ -17,7 +17,7 @@ resources:
             cidr: 10.101.0.0/24
             network: mex-k8s-net-1
             gateway_ip: 10.101.0.1
-            enable_dhcp: no
+            enable_dhcp: yes
             dns_nameservers:
                  - 1.1.1.1
                  - 1.0.0.1

--- a/crm-platforms/openstack/openstack-fip-test-heat.yaml
+++ b/crm-platforms/openstack/openstack-fip-test-heat.yaml
@@ -17,7 +17,7 @@ resources:
             cidr: 10.101.0.0/24
             network: mex-k8s-net-1
             gateway_ip: 10.101.0.1
-            enable_dhcp: no
+            enable_dhcp: yes
             dns_nameservers:
                  - 1.1.1.1
                  - 1.0.0.1

--- a/crm-platforms/openstack/openstack-test-heat-expected.yaml
+++ b/crm-platforms/openstack/openstack-test-heat-expected.yaml
@@ -9,7 +9,7 @@ resources:
             cidr: 10.101.0.0/24
             network: mex-k8s-net-1
             gateway_ip: 10.101.0.1
-            enable_dhcp: no
+            enable_dhcp: yes
             dns_nameservers:
                  - 1.1.1.1
                  - 1.0.0.1

--- a/crm-platforms/openstack/openstack-test-heat.yaml
+++ b/crm-platforms/openstack/openstack-test-heat.yaml
@@ -9,7 +9,7 @@ resources:
             cidr: 10.101.0.0/24
             network: mex-k8s-net-1
             gateway_ip: 10.101.0.1
-            enable_dhcp: no
+            enable_dhcp: yes
             dns_nameservers:
                  - 1.1.1.1
                  - 1.0.0.1

--- a/crm-platforms/vsphere/vsphere-orch.go
+++ b/crm-platforms/vsphere/vsphere-orch.go
@@ -211,24 +211,6 @@ func (v *VSpherePlatform) populateOrchestrationParams(ctx context.Context, vmgp 
 	// populate vm fields
 	for vmidx, vm := range vmgp.VMs {
 		vmHasExternalIp := false
-		// EDGECLOUD 3990: VM-based apps with LB need DHCP in their subnets
-		// For VM-based apps with LB on vSphere, cloud-init is mandatory as there is
-		// no DHCP server configured on the setup. End user must specify static IP in cloud-init config
-		if vm.Role == vmlayer.RoleVMApplication && vm.DeploymentManifest == "" {
-			isDHCPEnabled := false
-			for _, sn := range vmgp.Subnets {
-				if sn.DHCPEnabled == "yes" {
-					isDHCPEnabled = true
-					break
-				}
-			}
-			if isDHCPEnabled {
-				return fmt.Errorf("missing cloud-init config from app's deployment manifest, " +
-					"please specify static IP configuration as part of cloud-init config as the " +
-					"setup doesn't support DHCP server")
-			}
-
-		}
 		vmgp.VMs[vmidx].MetaData = vmlayer.GetVMMetaData(vm.Role, masterIP, vmsphereMetaDataFormatter)
 		userdata, err := vmlayer.GetVMUserData(vm.Name, vm.SharedVolume, vm.DeploymentManifest, vm.Command, &vm.CloudConfigParams, vmsphereUserDataFormatter)
 		if err != nil {


### PR DESCRIPTION
* Enable DHCP for all subnets as Openstack infra will provide a DHCP server.
* For vSphere, i guess there is nothing we can do, unless we have a dhcp server running on the infra. Currently we throw an error if cloud-init is configured for vm based apps using LB
* Thanks @jlmorris3827 @venkytv for the suggestions.
