### PR TITLE
Alerts for cloud-hosted ElasticSearch

### DIFF
--- a/ansible/files/kapacitor/tasks/elasticsearch-status.tick
+++ b/ansible/files/kapacitor/tasks/elasticsearch-status.tick
@@ -1,0 +1,23 @@
+dbrp "telegraf"."autogen"
+
+var name = 'ElasticSearch Status Alert'
+
+var period = 5m
+
+var alert_interval = 6h
+
+var data = batch
+    |query(''' SELECT LAST(status) AS status FROM "telegraf"."autogen"."elasticsearch_cluster_health" ''')
+        .period(period)
+        .every(period)
+        .groupBy('name')
+
+var alert = data
+    |alert()
+        .id(name + ':{{.Group}}')
+        .message('{{ .ID }}: Status is {{ .Level }}')
+        .warn(lambda: "status" == 'yellow')
+        .crit(lambda: "status" == 'red')
+        .stateChangesOnly(alert_interval)
+        .pagerDuty2()
+        .slack()

--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -230,6 +230,7 @@
         - cloudflare-dns-entries.tick
         - cpu-usage.tick
         - disk-usage.tick
+        - elasticsearch-status.tick
         - etcd-db.tick
         - memory-usage.tick
         - vault-seal-status.tick


### PR DESCRIPTION
Metrics are being loaded into the internal InfluxDB already.