### PR TITLE
floating ips error checking

### DIFF
--- a/crm-platforms/openstack/openstack-cmd.go
+++ b/crm-platforms/openstack/openstack-cmd.go
@@ -265,6 +265,9 @@ func (s *OpenstackPlatform) ListFloatingIPs(ctx context.Context, network string)
 	} else {
 		out, err = s.TimedOpenStackCommand(ctx, "openstack", "floating", "ip", "list", "--network", network, "-f", "json")
 	}
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list floating IPs: %s, %s - %v", network, out, err)
+	}
 	var fips []OSFloatingIP
 	err = json.Unmarshal(out, &fips)
 	if err != nil {

--- a/crm-platforms/openstack/openstack-objs.go
+++ b/crm-platforms/openstack/openstack-objs.go
@@ -32,7 +32,7 @@ type OSFloatingIP struct {
 	Project           string `json:"Project"`
 	FixedIPAddress    string `json:"Fixed IP Address"`
 	Port              string `json:"Port"`
-	FloatingNetwork   string `json:"FloatingNetwork"`
+	FloatingNetwork   string `json:"Floating Network"`
 	FloatingIPAddress string `json:"Floating IP Address"`
 }
 


### PR DESCRIPTION
While investigating EDGECLOUD-3995 (Sturfee Create Cluster Fails on KDDI Cloudlet) it was discovered that the error checking for ListFloatingIPs is deficient, if the openstack command fails the error is ignored (thanks Jon for pointing it out).

While this was not the root cause of the KDDI issue, it made debugging more difficult. 

Another issue was found with marshaling the floating IP output json as  "FloatingNetwork" should be "Floating Network".  This is not causing an immediate problem as we never read this field, but it could in future.