### PR TITLE
fix vmapp image

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -54,6 +54,9 @@ func (v *VMPlatform) PerformOrchestrationForVMApp(ctx context.Context, app *edge
 	imageInfo.LocalImageName = imageName + "-" + md5Sum
 	imageInfo.Md5sum = md5Sum
 	imageInfo.SourceImageTime = sourceImageTime
+	if err != nil {
+		return &orchVals, err
+	}
 
 	err = v.VMProvider.AddAppImageIfNotPresent(ctx, &imageInfo, app, appInst.Flavor.Name, updateCallback)
 	if err != nil {


### PR DESCRIPTION
My previous fix for EDGECLOUD-2443 failed to update the code that sets the image in the orch params, meaning the old image name with no md5 was used in the heat template

As part of this removed "action" parameter from PerformOrchestrationForVMApp to simplify it a bit as action was always set to Create when calling this function anyway