### PR TITLE
Fix shard limit issue in Elasticsearch

### DIFF
--- a/ansible/roles/esproxy/defaults/main.yml
+++ b/ansible/roles/esproxy/defaults/main.yml
@@ -1,1 +1,1 @@
-events_elasticsearch_cleanup_age: 30
+events_elasticsearch_cleanup_age: 5

--- a/ansible/roles/esproxy/templates/index-cleanup.py.j2
+++ b/ansible/roles/esproxy/templates/index-cleanup.py.j2
@@ -35,6 +35,6 @@ delete = [ x for x in indexes if x < oldest_index ]
 
 for index in delete:
     logging.info(f"Deleting index: {index}")
-    r = requests.delete(f"{ES}/{index}", headers=headers)
+    r = requests.delete(f"{ES}/{index}?master_timeout=60s", headers=headers)
     if r.status_code != requests.codes.ok:
         raise Exception(f"Failed to delete index: {index}: {r.status_code} {r.text}")


### PR DESCRIPTION
With the number of setups we have currently, we have used up the shard
limit in ElasticSearch. We have daily indexes for events, and each index
has ten shards.  The upper limit for the cluster is set to 2000 shards,
which we have hit already.

This is mitigation rather than a complete fix. We probably need to
switch from daily indexes to monthly ones for events. The number of
indexes/shards blows up memory usage requirements, and the amount of
data we have in each daily index is pretty small right now---about 20MB
per day in the QA setup.