### PR TITLE
EDGECLOUD-4233 Upgrade docker base image [CVE-2020-1971]

### DIFF
--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y \
 	azure-cli=2.0.75-1~bionic \
 	google-cloud-sdk=267.0.0-0 \
 	kubectl=1.16.2-00 \
-	qemu-utils=1:2.11+dfsg-1ubuntu7.32
+	qemu-utils=1:2.11+dfsg-1ubuntu7.34
 
 COPY --from=python /python/ /
 


### PR DESCRIPTION
- Pull the latest version of the Ubuntu base and rebuild the base image
- Update to latest version of qemu-utils