### PR TITLE
Vault upgrade and migration to integrated storage

### DIFF
--- a/ansible/development/list
+++ b/ansible/development/list
@@ -42,6 +42,7 @@ postgres-dev.mobiledgex.net
 [vault]
 vault-dev-a.mobiledgex.net
 vault-dev-b.mobiledgex.net
+vault-dev-c.mobiledgex.net
 
 [console]
 console-dev.mobiledgex.net

--- a/ansible/main/group_vars/all
+++ b/ansible/main/group_vars/all
@@ -9,5 +9,6 @@ vault_audit_elasticsearch: yes
 vault_ha_zones:
   us: us-central1-a
   eu: europe-west3-a
+  as: asia-east1-b
 offline_root_cert: yes
 vault_github_teams: []

--- a/ansible/main/list
+++ b/ansible/main/list
@@ -36,6 +36,7 @@ stun.mobiledgex.net
 [vault]
 vault-main-a.mobiledgex.net
 vault-main-b.mobiledgex.net
+vault-main-c.mobiledgex.net
 
 [jaeger]
 jaeger.mobiledgex.net		es_instance=main

--- a/ansible/qa/list
+++ b/ansible/qa/list
@@ -51,6 +51,7 @@ console-qa.mobiledgex.net
 [vault]
 vault-qa-a.mobiledgex.net
 vault-qa-b.mobiledgex.net
+vault-qa-c.mobiledgex.net
 
 [artifactory]
 artifactory-qa.mobiledgex.net

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-vault_version: 1.1.2
-vault_checksum: sha256:e927fd4daac11f6c7b8b3f1f53f2017516e29e99585dc975b657acdeac43500b
+vault_version: 1.5.5
+vault_checksum: sha256:2a6958e6c8d6566d8d529fe5ef9378534903305d0f00744d526232d1c860e1ed
 vault_letsencrypt_plugin: "{{ artifactory_address }}/binaries/vault-letsencrypt-plugin/1.1/letsencrypt-plugin"
 vault_letsencrypt_plugin_sha256sum: e111a2db44059d0e460178ec25eaab72c7b44667d5a0f89fcae18d37ad86155d
 certgen_image_version: 2019-11-01

--- a/ansible/roles/vault/tasks/main.yml
+++ b/ansible/roles/vault/tasks/main.yml
@@ -59,74 +59,23 @@
   tags: setup
   when: vault_ha_instance_port < 1024
 
-- name: Create storage bucket
-  command: "gsutil mb gs://{{ storage_bucket_name }}"
-  changed_when: false
-  register: result
-  failed_when:
-    - result.rc != 0
-    - "'already exists' not in result.stderr"
-  delegate_to: localhost
-  tags: setup
+- name: Set up vault data dir
+  file:
+    path: "{{ vault_data_directory }}"
+    state: directory
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
+    mode: 0700
+  become: yes
 
+# Get a list of other vault nodes in the HA setup
 - set_fact:
-    storage_bucket_service_account_name: "{{ storage_bucket_name }}-user"
-    storage_bucket_service_account_email: "{{ storage_bucket_name }}-user@{{ project }}.iam.gserviceaccount.com"
-
-- name: Create service account
-  command: "gcloud iam service-accounts create {{ storage_bucket_service_account_name }} --display-name {{ storage_bucket_service_account_name }}"
-  changed_when: false
-  register: result
-  failed_when:
-    - result.rc != 0
-    - "'already exists within project' not in result.stderr"
-  delegate_to: localhost
-  tags: setup
-
-- name: Grant access to storage bucket
-  command: "gsutil iam ch serviceAccount:{{ storage_bucket_service_account_email }}:roles/storage.objectAdmin gs://{{ storage_bucket_name }}"
-  changed_when: false
-  delegate_to: localhost
-  tags: setup
-
-- block:
-
-    - stat:
-        path: "{{ storage_service_account_key }}"
-      become: yes
-      register: key
-
-    - name: Verify that service account key is present
-      assert:
-        that: key.stat.exists
-
-  rescue:
-
-    - name: Make sure key directory is present
-      file:
-        path: "{{ storage_service_account_key | dirname }}"
-        owner: "{{ vault_user }}"
-        group: "{{ vault_group }}"
-        state: directory
-        mode: 0700
-      become: yes
-
-    - tempfile:
-        suffix: .json
-      register: key_tempfile
-      notify: Delete key tempfile
-
-    - name: Get service account key
-      command: "gcloud iam service-accounts keys create {{ key_tempfile.path }} --iam-account {{ storage_bucket_service_account_email }}"
-      delegate_to: localhost
-
-    - name: Install service account key
-      copy:
-        src: "{{ key_tempfile.path }}"
-        dest: "{{ storage_service_account_key }}"
-      become: yes
-      notify: Reload vault
-  tags: setup
+    other_vaults: []
+- set_fact:
+    other_vaults: "{{ other_vaults }} + [ '{{ item }}' ]"
+  with_inventory_hostnames:
+    - vault
+  when: inventory_hostname != item
 
 - name: Install vault config file
   template:

