### PR TITLE
EDGECLOUD-4282  [alertreciever] Allow # to be Optional for Channel Name

### DIFF
--- a/e2e-tests/data/mc_user2_alert_receiver.yml
+++ b/e2e-tests/data/mc_user2_alert_receiver.yml
@@ -18,7 +18,7 @@ alertreceivers:
 - name: emailSlackReceiver
   type: slack
   severity: error
-  slackchannel: "#alerts"
+  slackchannel: "alerts"
   slackwebhook: "http://host.docker.internal:9100/slack/webhook"
   appinst:
     appkey:

--- a/mc/orm/alertmgr_api.go
+++ b/mc/orm/alertmgr_api.go
@@ -2,6 +2,7 @@ package orm
 
 import (
 	fmt "fmt"
+	"strings"
 
 	"github.com/labstack/echo"
 	"github.com/mobiledgex/edge-cloud-infra/mc/orm/alertmgr"
@@ -105,6 +106,12 @@ func CreateAlertReceiver(c echo.Context) error {
 			return setReply(c, fmt.Errorf("Both slack URL and slack channel must be specified"),
 				nil)
 		}
+		// make sure channel has "#" as a prefix
+		// this allows channel to be specified without # on the api
+		if !strings.HasPrefix(in.SlackChannel, "#") {
+			in.SlackChannel = "#" + in.SlackChannel
+		}
+
 		err = AlertManagerServer.CreateReceiver(ctx, &in)
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelInfo, "Failed to create a receiver", "err", err)


### PR DESCRIPTION
Per Jay's request added handling of a channel string if it doesn't have a `#` prefix.
Modified e2e-test to verify that it is handled correctly.