### PR TITLE
EDGECLOUD-4318: Multiple subnets with DHCP enabled set to yes fails for KDDI cloudlets

### DIFF
--- a/crm-platforms/openstack/openstack-fip-test-heat-expected.yaml
+++ b/crm-platforms/openstack/openstack-fip-test-heat-expected.yaml
@@ -75,6 +75,15 @@ resources:
                 - subnet: { get_resource: subnet-test }
                   ip_address:  10.101.0.102
             port_security_enabled: false
+    app-vm-subnet-test-port:
+        type: OS::Neutron::Port
+        properties:
+            name: app-vm-subnet-test-port
+            network: mex-k8s-net-1
+            fixed_ips:
+                - subnet: { get_resource: subnet-test }
+                  ip_address:  10.101.0.103
+            port_security_enabled: false
     testvmgroup-sg:
         type: OS::Neutron::SecurityGroup
         properties:
@@ -311,6 +320,52 @@ resources:
                 skipk8s: no
                 role: k8s-node
                 k8smaster: 10.101.0.10
+        
+    app-vm:
+        type: OS::Nova::Server
+        properties:
+            name: app-vm
+            networks:
+                - port: { get_resource: app-vm-subnet-test-port }
+            availability_zone: nova1
+            image: mobiledgex-v9.9.9 
+            flavor: m1.medium
+            config_drive: true
+            user_data_format: RAW
+            user_data: |
+                #cloud-config
+                chef:
+                  server_url: cheftestserver.mobiledgex.net/organizations/mobiledgex
+                  node_name: app-vm
+                  environment: ""
+                  validation_name: mobiledgex-validator
+                  validation_key: /etc/chef/client.pem
+                  validation_cert: |
+                          -----BEGIN RSA PRIVATE KEY-----
+                          NDFGHJKLJHGHJKJNHJNBHJNBGYUJNBGHJNBGSZiO/8i6ERbmqPopV8GWC5VjxlZm
+                          -----END RSA PRIVATE KEY-----
+                bootcmd:
+                 - echo MOBILEDGEX CLOUD CONFIG START
+                 - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
+                 - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
+                 - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
+                  - path:  /etc/systemd/resolved.conf
+                    content: |
+                       [Resolve]
+                       DNS=1.1.1.1
+                       FallbackDNS=1.0.0.1
+                chpasswd: { expire: False }
+                ssh_pwauth: False
+                timezone: UTC
+                runcmd:
+                 - systemctl restart systemd-resolved
+                 - echo MOBILEDGEX doing ifconfig
+                 - ifconfig -a
     rootlb-xyz-external-network-shared-port-fip:
         type: OS::Neutron::FloatingIPAssociation
         properties:

--- a/crm-platforms/openstack/openstack-fip-test-heat.yaml
+++ b/crm-platforms/openstack/openstack-fip-test-heat.yaml
@@ -75,6 +75,15 @@ resources:
                 - subnet: { get_resource: subnet-test }
                   ip_address:  10.101.0.102
             port_security_enabled: false
+    app-vm-subnet-test-port:
+        type: OS::Neutron::Port
+        properties:
+            name: app-vm-subnet-test-port
+            network: mex-k8s-net-1
+            fixed_ips:
+                - subnet: { get_resource: subnet-test }
+                  ip_address:  10.101.0.103
+            port_security_enabled: false
     testvmgroup-sg:
         type: OS::Neutron::SecurityGroup
         properties:
@@ -311,6 +320,52 @@ resources:
                 skipk8s: no
                 role: k8s-node
                 k8smaster: 10.101.0.10
+        
+    app-vm:
+        type: OS::Nova::Server
+        properties:
+            name: app-vm
+            networks:
+                - port: { get_resource: app-vm-subnet-test-port }
+            availability_zone: nova1
+            image: mobiledgex-v9.9.9 
+            flavor: m1.medium
+            config_drive: true
+            user_data_format: RAW
+            user_data: |
+                #cloud-config
+                chef:
+                  server_url: cheftestserver.mobiledgex.net/organizations/mobiledgex
+                  node_name: app-vm
+                  environment: ""
+                  validation_name: mobiledgex-validator
+                  validation_key: /etc/chef/client.pem
+                  validation_cert: |
+                          -----BEGIN RSA PRIVATE KEY-----
+                          NDFGHJKLJHGHJKJNHJNBHJNBGYUJNBGHJNBGSZiO/8i6ERbmqPopV8GWC5VjxlZm
+                          -----END RSA PRIVATE KEY-----
+                bootcmd:
+                 - echo MOBILEDGEX CLOUD CONFIG START
+                 - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
+                 - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
+                 - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
+                  - path:  /etc/systemd/resolved.conf
+                    content: |
+                       [Resolve]
+                       DNS=1.1.1.1
+                       FallbackDNS=1.0.0.1
+                chpasswd: { expire: False }
+                ssh_pwauth: False
+                timezone: UTC
+                runcmd:
+                 - systemctl restart systemd-resolved
+                 - echo MOBILEDGEX doing ifconfig
+                 - ifconfig -a
     rootlb-xyz-external-network-shared-port-fip:
         type: OS::Neutron::FloatingIPAssociation
         properties:

