### PR TITLE
fix egress secgrp for platform vm

### DIFF
--- a/vmlayer/vmparams.go
+++ b/vmlayer/vmparams.go
@@ -659,8 +659,10 @@ func (v *VMPlatform) getVMGroupOrchestrationParamsFromGroupSpec(ctx context.Cont
 		egressRules = spec.TrustPolicy.OutboundSecurityRules
 	}
 	if spec.NewSecgrpName != "" {
-		// egress is always restricted on per-cluster groups.  If egress is allowed, it is done on the cloudlet level group
-		externalSecGrp, err := GetSecGrpParams(spec.NewSecgrpName, SecGrpWithAccessPorts(spec.AccessPorts, spec.AccessCidr), SecGrpWithEgressRules(egressRules, true))
+		// egress is always restricted on per-cluster groups.  If egress is allowed, it is done on the cloudlet level group,
+		// unless there is no cloudlet group applied (in which case SkipDefaultSecGrp is true)
+		egressRestricted := !spec.SkipDefaultSecGrp
+		externalSecGrp, err := GetSecGrpParams(spec.NewSecgrpName, SecGrpWithAccessPorts(spec.AccessPorts, spec.AccessCidr), SecGrpWithEgressRules(egressRules, egressRestricted))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
EDGECLOUD-4192

Newly created platform VMs erroneously have egress restricted and cannot reach the chef server because they are not included in the cloudlet-level group.   

Fix is to set egressRestricted to false on new security groups if there is no cloudlet-level group