### PR TITLE
use common external networking setting for vCD

### DIFF
--- a/crm-platforms/vcd/vcd-network.go
+++ b/crm-platforms/vcd/vcd-network.go
@@ -25,7 +25,7 @@ func (v *VcdPlatform) GetNetworkList(ctx context.Context) ([]string, error) {
 func (v *VcdPlatform) GetExtNetwork(ctx context.Context, vcdClient *govcd.VCDClient) (*govcd.OrgVDCNetwork, error) {
 
 	// infra propert from env
-	netName := v.GetExtNetworkName()
+	netName := v.vmProperties.GetCloudletExternalNetwork()
 
 	vdc, err := v.GetVdc(ctx, vcdClient)
 	if err != nil {
@@ -119,7 +119,7 @@ func (v *VcdPlatform) AddPortsToVapp(ctx context.Context, vapp *govcd.VApp, vmgp
 				&types.NetworkConnection{
 					IsConnected:             true,
 					IPAddressAllocationMode: types.IPAllocationModePool,
-					Network:                 v.GetExtNetworkName(),
+					Network:                 v.vmProperties.GetCloudletExternalNetwork(),
 					NetworkConnectionIndex:  conIdx,
 				})
 
@@ -452,7 +452,7 @@ func (v *VcdPlatform) GetIntAddrsOfVM(ctx context.Context, vm *govcd.VM) ([]stri
 
 	nc := ncs.NetworkConnection
 	for _, n := range nc {
-		if n.Network != v.GetExtNetworkName() {
+		if n.Network != v.vmProperties.GetCloudletExternalNetwork() {
 			addrs = append(addrs, n.IPAddress)
 		}
 	}

--- a/crm-platforms/vcd/vcd-prop.go
+++ b/crm-platforms/vcd/vcd-prop.go
@@ -100,10 +100,6 @@ func (v *VcdPlatform) GetVDCTemplateName() string {
 	return v.vcdVars["VDCTEMPLATE"]
 }
 
-func (v *VcdPlatform) GetExtNetworkName() string {
-	return v.vcdVars["MEX_EXT_NETWORK"]
-}
-
 // properties from envvars
 func (v *VcdPlatform) GetVcdVerbose() bool {
 	verbose, _ := v.vmProperties.CommonPf.Properties.GetValue("VCDVerbose")

--- a/crm-platforms/vcd/vcd-vm.go
+++ b/crm-platforms/vcd/vcd-vm.go
@@ -876,7 +876,7 @@ func (v *VcdPlatform) GetVMAddresses(ctx context.Context, vm *govcd.VM) ([]vmlay
 			InternalAddr: connection.IPAddress,
 			PortName:     strconv.Itoa(connection.NetworkConnectionIndex),
 		}
-		if connection.Network != v.GetExtNetworkName() {
+		if connection.Network != v.vmProperties.GetCloudletExternalNetwork() {
 			// internal isolated net
 			servIP.PortName = vmName + "-" + connection.Network + "-port"
 			// servIP.PortName = connection.Network
@@ -911,7 +911,7 @@ func (v *VcdPlatform) GetServerGroupResources(ctx context.Context, name string) 
 	if err != nil {
 		return nil, err
 	}
-	extNetName := v.GetExtNetworkName()
+	extNetName := v.vmProperties.GetCloudletExternalNetwork()
 
 	vappName := name + "-vapp"
 	vapp, err := vdc.GetVAppByName(vappName, true)
@@ -957,7 +957,6 @@ func (v *VcdPlatform) GetServerGroupResources(ctx context.Context, name string) 
 		}
 		ipAddr := edgeproto.IpAddr{}
 
-		//extAddr, err := v.GetExtAddrOfVM(ctx, vm, v.GetExtNetworkName())
 		// Find addr of vm for the given network
 		extAddr, err := v.GetAddrOfVM(ctx, vm, extNetName)
 		// It fine if some vm doesn't have an external net connection

--- a/crm-platforms/vcd/vcd.go
+++ b/crm-platforms/vcd/vcd.go
@@ -311,7 +311,7 @@ func (v *VcdPlatform) GetAllVAppsForVdc(ctx context.Context, vcdClient *govcd.VC
 	if err != nil {
 		return vappMap, err
 	}
-	netName := v.GetExtNetworkName()
+	netName := v.vmProperties.GetCloudletExternalNetwork()
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVappsForVcd by ext addr on ", "network", netName)
 	for _, r := range vdc.Vdc.ResourceEntities {
 		for _, res := range r.ResourceEntity {
@@ -347,7 +347,7 @@ func (v *VcdPlatform) GetAllVMsForVdcByIntAddr(ctx context.Context, vcdClient *g
 	if err != nil {
 		return vmMap, err
 	}
-	netName := v.GetExtNetworkName()
+	netName := v.vmProperties.GetCloudletExternalNetwork()
 
 	for _, r := range vdc.Vdc.ResourceEntities {
 		for _, res := range r.ResourceEntity {
@@ -396,7 +396,7 @@ func (v *VcdPlatform) GetAllVAppsForVdcByIntAddr(ctx context.Context, vcdClient 
 		return vappMap, err
 	}
 
-	extNetName := v.GetExtNetworkName()
+	extNetName := v.vmProperties.GetCloudletExternalNetwork()
 
 	for _, r := range vdc.Vdc.ResourceEntities {
 		for _, res := range r.ResourceEntity {


### PR DESCRIPTION
Consolidate vCD's GetExtNetworkName from vault with the common GetCloudletExternalNetwork from properties.  They need to match in any case since the vmlayer code uses GetCloudletExternalNetwork