### PR TITLE
EDGECLOUD-4074 EDGECLOUD-3988 Template fix for cloudlet alert receivers and labels fix

### DIFF
--- a/ansible/roles/alertmanager/files/alertmanager.tmpl
+++ b/ansible/roles/alertmanager/files/alertmanager.tmpl
@@ -124,7 +124,7 @@ SOFTWARE.
 {{ end }}
 
 {{ define "common.title" -}}
-[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Alert for {{ reReplaceAll "([^-]*)-.*" "${1}" .Receiver}}: {{.CommonLabels.alertname }} Application: {{.CommonLabels.app}} Version: {{.CommonLabels.appver}}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Alert for {{ reReplaceAll "([^-]*)-.*" "${1}" .Receiver}}: {{.CommonLabels.alertname }}{{ if .CommonLabels.app }} Application: {{.CommonLabels.app}} Version: {{.CommonLabels.appver}}{{ else if .CommonLabels.cloudlet}} Cloudlet: {{.CommonLabels.cloudlet}}{{ end }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Alert for {{ reReplaceAll "([^-]*)-.*" "${1}" .Receiver}}: {{.CommonLabels.alertname }} Application: {{.CommonLabels.app}} Version: {{.CommonLabels.appver}}
 {{ end }}
 
 {{ define "email.text" }}

--- a/e2e-tests/data/alertmanager.tmpl
+++ b/e2e-tests/data/alertmanager.tmpl
@@ -121,7 +121,7 @@ SOFTWARE.
 {{ end }}
 
 {{ define "common.title" -}}
-[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Alert for {{ reReplaceAll "([^-]*)-.*" "${1}" .Receiver}}: {{.CommonLabels.alertname }} Application: {{.CommonLabels.app}} Version: {{.CommonLabels.appver}}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Alert for {{ reReplaceAll "([^-]*)-.*" "${1}" .Receiver}}: {{.CommonLabels.alertname }}{{ if .CommonLabels.app }} Application: {{.CommonLabels.app}} Version: {{.CommonLabels.appver}}{{ else if .CommonLabels.cloudlet}} Cloudlet: {{.CommonLabels.cloudlet}}{{ end }}
 {{ end }}
 
 {{ define "email.text" }}

--- a/e2e-tests/data/emaildata_cloudlet_alert_firing.yml
+++ b/e2e-tests/data/emaildata_cloudlet_alert_firing.yml
@@ -2,7 +2,7 @@
     \ cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n  region=local\n\n  scope=Cloudlet\n\n\n
     \ [1] Firing\n\n\n"
   headers:
-    subject: "[FIRING:1] Alert for emailCloudletAlertReceiver: CloudletDown Application:
-      \ Version: \n"
+    subject: |
+      [FIRING:1] Alert for emailCloudletAlertReceiver: CloudletDown Cloudlet: tmus-cloud-1
     to: ops@mobiledgex.net
     from: alerts@mobiledgex.com

--- a/e2e-tests/data/emaildata_cloudlet_alert_resolved.yml
+++ b/e2e-tests/data/emaildata_cloudlet_alert_resolved.yml
@@ -2,15 +2,15 @@
     \ cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n  region=local\n\n  scope=Cloudlet\n\n\n
     \ [1] Firing\n\n\n"
   headers:
-    subject: "[FIRING:1] Alert for emailCloudletAlertReceiver: CloudletDown Application:
-      \ Version: \n"
+    subject: |
+      [FIRING:1] Alert for emailCloudletAlertReceiver: CloudletDown Cloudlet: tmus-cloud-1
     to: ops@mobiledgex.net
     from: alerts@mobiledgex.com
 - text: "\nMobiledX Monitoring System: 1 alert for \n  alertname=CloudletDown\n\n
     \ cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n  region=local\n\n  scope=Cloudlet\n\n\n\n
     \ [1] Resolved\n\n"
   headers:
-    subject: "[RESOLVED] Alert for emailCloudletAlertReceiver: CloudletDown Application:
-      \ Version: \n"
+    subject: |
+      [RESOLVED] Alert for emailCloudletAlertReceiver: CloudletDown Cloudlet: tmus-cloud-1
     to: ops@mobiledgex.net
     from: alerts@mobiledgex.com

--- a/mc/orm/alertmgr/alertmgr.go
+++ b/mc/orm/alertmgr/alertmgr.go
@@ -148,6 +148,12 @@ func isInternalAlert(alert *edgeproto.Alert) bool {
 	return true
 }
 
+func isLabelInternal(label string) bool {
+	if label == "instance" {
+		return true
+	}
+	return false
+}
 func (s *AlertMgrServer) alertsToOpenAPIAlerts(alerts []*edgeproto.Alert) models.PostableAlerts {
 	openAPIAlerts := models.PostableAlerts{}
 	for _, a := range alerts {
@@ -159,6 +165,10 @@ func (s *AlertMgrServer) alertsToOpenAPIAlerts(alerts []*edgeproto.Alert) models
 		end := strfmt.DateTime(time.Now().Add(s.AlertResolutionTimout))
 		labels := make(map[string]string)
 		for k, v := range a.Labels {
+			// drop labels we don't want to expose to the end-users
+			if isLabelInternal(k) {
+				continue
+			}
 			// Convert appInst status to a human-understandable format
 			if k == cloudcommon.AlertHealthCheckStatus {
 				if tmp, err := strconv.ParseInt(v, 10, 32); err == nil {

--- a/mc/orm/alertmgr/testAlertmanagerTemplates.tmpl
+++ b/mc/orm/alertmgr/testAlertmanagerTemplates.tmpl
@@ -121,7 +121,7 @@ SOFTWARE.
 {{ end }}
 
 {{ define "common.title" -}}
-[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Alert for {{ reReplaceAll "([^-]*)-.*" "${1}" .Receiver}}: {{.CommonLabels.alertname }} Application: {{.CommonLabels.app}} Version: {{.CommonLabels.appver}}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Alert for {{ reReplaceAll "([^-]*)-.*" "${1}" .Receiver}}: {{.CommonLabels.alertname }}{{ if .CommonLabels.app }} Application: {{.CommonLabels.app}} Version: {{.CommonLabels.appver}}{{ else if .CommonLabels.cloudlet}} Cloudlet: {{.CommonLabels.cloudlet}}{{ end }}
 {{ end }}
 
 {{ define "email.text" }}


### PR DESCRIPTION
EDGECLOUD-4074 alertreceiver CloudletDown email title should remove the app name and include the cloudlet name
   - fixed templates to use cloudlet name instead of the app details for cloudlet alerts from alertmanager
EDGECLOUD-3988 alertreceiver email showing instance label for HealthCheckFailRootlbOffline
   - need to remove some of the internal labels from alerts before forwarding it to alertmanager