### PR TITLE
Build scripts for the vCD parseovf package

### DIFF
--- a/openstack-tenant/packages/parseovf/Makefile
+++ b/openstack-tenant/packages/parseovf/Makefile
@@ -1,0 +1,19 @@
+PACKAGE = parseovf
+VERSION = 0.1
+
+DISTRIBUTION = cirrus
+COMPONENT = main
+
+PKGDIR = $(PACKAGE)_$(VERSION)
+
+all: build
+	../build.sh $(PACKAGE) $(VERSION) $(DISTRIBUTION) $(COMPONENT)
+
+build:
+	mkdir -p $(PKGDIR)/usr/local/bin
+	GOOS=linux GOARCH=amd64 go build -o $(PKGDIR)/usr/local/bin/parseovfenv \
+	     ../../../crm-platforms/vcd/parseovf
+
+clean:
+	$(RM) -r $(PKGDIR)
+	$(RM) $(PKGDIR).deb $(DOWNLOAD)

--- a/openstack-tenant/packages/parseovf/description
+++ b/openstack-tenant/packages/parseovf/description
@@ -1,0 +1,1 @@
+Tool to parse OVF env

--- a/openstack-tenant/packages/parseovf/postinst
+++ b/openstack-tenant/packages/parseovf/postinst
@@ -1,0 +1,2 @@
+#!/bin/bash
+chown root:root /usr/local/bin/parseovfenv


### PR DESCRIPTION
This is currently v0.1. Once @jlmorris3827's PR https://github.com/mobiledgex/edge-cloud-infra/pull/1264 is merged, this can be bumped up to v0.2