--- a/ansible/roles/vault/tasks/vault-ssh.yml
+++ b/ansible/roles/vault/tasks/vault-ssh.yml
@@ -1,38 +1,42 @@
 ---
-- name: Fetch vault SSH CA cert
-  uri:
-    url: "{{ vault_address }}/v1/ssh-ansible/public_key"
-    return_content: yes
-  register: result
-  delegate_to: localhost
+- block:
 
-- name: Update trusted key file
-  blockinfile:
-    path: /etc/ssh/trusted-user-ca-keys.pem
-    block: "{{ result.content }}"
-    create: yes
-    backup: yes
-  become: yes
-  notify: Restart sshd
+  - name: Fetch vault SSH CA cert
+    uri:
+      url: "{{ vault_address }}/v1/ssh-ansible/public_key"
+      return_content: yes
+    register: result
+    delegate_to: localhost
 
-- name: Update sshd config
-  blockinfile:
-    path: /etc/ssh/sshd_config
-    block: "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem"
-    backup: yes
-  become: yes
-  notify: Restart sshd
+  - name: Update trusted key file
+    blockinfile:
+      path: /etc/ssh/trusted-user-ca-keys.pem
+      block: "{{ result.content }}"
+      create: yes
+      backup: yes
+    become: yes
+    notify: Restart sshd
 
-- name: Restart sshd now, if necessary
-  meta: flush_handlers
+  - name: Update sshd config
+    blockinfile:
+      path: /etc/ssh/sshd_config
+      block: "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem"
+      backup: yes
+    become: yes
+    notify: Restart sshd
 
-- name: Remove authorized key files
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - /home/ansible/.ssh/authorized_keys
-    - /home/ubuntu/.ssh/authorized_keys
-    - /root/.ssh/authorized_keys
-  become: yes
-  when: retain_common_key is not defined or not retain_common_key
+  - name: Restart sshd now, if necessary
+    meta: flush_handlers
+
+  - name: Remove authorized key files
+    file:
+      path: "{{ item }}"
+      state: absent
+    loop:
+      - /home/ansible/.ssh/authorized_keys
+      - /home/ubuntu/.ssh/authorized_keys
+      - /root/.ssh/authorized_keys
+    become: yes
+    when: retain_common_key is not defined or not retain_common_key
+
+  tags: vault_ssh

--- a/ansible/roles/vault/templates/vault.hcl.j2
+++ b/ansible/roles/vault/templates/vault.hcl.j2
@@ -12,9 +12,14 @@ listener "tcp" {
   x_forwarded_for_reject_not_present = "false"
   x_forwarded_for_hop_skips = "1"
 }