--- a/crm-platforms/openstack/openstack-test-heat-expected.yaml
+++ b/crm-platforms/openstack/openstack-test-heat-expected.yaml
@@ -9,7 +9,7 @@ resources:
             cidr: 10.101.0.0/24
             network: mex-k8s-net-1
             gateway_ip: 10.101.0.1
-            enable_dhcp: yes
+            enable_dhcp: no
             dns_nameservers:
                  - 1.1.1.1
                  - 1.0.0.1
@@ -66,6 +66,15 @@ resources:
             fixed_ips:
                 - subnet: { get_resource: subnet-test }
                   ip_address:  10.101.0.102
+            port_security_enabled: false
+    app-vm-subnet-test-port:
+        type: OS::Neutron::Port
+        properties:
+            name: app-vm-subnet-test-port
+            network: mex-k8s-net-1
+            fixed_ips:
+                - subnet: { get_resource: subnet-test }
+                  ip_address:  10.101.0.103
             port_security_enabled: false
     testvmgroup-sg:
         type: OS::Neutron::SecurityGroup
@@ -303,3 +312,49 @@ resources:
                 skipk8s: no
                 role: k8s-node
                 k8smaster: 10.101.0.10
+        
+    app-vm:
+        type: OS::Nova::Server
+        properties:
+            name: app-vm
+            networks:
+                - port: { get_resource: app-vm-subnet-test-port }
+            availability_zone: nova1
+            image: mobiledgex-v9.9.9 
+            flavor: m1.medium
+            config_drive: true
+            user_data_format: RAW
+            user_data: |
+                #cloud-config
+                chef:
+                  server_url: cheftestserver.mobiledgex.net/organizations/mobiledgex
+                  node_name: app-vm
+                  environment: ""
+                  validation_name: mobiledgex-validator
+                  validation_key: /etc/chef/client.pem
+                  validation_cert: |
+                          -----BEGIN RSA PRIVATE KEY-----
+                          NDFGHJKLJHGHJKJNHJNBHJNBGYUJNBGHJNBGSZiO/8i6ERbmqPopV8GWC5VjxlZm
+                          -----END RSA PRIVATE KEY-----
+                bootcmd:
+                 - echo MOBILEDGEX CLOUD CONFIG START
+                 - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
+                 - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
+                 - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
+                  - path:  /etc/systemd/resolved.conf
+                    content: |
+                       [Resolve]
+                       DNS=1.1.1.1
+                       FallbackDNS=1.0.0.1
+                chpasswd: { expire: False }
+                ssh_pwauth: False
+                timezone: UTC
+                runcmd:
+                 - systemctl restart systemd-resolved
+                 - echo MOBILEDGEX doing ifconfig
+                 - ifconfig -a

--- a/crm-platforms/openstack/openstack-test-heat.yaml
+++ b/crm-platforms/openstack/openstack-test-heat.yaml
@@ -9,7 +9,7 @@ resources:
             cidr: 10.101.0.0/24
             network: mex-k8s-net-1
             gateway_ip: 10.101.0.1
-            enable_dhcp: yes
+            enable_dhcp: no
             dns_nameservers:
                  - 1.1.1.1
                  - 1.0.0.1
@@ -66,6 +66,15 @@ resources:
             fixed_ips:
                 - subnet: { get_resource: subnet-test }
                   ip_address:  10.101.0.102
+            port_security_enabled: false
+    app-vm-subnet-test-port:
+        type: OS::Neutron::Port
+        properties:
+            name: app-vm-subnet-test-port
+            network: mex-k8s-net-1
+            fixed_ips:
+                - subnet: { get_resource: subnet-test }
+                  ip_address:  10.101.0.103
             port_security_enabled: false
     testvmgroup-sg:
         type: OS::Neutron::SecurityGroup
@@ -303,3 +312,49 @@ resources:
                 skipk8s: no
                 role: k8s-node
                 k8smaster: 10.101.0.10
