### PR TITLE
force image pull on docker create

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -377,7 +377,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 
 		updateCallback(edgeproto.UpdateTask, "Deploying Docker App")
 
-		err = dockermgmt.CreateAppInst(ctx, v.VMProperties.CommonPf.PlatformConfig.AccessApi, appClient, app, appInst)
+		err = dockermgmt.CreateAppInst(ctx, v.VMProperties.CommonPf.PlatformConfig.AccessApi, appClient, app, appInst, dockermgmt.WithForceImagePull(true))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
EDGECLOUD-4077

Addresses the scenario in which a docker AppInst is:
1) created
2) deleted
3) image is updated with no changes to tag
4) created again on same ClusterInst

In this case, the new image is not re-pulled as it is cached within the docker node VM.  The solution is to use ForceImagePull to pull the image each time.  This was previously only used on UpdateAppInst, but to address this case we will do it on Create as well.    There's not really any impact to the timing as the image has to be pulled anyway.
