### PR TITLE
vcd client for CreateCloudlet/DeleteCloudlet

### DIFF
--- a/crm-platforms/vcd/vcd-network.go
+++ b/crm-platforms/vcd/vcd-network.go
@@ -534,7 +534,7 @@ func (v *VcdPlatform) GetAddrOfVM(ctx context.Context, vm *govcd.VM, netName str
 // Returns the first addr on the given network.
 func (v *VcdPlatform) GetAddrOfVapp(ctx context.Context, vapp *govcd.VApp, netName string) (string, error) {
 
-	if vapp == nil {
+	if vapp == nil || vapp.VApp == nil || vapp.VApp.Children == nil || len(vapp.VApp.Children.VM) == 0 {
 		return "", fmt.Errorf("Invalid Arg")
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetAddrOfVapp", "vapp", vapp.VApp.Name, "network", netName)

--- a/crm-platforms/vcd/vcd-security.go
+++ b/crm-platforms/vcd/vcd-security.go
@@ -153,6 +153,11 @@ func (v *VcdPlatform) GetClient(ctx context.Context, creds *VcdConfigParams) (cl
 		}
 	}
 
+	if creds == nil {
+		// usually indicates we called GetClient before InitProvider
+		return nil, fmt.Errorf("nil creds passed to GetClient")
+	}
+
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetClient", "user", creds.User)
 
 	u, err := url.ParseRequestURI(creds.Href)

--- a/crm-platforms/vcd/vcd-vapp.go
+++ b/crm-platforms/vcd/vcd-vapp.go
@@ -62,7 +62,7 @@ func (v *VcdPlatform) CreateVApp(ctx context.Context, vappTmpl *govcd.VAppTempla
 	networks := []*types.OrgVDCNetwork{}
 	networks = append(networks, vdcNet.OrgVDCNetwork)
 
-	log.SpanLog(ctx, log.DebugLevelInfra, "CreateVApp compose vapp with regen UUID", "name", vappName, "vmRole", vmRole, "vmType", vmType)
+	log.SpanLog(ctx, log.DebugLevelInfra, "CreateVApp compose vApp", "name", vappName, "vmRole", vmRole, "vmType", vmType)
 
 	description = description + vcdProviderVersion
 	task, err := vdc.ComposeVApp(networks, *vappTmpl, storRef, vappName, description, true)

--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -174,7 +174,6 @@ func (v *VMPlatform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 			return err
 		}
 	}
-
 	v.VMProperties.Domain = VMDomainPlatform
 	pc := infracommon.GetPlatformConfig(cloudlet, pfConfig, accessApi)
 	err = v.InitProps(ctx, pc)
@@ -229,6 +228,11 @@ func (v *VMPlatform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 	if err != nil {
 		return err
 	}
+	ctx, err = v.VMProvider.InitOperationContext(ctx, OperationInitStart)
+	if err != nil {
+		return err
+	}
+	defer v.VMProvider.InitOperationContext(ctx, OperationInitComplete)
 
 	chefAttributes, err := v.GetChefPlatformAttributes(ctx, cloudlet, pfConfig)
 	if err != nil {
@@ -261,12 +265,6 @@ func (v *VMPlatform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 		// Return, as end-user will setup the platform VM
 		return nil
 	}
-
-	ctx, err = v.VMProvider.InitOperationContext(ctx, OperationInitStart)
-	if err != nil {
-		return err
-	}
-	defer v.VMProvider.InitOperationContext(ctx, OperationInitComplete)
 
 	err = v.SetupPlatformVM(ctx, accessApi, cloudlet, pfConfig, pfFlavor, updateCallback)
 	if err != nil {
@@ -387,6 +385,12 @@ func (v *VMPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 
 	v.Caches = caches
 	v.VMProvider.InitProvider(ctx, caches, ProviderInitDeleteCloudlet, updateCallback)
+
+	ctx, err = v.VMProvider.InitOperationContext(ctx, OperationInitStart)
+	if err != nil {
+		return err
+	}
+	defer v.VMProvider.InitOperationContext(ctx, OperationInitComplete)
 
 	chefClient := v.VMProperties.GetChefClient()
 	if chefClient == nil {


### PR DESCRIPTION
The new per-operation client is in the wrong place for CreateCloudlet as there was an API call made before the client is initialized.  It was missing totally for DeleteCloudlet

Also fix a random panic in vmware's code I saw due to a vApp missing children VMs and add protective check for trying to create the client with no credentials. 