-storage "gcs" {
-  bucket = "{{ storage_bucket_name }}"
-  ha_enabled = "true"
+storage "raft" {
+  path    = "{{ vault_data_directory }}"
+  node_id = "{{ inventory_hostname_short }}"
+{% for node in other_vaults %}
+  retry_join {
+    leader_api_addr = "https://{{ node }}:8200"
+  }
+{% endfor %}
 }
 plugin_directory = "{{ vault_plugin_directory }}"
 telemetry {

--- a/ansible/roles/vault/vars/main.yml
+++ b/ansible/roles/vault/vars/main.yml
@@ -3,6 +3,7 @@ vault_group: vault
 vault_path: /usr/local/bin
 vault_conf: /etc/vault.hcl
 vault_plugin_directory: /etc/vault-plugins
+vault_data_directory: /var/lib/vault
 vault_audit_log: /var/log/vault_audit.log
 vault_logrotate_path: /etc/logrotate.d/vault
 certgen_image: "{{ mex_docker_registry }}/mobiledgex/certgen"

--- a/ansible/staging/list
+++ b/ansible/staging/list
@@ -48,6 +48,7 @@ console-stage.mobiledgex.net
 [vault]
 vault-stage-a.mobiledgex.net
 vault-stage-b.mobiledgex.net
+vault-stage-c.mobiledgex.net
 
 [jaeger]
 jaeger-stage.mobiledgex.net	nginx_config_filename=jaeger jaeger_ui_port=8443

--- a/terraform/mexplat/dev/main.tf
+++ b/terraform/mexplat/dev/main.tf
@@ -108,12 +108,14 @@ module "console" {
     "vault-ac",
     "notifyroot",
     "alertmanager",
+    "vault-ac",
     "${module.fw_vault_gcp.target_tag}"
   ]
   labels              = {
     "environ"         = "${var.environ_tag}",
     "console"         = "true",
     "owner"           = "ops",
+    "vault"           = "true",
   }
 }
 
@@ -182,6 +184,12 @@ module "vault_b_dns" {
   source                        = "../../modules/cloudflare_record"
   hostname                      = "${var.vault_b_domain_name}"
   ip                            = "${module.vault_b.external_ip}"
+}
+
+module "vault_c_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.vault_c_domain_name}"
+  ip                            = "${module.console.external_ip}"
 }
 
 module "fw_vault_gcp" {

--- a/terraform/mexplat/dev/variables.tf
+++ b/terraform/mexplat/dev/variables.tf
@@ -128,6 +128,10 @@ variable "vault_b_domain_name" {
   default     = "vault-dev-b.mobiledgex.net"
 }
 
+variable "vault_c_domain_name" {
+  default     = "vault-dev-c.mobiledgex.net"
+}
+
 variable "ssh_public_key_file" {
   description = "SSH public key file for the ansible account"
   type        = "string"

--- a/terraform/mexplat/main/main.tf
+++ b/terraform/mexplat/main/main.tf
@@ -42,7 +42,7 @@ module "gitlab" {
   zone                      = "${var.gitlab_gcp_zone}"
   boot_image                = ""
   boot_disk_size            = 100
-  allow_stopping_for_update = ""
+  allow_stopping_for_update = "true"
   tags                      = [
     "mexplat-${var.environ_tag}",
     "gitlab-registry",
@@ -107,6 +107,31 @@ module "vault_b_dns" {
   ip                            = "${module.vault_b.external_ip}"
 }
 
+module "vault_c" {
+  source              = "../../modules/vm_gcp"
+
+  instance_name       = "${var.vault_c_vm_name}"
+  environ_tag         = "${var.environ_tag}"
+  zone                = "${var.vault_c_gcp_zone}"
+  boot_disk_size      = 20
+  tags                = [
+    "mexplat-${var.environ_tag}",
+    "vault-ac",
+    "${module.fw_vault_gcp.target_tag}"
+  ]
+  labels              = {
+    "environ"         = "${var.environ_tag}",
+    "vault"           = "true",
+    "owner"           = "ops",
+  }
+}
+
+module "vault_c_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.vault_c_domain_name}"
+  ip                            = "${module.vault_c.external_ip}"
+}
+
 # VM for console
 module "console" {
   source              = "../../modules/vm_gcp"
@@ -125,6 +150,7 @@ module "console" {
     "mc-notify-${var.environ_tag}",
     "notifyroot",
     "alertmanager",
+    "stun-turn",
   ]
   labels              = {
     "environ"         = "${var.environ_tag}",

--- a/terraform/mexplat/main/variables.tf
+++ b/terraform/mexplat/main/variables.tf
@@ -85,18 +85,30 @@ variable "vault_b_domain_name" {
   default     = "vault-main-b.mobiledgex.net"
 }
 
+variable "vault_c_vm_name" {
+  default     = "vault-main-c"
+}
+
+variable "vault_c_gcp_zone" {
+  default     = "asia-east1-b"
+}
+
+variable "vault_c_domain_name" {
+  default     = "vault-main-c.mobiledgex.net"
+}
+
 variable "console_instance_name" {
   default     = "console-main"
 }
 
 variable "console_domain_name" {
   description = "Console domain name"
-  type        = "string"
+  default     = "console.mobiledgex.net"
 }
 
 variable "console_vnc_domain_name" {
   description = "Console VNC domain name"
-  type        = "string"
+  default     = "console-vnc.mobiledgex.net"
 }
 
 variable "alertmanager_domain_name" {
@@ -105,7 +117,7 @@ variable "alertmanager_domain_name" {
 
 variable "notifyroot_domain_name" {
   description = "Notifyroot service domain name"
-  type        = "string"
+  default     = "notifyroot.mobiledgex.net"
 }
 
 variable "stun_domain_name" {

--- a/terraform/mexplat/qa/main.tf
+++ b/terraform/mexplat/qa/main.tf
@@ -41,7 +41,7 @@ module "gitlab" {
   environ_tag         = "${var.environ_tag}"
   instance_size       = "custom-1-7680-ext"
   zone                = "${var.gcp_zone}"
-  boot_disk_size      = 100
+  boot_disk_size      = 200
   tags                = [
     "mexplat-${var.environ_tag}",
     "gitlab-registry",
@@ -124,11 +124,13 @@ module "console" {
     "alt-https",
     "notifyroot",
     "alertmanager",
+    "vault-ac",
   ]
   labels              = {
     "environ"         = "${var.environ_tag}",
     "console"         = "true",
     "owner"           = "qa",
+    "vault"           = "true",
   }
 }
 
@@ -178,6 +180,12 @@ module "vault_b_dns" {
   source                        = "../../modules/cloudflare_record"
   hostname                      = "${var.vault_b_domain_name}"
   ip                            = "${module.vault_b.external_ip}"
+}
+
+module "vault_c_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.vault_c_domain_name}"
+  ip                            = "${module.console.external_ip}"
 }
 
 module "fw_vault_gcp" {

--- a/terraform/mexplat/qa/variables.tf
+++ b/terraform/mexplat/qa/variables.tf
@@ -140,6 +140,10 @@ variable "vault_b_domain_name" {
   default     = "vault-qa-b.mobiledgex.net"
 }
 
+variable "vault_c_domain_name" {
+  default     = "vault-qa-c.mobiledgex.net"
+}
+
 variable "ssh_public_key_file" {
   description = "SSH public key file for the ansible account"
   type        = "string"

--- a/terraform/mexplat/stage/main.tf
+++ b/terraform/mexplat/stage/main.tf
@@ -124,11 +124,13 @@ module "console" {
     "alt-https",
     "notifyroot",
     "alertmanager",
+    "vault-ac",
   ]
   labels              = {
     "environ"         = "${var.environ_tag}",
     "console"         = "true",
     "owner"           = "ops",
+    "vault"           = "true",
   }
 }
 
@@ -178,6 +180,12 @@ module "vault_b_dns" {
   source                        = "../../modules/cloudflare_record"
   hostname                      = "${var.vault_b_domain_name}"
   ip                            = "${module.vault_b.external_ip}"
+}
+
+module "vault_c_dns" {
+  source                        = "../../modules/cloudflare_record"
+  hostname                      = "${var.vault_c_domain_name}"
+  ip                            = "${module.console.external_ip}"
 }
 
 module "fw_vault_gcp" {

--- a/terraform/mexplat/stage/variables.tf
+++ b/terraform/mexplat/stage/variables.tf
@@ -138,6 +138,10 @@ variable "vault_b_domain_name" {
   default     = "vault-stage-b.mobiledgex.net"
 }
 
+variable "vault_c_domain_name" {
+  default     = "vault-stage-c.mobiledgex.net"
+}
+
 variable "ssh_public_key_file" {
   description = "SSH public key file for the ansible account"
   type        = "string"


### PR DESCRIPTION
- Upgrade vault to 1.5.5
- Bump up HA nodes from two to three
- Switch from GCS to integrated Raft storage as the backing store