+        
+    app-vm:
+        type: OS::Nova::Server
+        properties:
+            name: app-vm
+            networks:
+                - port: { get_resource: app-vm-subnet-test-port }
+            availability_zone: nova1
+            image: mobiledgex-v9.9.9 
+            flavor: m1.medium
+            config_drive: true
+            user_data_format: RAW
+            user_data: |
+                #cloud-config
+                chef:
+                  server_url: cheftestserver.mobiledgex.net/organizations/mobiledgex
+                  node_name: app-vm
+                  environment: ""
+                  validation_name: mobiledgex-validator
+                  validation_key: /etc/chef/client.pem
+                  validation_cert: |
+                          -----BEGIN RSA PRIVATE KEY-----
+                          NDFGHJKLJHGHJKJNHJNBHJNBGYUJNBGHJNBGSZiO/8i6ERbmqPopV8GWC5VjxlZm
+                          -----END RSA PRIVATE KEY-----
+                bootcmd:
+                 - echo MOBILEDGEX CLOUD CONFIG START
+                 - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
+                 - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
+                 - echo "Removed APT and Ubuntu extra packages" | systemd-cat
+                 - cloud-init-per once ssh-users-ca echo "TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem" >> /etc/ssh/sshd_config
+                write_files:
+                  - path: /etc/ssh/trusted-user-ca-keys.pem
+                    content: ssh-rsa DUMMYTESTCACERT
+                    append: true
+                  - path:  /etc/systemd/resolved.conf
+                    content: |
+                       [Resolve]
+                       DNS=1.1.1.1
+                       FallbackDNS=1.0.0.1
+                chpasswd: { expire: False }
+                ssh_pwauth: False
+                timezone: UTC
+                runcmd:
+                 - systemctl restart systemd-resolved
+                 - echo MOBILEDGEX doing ifconfig
+                 - ifconfig -a

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -166,6 +166,11 @@ var VMProviderProps = map[string]*edgeproto.PropertyInfo{
 		Name:        "NTP Servers",
 		Description: "Optional comma separated list of NTP servers to override default of ntp.ubuntu.com",
 	},
+	"MEX_VM_APP_SUBNET_DHCP_ENABLED": {
+		Name:        "VM App subnet enable DHCP",
+		Description: "Enable DHCP for the subnet created for VM based applications (yes or no)",
+		Value:       "yes",
+	},
 }
 
 func GetSupportedRouterTypes() string {
@@ -359,6 +364,11 @@ func (vp *VMProperties) GetCloudletCRMGatewayIPAndPort() (string, int) {
 		log.FatalLog("Error in MEX_CRM_GATEWAY_ADDR port format")
 	}
 	return host, port
+}
+
+func (vp *VMProperties) GetVMAppSubnetDHCPEnabled() string {
+	value, _ := vp.CommonPf.Properties.GetValue("MEX_VM_APP_SUBNET_DHCP_ENABLED")
+	return value
 }
 
 func (vp *VMProperties) GetChefClient() *chef.Client {

--- a/vmlayer/vmparams.go
+++ b/vmlayer/vmparams.go
@@ -672,12 +672,23 @@ func (v *VMPlatform) getVMGroupOrchestrationParamsFromGroupSpec(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
+	vmAppSubnet := false
+	for _, vm := range spec.VMs {
+		if vm.Type == VMTypeAppVM {
+			vmAppSubnet = true
+			break
+		}
+	}
+	dhcpEnabled := "no"
+	if vmAppSubnet && v.VMProperties.GetVMAppSubnetDHCPEnabled() != "no" {
+		dhcpEnabled = "yes"
+	}
 	if spec.NewSubnetName != "" {
 		newSubnet := SubnetOrchestrationParams{
 			Name:              spec.NewSubnetName,
 			Id:                v.VMProvider.IdSanitize(spec.NewSubnetName),
 			CIDR:              NextAvailableResource,
-			DHCPEnabled:       "yes",
+			DHCPEnabled:       dhcpEnabled,
 			DNSServers:        subnetDns,
 			NetworkName:       v.VMProperties.GetCloudletMexNetwork(),
 			SecurityGroupName: spec.NewSecgrpName,


### PR DESCRIPTION
* As part of R2.4, we made a change to enable_dhcp: yes for any subnet we create on Openstack. This works fine for TDG cloudlets. But for KDDI this was causing the issue, because their NSX plugin has some limitation on it.
* Reference: https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.1/rn/VMware-NSX-T-Data-Center-Plugin-31-for-OpenStack-Neutron-Release-Notes.html
* As part of Known limitations, it is mentioned that:
```
Cannot add more than one subnet with DHCP enabled to a network
```
* Hence have made the following change:
  - Enable DHCP for subnet only if it is for VM based Apps
  - Added envvar to disable dhcp for cloudlets like KDDI