### PR TITLE
EDGECLOUD-4099  remove "job" label from alertreceiver email alerts

### DIFF
--- a/e2e-tests/data/emaildata_alert_firing.yml
+++ b/e2e-tests/data/emaildata_alert_firing.yml
@@ -1,6 +1,6 @@
 - text: "\nMobiledX Monitoring System: 1 alert for \n  alertname=AppInstDown\n\n  app=someapplication1\n\n
     \ apporg=AcmeAppCo\n\n  appver=1.0\n\n  cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n
-    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n  job=MobiledgeX Monitoring\n\n
+    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n
     \ region=local\n\n  scope=Application\n\n  status=HealthCheckFailServerFail\n\n\n
     \ [1] Firing\n\n\n"
   headers:
@@ -10,7 +10,7 @@
     from: alerts@mobiledgex.com
 - text: "\nMobiledX Monitoring System: 1 alert for \n  alertname=AppInstDown\n\n  app=someapplication1\n\n
     \ apporg=AcmeAppCo\n\n  appver=1.0\n\n  cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n
-    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n  job=MobiledgeX Monitoring\n\n
+    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n
     \ region=local\n\n  scope=Application\n\n  status=HealthCheckFailServerFail\n\n\n
     \ [1] Firing\n\n\n"
   headers:

--- a/e2e-tests/data/emaildata_alert_resolved.yml
+++ b/e2e-tests/data/emaildata_alert_resolved.yml
@@ -1,6 +1,6 @@
 - text: "\nMobiledX Monitoring System: 1 alert for \n  alertname=AppInstDown\n\n  app=someapplication1\n\n
     \ apporg=AcmeAppCo\n\n  appver=1.0\n\n  cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n
-    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n  job=MobiledgeX Monitoring\n\n
+    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n
     \ region=local\n\n  scope=Application\n\n  status=HealthCheckFailServerFail\n\n\n
     \ [1] Firing\n\n\n"
   headers:
@@ -10,7 +10,7 @@
     from: alerts@mobiledgex.com
 - text: "\nMobiledX Monitoring System: 1 alert for \n  alertname=AppInstDown\n\n  app=someapplication1\n\n
     \ apporg=AcmeAppCo\n\n  appver=1.0\n\n  cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n
-    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n  job=MobiledgeX Monitoring\n\n
+    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n
     \ region=local\n\n  scope=Application\n\n  status=HealthCheckFailServerFail\n\n\n
     \ [1] Firing\n\n\n"
   headers:
@@ -20,7 +20,7 @@
     from: alerts@mobiledgex.com
 - text: "\nMobiledX Monitoring System: 1 alert for \n  alertname=AppInstDown\n\n  app=someapplication1\n\n
     \ apporg=AcmeAppCo\n\n  appver=1.0\n\n  cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n
-    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n  job=MobiledgeX Monitoring\n\n
+    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n
     \ region=local\n\n  scope=Application\n\n  status=HealthCheckFailServerFail\n\n\n\n
     \ [1] Resolved\n\n"
   headers:
@@ -30,7 +30,7 @@
     from: alerts@mobiledgex.com
 - text: "\nMobiledX Monitoring System: 1 alert for \n  alertname=AppInstDown\n\n  app=someapplication1\n\n
     \ apporg=AcmeAppCo\n\n  appver=1.0\n\n  cloudlet=tmus-cloud-1\n\n  cloudletorg=tmus\n\n
-    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n  job=MobiledgeX Monitoring\n\n
+    \ cluster=SmallCluster\n\n  clusterorg=AcmeAppCo\n\n
     \ region=local\n\n  scope=Application\n\n  status=HealthCheckFailServerFail\n\n\n\n
     \ [1] Resolved\n\n"
   headers:

--- a/e2e-tests/data/slackdata_alert_firing.yml
+++ b/e2e-tests/data/slackdata_alert_firing.yml
@@ -8,8 +8,7 @@
     text: "\n*Alert:* AppInstDown\n\n*Description:* Application server port is not responding\n\n*Details:*\n
       \  • *alertname:* AppInstDown\n   • *app:* someapplication1\n   • *apporg:*
       AcmeAppCo\n   • *appver:* 1.0\n   • *cloudlet:* tmus-cloud-1\n   • *cloudletorg:*
-      tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:* AcmeAppCo\n   • *job:*
-      MobiledgeX Monitoring\n   • *region:* local\n   • *scope:* Application\n   •
+      tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:* AcmeAppCo\n   • *region:* local\n   • *scope:* Application\n   •
       *status:* HealthCheckFailServerFail\n  \n\n"
     fallback: |+
       [FIRING:1] Alert for emailSlackReceiver: AppInstDown Application: someapplication1 Version: 1.0 | https://console.mobiledgex.net

--- a/e2e-tests/data/slackdata_alert_resolved.yml
+++ b/e2e-tests/data/slackdata_alert_resolved.yml
@@ -8,8 +8,8 @@
     text: "\n*Alert:* AppInstDown\n\n*Description:* Application server port is not responding\n\n*Details:*\n
       \  • *alertname:* AppInstDown\n   • *app:* someapplication1\n   • *apporg:*
       AcmeAppCo\n   • *appver:* 1.0\n   • *cloudlet:* tmus-cloud-1\n   • *cloudletorg:*
-      tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:* AcmeAppCo\n   • *job:*
-      MobiledgeX Monitoring\n   • *region:* local\n   • *scope:* Application\n   •
+      tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:* AcmeAppCo\n   • *region:*
+      local\n   • *scope:* Application\n   •
       *status:* HealthCheckFailServerFail\n  \n\n"
     fallback: |+
       [FIRING:1] Alert for emailSlackReceiver: AppInstDown Application: someapplication1 Version: 1.0 | https://console.mobiledgex.net
@@ -24,8 +24,8 @@
     text: "\n*Alert:* AppInstDown\n\n*Description:* Application server port is not responding\n\n*Details:*\n
       \  • *alertname:* AppInstDown\n   • *app:* someapplication1\n   • *apporg:*
       AcmeAppCo\n   • *appver:* 1.0\n   • *cloudlet:* tmus-cloud-1\n   • *cloudletorg:*
-      tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:* AcmeAppCo\n   • *job:*
-      MobiledgeX Monitoring\n   • *region:* local\n   • *scope:* Application\n   •
+      tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:* AcmeAppCo\n   • *region:*
+      local\n   • *scope:* Application\n   •
       *status:* HealthCheckFailServerFail\n  \n\n"
     fallback: |+
       [RESOLVED] Alert for emailSlackReceiver: AppInstDown Application: someapplication1 Version: 1.0 | https://console.mobiledgex.net

--- a/mc/orm/alertmgr/alertmgr.go
+++ b/mc/orm/alertmgr/alertmgr.go
@@ -149,7 +149,7 @@ func isInternalAlert(alert *edgeproto.Alert) bool {
 }
 
 func isLabelInternal(label string) bool {
-	if label == "instance" {
+	if label == "instance" || label == "job" {
 		return true
 	}
 	return false


### PR DESCRIPTION
Hide job label from alertmanager alerts.
This label is internal, so we should not show it to the users receiving notifications.