### PR TITLE
Check Gitlab version before deployment

### DIFF
--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -54,6 +54,15 @@
 
       tags: console
 
+- name: Check gitlab version
+  hosts:
+    - gitlab
+  gather_facts: no
+  tasks:
+    - import_role:
+        name: gitlab
+        tasks_from: version-check
+
 - name: Set up vault auth, policies, and roles
   import_playbook: vault-setup.yml
   tags: vault-setup

--- a/ansible/roles/gitlab/tasks/version-check.yml
+++ b/ansible/roles/gitlab/tasks/version-check.yml
@@ -1,0 +1,6 @@
+- name: Get package versions
+  package_facts:
+
+- name: "Ensure that gitlab version is {{ gitlab_version }}"
+  assert:
+    that: ansible_facts.packages['gitlab-ee'][0]['version'] == gitlab_version


### PR DESCRIPTION
Gitlab upgrades frequently require manual steps.  Do not attempt to
upgrade the package automatically, and instead just assert that the
installed version matches what is expected for the setup.

Prep for Gitlab upgrade to the next major version.