### PR TITLE
EDGECLOUD-3875  AppInstDown alert is generated when deleting the appinst

### DIFF
--- a/e2e-tests/data/undeploy_alerts_show.yml
+++ b/e2e-tests/data/undeploy_alerts_show.yml
@@ -9,7 +9,7 @@
     clusterorg: MobiledgeX
     job: MobiledgeX Monitoring
     region: local
-  state: pending
+  state: firing
   activeat:
     seconds: 1594945144
     nanos: 494892341

--- a/shepherd/prom-stats.go
+++ b/shepherd/prom-stats.go
@@ -95,6 +95,11 @@ func getPromAlerts(ctx context.Context, addr string, client ssh.Client) ([]edgep
 	}
 	alerts := []edgeproto.Alert{}
 	for _, pa := range resp.Data.Alerts {
+		// skip pending alerts
+		if pa.State != "firing" {
+			log.SpanLog(ctx, log.DebugLevelMetrics, "Skip pending alert", "alert", pa)
+			continue
+		}
 		alert := edgeproto.Alert{}
 		alert.Labels = pa.Labels
 		alert.Annotations = pa.Annotations

--- a/shepherd/prom-stats_test.go
+++ b/shepherd/prom-stats_test.go
@@ -353,8 +353,8 @@ func TestPromStats(t *testing.T) {
 	assert.Equal(t, float64(50.0), clusterMetrics.Disk)
 	assert.Equal(t, uint64(11111), clusterMetrics.NetSent)
 	assert.Equal(t, uint64(22222), clusterMetrics.NetRecv)
-	// Check Alerts
-	require.Equal(t, len(expectedTestAlerts), len(alerts))
+	// Check Alerts - should not return pending alert
+	require.Equal(t, len(expectedTestAlerts)-1, len(alerts))
 	for ii := 0; ii < len(alerts); ii++ {
 		expected := expectedTestAlerts[ii]
 		alert := alerts[ii]


### PR DESCRIPTION
The root cause is that a deletion might trigger a `pending` alert in Prometheus. Alert in this state is not firing yet, and should not be propagated through the MobiledgeX platform