### PR TITLE
EDGECLOUD-4030  Temp fix of increasing limit and time difference of metric data based on time range for R2.4

### DIFF
--- a/e2e-tests/data/mc_showaudit_admin.yml
+++ b/e2e-tests/data/mc_showaudit_admin.yml
@@ -22,7 +22,7 @@
   status: 200
   starttime: "2020-04-22T13:16:44.281831-07:00"
   duration: 2.39ms
-  request: '{"adminpasswordmincracktimesec":63072000,"notifyemailaddress":"support@mobiledgex.com","passwordmincracktimesec":2592000,"skipverifyemail":true}'
+  request: '{"adminpasswordmincracktimesec":63072000,"maxmetricsdatapoints":10000,"notifyemailaddress":"support@mobiledgex.com","passwordmincracktimesec":2592000,"skipverifyemail":true}'
   traceid: 7add8f1b8f2a8aaa
 - operationname: /api/v1/login
   username: mexadmin

--- a/e2e-tests/data/mc_showaudit_all.yml
+++ b/e2e-tests/data/mc_showaudit_all.yml
@@ -40,7 +40,7 @@
   status: 200
   starttime: "2020-04-22T13:05:08.227371-07:00"
   duration: 2.377ms
-  request: '{"adminpasswordmincracktimesec":63072000,"notifyemailaddress":"support@mobiledgex.com","passwordmincracktimesec":2592000,"skipverifyemail":true}'
+  request: '{"adminpasswordmincracktimesec":63072000,"maxmetricsdatapoints":10000,"notifyemailaddress":"support@mobiledgex.com","passwordmincracktimesec":2592000,"skipverifyemail":true}'
   traceid: 57c8051e9b691a7f
 - operationname: /api/v1/login
   username: mexadmin

--- a/e2e-tests/data/mcconfig.yml
+++ b/e2e-tests/data/mcconfig.yml
@@ -2,3 +2,4 @@ skipverifyemail: true
 notifyemailaddress: support@mobiledgex.com
 passwordmincracktimesec: 2.592e+06
 adminpasswordmincracktimesec: 6.3072e+07
+maxmetricsdatapoints: 10000

--- a/e2e-tests/data/mcconfig_default.yml
+++ b/e2e-tests/data/mcconfig_default.yml
@@ -1,3 +1,4 @@
 notifyemailaddress: support@mobiledgex.com
 passwordmincracktimesec: 2.592e+06
 adminpasswordmincracktimesec: 6.3072e+07
+maxmetricsdatapoints: 10000

--- a/mc/mcctl/ormctl/config.go
+++ b/mc/mcctl/ormctl/config.go
@@ -9,7 +9,7 @@ import (
 func GetConfigCommand() *cobra.Command {
 	cmds := []*cli.Command{&cli.Command{
 		Use:          "update",
-		OptionalArgs: "locknewaccounts notifyemailaddress, skipverifyemail",
+		OptionalArgs: "locknewaccounts notifyemailaddress, skipverifyemail, maxmetricsdatapoints",
 		ReqData:      &ormapi.Config{},
 		Run:          runRest("/auth/config/update"),
 	}, &cli.Command{

--- a/mc/orm/config.go
+++ b/mc/orm/config.go
@@ -16,6 +16,7 @@ var defaultConfig = ormapi.Config{
 	NotifyEmailAddress:           "support@mobiledgex.com",
 	PasswordMinCrackTimeSec:      30 * 86400,      // 30 days
 	AdminPasswordMinCrackTimeSec: 2 * 365 * 86400, // 2 years
+	MaxMetricsDataPoints:         10000,
 }
 
 func InitConfig(ctx context.Context) error {
@@ -37,6 +38,14 @@ func InitConfig(ctx context.Context) error {
 	if config.PasswordMinCrackTimeSec == 0 && config.AdminPasswordMinCrackTimeSec == 0 {
 		config.PasswordMinCrackTimeSec = defaultConfig.PasswordMinCrackTimeSec
 		config.AdminPasswordMinCrackTimeSec = defaultConfig.AdminPasswordMinCrackTimeSec
+		err = db.Save(&config).Error
+		if err != nil {
+			return err
+		}
+	}
+	// set influxDB data points max number if not set
+	if config.MaxMetricsDataPoints == 0 {
+		config.MaxMetricsDataPoints = defaultConfig.MaxMetricsDataPoints
 		err = db.Save(&config).Error
 		if err != nil {
 			return err

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -24,7 +24,7 @@ var operatorInfluxDBTemplate *template.Template
 // 100 values at a time
 var queryChunkSize = 100
 
-var MaxEntriesFromInfluxDb = 10000
+var maxEntriesFromInfluxDb = 10000
 
 type InfluxDBContext struct {
 	region string
@@ -291,7 +291,7 @@ func fillTimeAndGetCmd(q *influxQueryArgs, tmpl *template.Template, start *time.
 	}
 	// We set max number of responses we will get from InfluxDB
 	if q.Last == 0 {
-		q.Last = MaxEntriesFromInfluxDb
+		q.Last = maxEntriesFromInfluxDb
 	}
 	// now that we know all the details of the query - build it
 	buf := bytes.Buffer{}
@@ -528,7 +528,11 @@ func GetMetricsCommon(c echo.Context) error {
 	}
 	rc.claims = claims
 	ctx := GetContext(c)
-
+	// Get the current config
+	config, err := getConfig(ctx)
+	if err == nil {
+		maxEntriesFromInfluxDb = config.MaxMetricsDataPoints
+	}
 	if strings.HasSuffix(c.Path(), "metrics/app") {
 		in := ormapi.RegionAppInstMetrics{}
 		success, err := ReadConn(c, &in)

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -130,6 +130,8 @@ type Config struct {
 	PasswordMinCrackTimeSec float64
 	// Admin accounts min password crack time seconds (a measure of strength)
 	AdminPasswordMinCrackTimeSec float64
+	// InfluxDB max number of data points returned
+	MaxMetricsDataPoints int
 }
 
 type OrgCloudletPool struct {


### PR DESCRIPTION
Bump up max number of returned data points by influxDB to 10k.