### PR TITLE
Gitlab upgrade to version 12.10.14-ee

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1,3 +1,3 @@
-gitlab_version: 12.7.6-ee.0
+gitlab_version: 12.10.14-ee.0
 gitlab_force_reconfigure: false
 gitlab_slack_notify_image_version: 2019-07-26


### PR DESCRIPTION
All existing instances have been upgraded manually.