### PR TITLE
EDGECLOUD-3944 OWASP Validation for DME

### DIFF
--- a/ansible/apidocs.yml
+++ b/ansible/apidocs.yml
@@ -61,6 +61,7 @@
           - apidocs/apidocs-massage.py
         swagger_gen_script_template: apidocs/swagger-gen.j2
         swagger_gen_run_once: yes
+        dme_api_host: eu-mexdemo.dme.mobiledgex.net:38001
       when: ( deploy_environ == 'mexdemo' ) or ( deploy_environ == 'prod' )
 
     - include_role:
@@ -75,6 +76,7 @@
           - apidocs/apidocs-massage.py
         swagger_gen_script_template: apidocs/swagger-gen.j2
         swagger_gen_run_once: no
+        dme_api_host: eu-stage.dme.mobiledgex.net:38001
       when: deploy_environ == 'stage'
 
 - hosts: akraino

--- a/ansible/templates/apidocs/swagger-gen.j2
+++ b/ansible/templates/apidocs/swagger-gen.j2
@@ -37,7 +37,7 @@ download_doxygen_doc() {
 
 download_doc external
 download_doc internal
-download_doc client --samples "{{ swagger_base_dir }}/code-samples"
+download_doc client --host "{{ dme_api_host }}" --samples "{{ swagger_base_dir }}/code-samples"
 download_doc mc --host "{{ console_vm_hostname }}"
 
 download_doxygen_doc edge-cloud-sdk-csharp


### PR DESCRIPTION
Set default hosts for DME in swagger.  The API console will provide
valid DME URIs based on this, and this also allows us to set up OWASP
API security scans.