### PR TITLE
EDGECLOUD-4011 public MC config show

### DIFF
--- a/mc/mcctl/cliwrapper/config.go
+++ b/mc/mcctl/cliwrapper/config.go
@@ -18,3 +18,10 @@ func (s *Client) ShowConfig(uri, token string) (*ormapi.Config, int, error) {
 	st, err := s.runObjs(uri, token, args, nil, &config)
 	return &config, st, err
 }
+
+func (s *Client) PublicConfig(uri string) (*ormapi.Config, int, error) {
+	args := []string{"config", "public"}
+	config := ormapi.Config{}
+	st, err := s.runObjs(uri, "", args, nil, &config)
+	return &config, st, err
+}

--- a/mc/mcctl/ormctl/config.go
+++ b/mc/mcctl/ormctl/config.go
@@ -20,6 +20,10 @@ func GetConfigCommand() *cobra.Command {
 		ReplyData: &ormapi.Config{},
 		Run:       runRest("/auth/config/show"),
 	}, &cli.Command{
+		Use:       "public",
+		ReplyData: &ormapi.Config{},
+		Run:       runRest("/publicconfig"),
+	}, &cli.Command{
 		Use:       "version",
 		ReplyData: &ormapi.Version{},
 		Run:       runRest("/auth/config/version"),

--- a/mc/orm/config.go
+++ b/mc/orm/config.go
@@ -142,3 +142,17 @@ func resetUserPasswordCrackTimes(ctx context.Context) error {
 	res := db.Model(&ormapi.User{}).Where("pass_crack_time_sec > ?", 0).Update("pass_crack_time_sec", 0)
 	return res.Error
 }
+
+// PubliConfig gets configuration that the UI needs to make the behavior of the
+// UI consistent with the behavior of the back-end. This is an un-authenticated
+// API so only that which is needed should be revealed.
+func PublicConfig(c echo.Context) error {
+	ctx := GetContext(c)
+	config, err := getConfig(ctx)
+	if err != nil {
+		return err
+	}
+	publicConfig := &ormapi.Config{}
+	publicConfig.PasswordMinCrackTimeSec = config.PasswordMinCrackTimeSec
+	return c.JSON(http.StatusOK, publicConfig)
+}

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -274,6 +274,14 @@ func RunServer(config *ServerConfig) (*Server, error) {
 	//   404: notFound
 	e.POST(root+"/usercreate", CreateUser)
 	e.POST(root+"/passwordresetrequest", PasswordResetRequest)
+	// swagger:route POST /publicconfig Config PublicConfig
+	// Show Public Configuration.
+	// Show Public Configuration for UI
+	// responses:
+	//   200: success
+	//   400: badRequest
+	//   404: notFound
+	e.POST(root+"/publicconfig", PublicConfig)
 	// swagger:route POST /passwordreset Security PasswdReset
 	// Reset Login Password.
 	// This resets your login password.

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -625,6 +625,16 @@ func testLockedUsers(t *testing.T, uri string, mcClient *ormclient.Client) {
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, notifyEmail, config.NotifyEmailAddress)
+	// show public config, make sure certain fields are hidden
+	publicConfig, status, err := mcClient.PublicConfig(uri)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, config.PasswordMinCrackTimeSec, publicConfig.PasswordMinCrackTimeSec)
+	require.Equal(t, 0, publicConfig.ID)
+	require.Equal(t, false, publicConfig.LockNewAccounts)
+	require.Equal(t, "", publicConfig.NotifyEmailAddress)
+	require.Equal(t, false, publicConfig.SkipVerifyEmail)
+	require.Equal(t, float64(0), publicConfig.AdminPasswordMinCrackTimeSec)
 
 	// make sure users can't see config
 	_, status, err = mcClient.ShowConfig(uri, tok1)

--- a/mc/ormclient/clientapi.go
+++ b/mc/ormclient/clientapi.go
@@ -61,6 +61,7 @@ type Api interface {
 	UpdateConfig(uri, token string, config map[string]interface{}) (int, error)
 	ResetConfig(uri, token string) (int, error)
 	ShowConfig(uri, token string) (*ormapi.Config, int, error)
+	PublicConfig(uri string) (*ormapi.Config, int, error)
 
 	CreateOrgCloudletPool(uri, token string, op *ormapi.OrgCloudletPool) (int, error)
 	DeleteOrgCloudletPool(uri, token string, op *ormapi.OrgCloudletPool) (int, error)

--- a/mc/ormclient/rest_client.go
+++ b/mc/ormclient/rest_client.go
@@ -238,6 +238,12 @@ func (s *Client) ShowConfig(uri, token string) (*ormapi.Config, int, error) {
 	return &config, status, err
 }
 
+func (s *Client) PublicConfig(uri string) (*ormapi.Config, int, error) {
+	config := ormapi.Config{}
+	status, err := s.PostJson(uri+"/publicconfig", "", nil, &config)
+	return &config, status, err
+}
+
 func (s *Client) RestrictedUserUpdate(uri, token string, user map[string]interface{}) (int, error) {
 	return s.PostJson(uri+"/auth/restricted/user/update", token, user, nil)
 }


### PR DESCRIPTION
This allows the UI to see what the configured password min crack time sec is, so that the UI can check the user's password strength during user create and have the same behavior as the back-end, which actually enforces the password strength.