### PR TITLE
EDGECLOUD-4112: Add support for other openstack console types

### DIFF
--- a/crm-platforms/openstack/openstack-cmd.go
+++ b/crm-platforms/openstack/openstack-cmd.go
@@ -934,7 +934,11 @@ func (o *OpenstackPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.Fla
 
 func (s *OpenstackPlatform) OSGetConsoleUrl(ctx context.Context, serverName string) (*OSConsoleUrl, error) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "get console url", "server", serverName)
-	out, err := s.TimedOpenStackCommand(ctx, "openstack", "console", "url", "show", "-f", "json", "-c", "url", "--novnc", serverName)
+	consoleType := s.GetConsoleType()
+	if consoleType == "" {
+		consoleType = "novnc"
+	}
+	out, err := s.TimedOpenStackCommand(ctx, "openstack", "console", "url", "show", "-f", "json", "-c", "url", "--"+consoleType, serverName)
 	if err != nil {
 		err = fmt.Errorf("can't get console url details for %s, %s, %v", serverName, out, err)
 		return nil, err

--- a/crm-platforms/openstack/openstack-props.go
+++ b/crm-platforms/openstack/openstack-props.go
@@ -11,6 +11,14 @@ import (
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
 
+var OpenstackProps = map[string]*edgeproto.PropertyInfo{
+	"MEX_CONSOLE_TYPE": {
+		Name:        "Openstack console type",
+		Description: "Openstack supported console type: novnc, xvpvnc, spice, rdp, serial, mks",
+		Value:       "novnc",
+	},
+}
+
 func (o *OpenstackPlatform) GetOpenRCVars(ctx context.Context, accessApi platform.AccessApi) error {
 	vars, err := accessApi.GetCloudletAccessVars(ctx)
 	if err != nil {
@@ -34,7 +42,7 @@ func (o *OpenstackPlatform) GetOpenRCVars(ctx context.Context, accessApi platfor
 }
 
 func (o *OpenstackPlatform) GetProviderSpecificProps(ctx context.Context) (map[string]*edgeproto.PropertyInfo, error) {
-	return map[string]*edgeproto.PropertyInfo{}, nil
+	return OpenstackProps, nil
 }
 
 func (o *OpenstackPlatform) InitApiAccessProperties(ctx context.Context, accessApi platform.AccessApi, vars map[string]string, stage vmlayer.ProviderInitStage) error {
@@ -51,5 +59,10 @@ func (o *OpenstackPlatform) GetVaultCloudletAccessPath(key *edgeproto.CloudletKe
 
 func (o *OpenstackPlatform) GetCloudletProjectName() string {
 	val, _ := o.openRCVars["OS_PROJECT_NAME"]
+	return val
+}
+
+func (o *OpenstackPlatform) GetConsoleType() string {
+	val, _ := o.VMProperties.CommonPf.Properties.GetValue("MEX_CONSOLE_TYPE")
 	return val
 }


### PR DESCRIPTION
Openstack supports following console types:
* novnc, xvpvnc, spice, rdp, serial, mks

Add support for an envvar to choose any of the type based on what is supported in Operator Infra.