### PR TITLE
EDGECLOUD-4054: Email OTP is valid only for 30 seconds and not 2 minutes

### DIFF
--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -131,7 +131,7 @@ func Login(c echo.Context) error {
 		opts := totp.ValidateOpts{
 			Period:    OTPExpirationTime,
 			Skew:      1,
-			Digits:    otp.DigitsSix,
+			Digits:    OTPLen,
 			Algorithm: otp.AlgorithmSHA1,
 		}
 		if login.TOTP == "" {


### PR DESCRIPTION
* Default option has period set to [30 seconds](https://github.com/pquerna/otp/blob/v1.3.0/totp/totp.go#L42). Override that by adding custom options