### PR TITLE
EDGECLOUD-3931: Add resource usage metrics

### DIFF
--- a/e2e-tests/data/mc_admin_data.yml
+++ b/e2e-tests/data/mc_admin_data.yml
@@ -73,6 +73,7 @@ regiondata:
       persistentconnectionmetricscollectioninterval: 1s
       influxdbmetricsretention: 672h0m0s
       cleanupreservableautoclusteridletime: 30m
+      influxdbcloudletusagemetricsretention: 8760h0m0s
     flavors:
     - key:
         name: x1.tiny
@@ -117,6 +118,7 @@ regiondata:
       persistentconnectionmetricscollectioninterval: 1s
       influxdbmetricsretention: 672h0m0s
       cleanupreservableautoclusteridletime: 30m
+      influxdbcloudletusagemetricsretention: 8760h0m0s
     flavors:
     - key:
         name: x1.tiny

--- a/mc/mcctl/ormctl/metrics.go
+++ b/mc/mcctl/ormctl/metrics.go
@@ -38,6 +38,15 @@ func GetMetricsCommand() *cobra.Command {
 		ReplyData:    &ormapi.AllMetrics{},
 		Run:          runRest("/auth/metrics/cloudlet"),
 	}, &cli.Command{
+		Use:          "cloudletusage",
+		RequiredArgs: strings.Join(append([]string{"region"}, CloudletMetricRequiredArgs...), " "),
+		OptionalArgs: strings.Join(CloudletMetricOptionalArgs, " "),
+		AliasArgs:    strings.Join(CloudletMetricAliasArgs, " "),
+		Comments:     mergeMetricComments(addRegionComment(MetricCommentsCommon), CloudletUsageMetricComments),
+		ReqData:      &ormapi.RegionCloudletMetrics{},
+		ReplyData:    &ormapi.AllMetrics{},
+		Run:          runRest("/auth/metrics/cloudlet/usage"),
+	}, &cli.Command{
 		Use:          "client",
 		RequiredArgs: strings.Join(append([]string{"region"}, ClientMetricRequiredArgs...), " "),
 		OptionalArgs: strings.Join(ClientMetricOptionalArgs, " "),
@@ -116,6 +125,7 @@ var CloudletMetricOptionalArgs = []string{
 	"last",
 	"starttime",
 	"endtime",
+	"platformtype",
 }
 
 var CloudletMetricAliasArgs = []string{
@@ -124,7 +134,13 @@ var CloudletMetricAliasArgs = []string{
 }
 
 var CloudletMetricComments = map[string]string{
-	"selector": "Comma separated list of metrics to view. Available metrics: \"" + strings.Join(orm.CloudletSelectors, "\", \"") + "\"",
+	"selector":     "Comma separated list of metrics to view. Available metrics: \"" + strings.Join(orm.CloudletSelectors, "\", \"") + "\"",
+	"platformtype": "Type of the cloudlet platform",
+}
+
+var CloudletUsageMetricComments = map[string]string{
+	"selector":     "Comma separated list of metrics to view. Available metrics: \"" + strings.Join(orm.CloudletUsageSelectors, "\", \"") + "\"",
+	"platformtype": "Type of the cloudlet platform",
 }
 
 var ClientMetricRequiredArgs = []string{

--- a/mc/mcctl/ormctl/settings.mc2.go
+++ b/mc/mcctl/ormctl/settings.mc2.go
@@ -113,6 +113,7 @@ var SettingsOptionalArgs = []string{
 	"dmeapimetricscollectioninterval",
 	"persistentconnectionmetricscollectioninterval",
 	"cleanupreservableautoclusteridletime",
+	"influxdbcloudletusagemetricsretention",
 }
 var SettingsAliasArgs = []string{
 	"fields=settings.fields",
@@ -140,6 +141,7 @@ var SettingsAliasArgs = []string{
 	"dmeapimetricscollectioninterval=settings.dmeapimetricscollectioninterval",
 	"persistentconnectionmetricscollectioninterval=settings.persistentconnectionmetricscollectioninterval",
 	"cleanupreservableautoclusteridletime=settings.cleanupreservableautoclusteridletime",
+	"influxdbcloudletusagemetricsretention=settings.influxdbcloudletusagemetricsretention",
 }
 var SettingsComments = map[string]string{
 	"fields":                                        "Fields are used for the Update API to specify which fields to apply",
@@ -167,6 +169,7 @@ var SettingsComments = map[string]string{
 	"dmeapimetricscollectioninterval":               "Metrics collection interval for DME API counts (duration)",
 	"persistentconnectionmetricscollectioninterval": "Metrics collection interval for persistent connection (appinstlatency and gps locations) (duration)",
 	"cleanupreservableautoclusteridletime":          "Idle reservable ClusterInst clean up time",
+	"influxdbcloudletusagemetricsretention":         "Default influxDB cloudlet usage metrics retention policy (duration)",
 }
 var SettingsSpecialArgs = map[string]string{
 	"settings.fields": "StringArray",

--- a/mc/orm/alert.mc2.go
+++ b/mc/orm/alert.mc2.go
@@ -151,6 +151,7 @@ func addControllerApis(method string, group *echo.Group) {
 	// DmeApiMetricsCollectionInterval: 23
 	// PersistentConnectionMetricsCollectionInterval: 24
 	// CleanupReservableAutoClusterIdletime: 25
+	// InfluxDbCloudletUsageMetricsRetention: 26
 	// ```
 	// Security:
 	//   Bearer:

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -532,6 +532,18 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	//   404: notFound
 	auth.POST("/metrics/cloudlet", GetMetricsCommon)
 
+	// swagger:route POST /auth/metrics/cloudlet/usage OperatorMetrics CloudletUsageMetrics
+	// Cloudlet usage related metrics.
+	// Display cloudlet usage related metrics.
+	// Security:
+	//   Bearer:
+	// responses:
+	//   200: success
+	//   400: badRequest
+	//   403: forbidden
+	//   404: notFound
+	auth.POST("/metrics/cloudlet/usage", GetMetricsCommon)
+
 	// swagger:route POST /auth/metrics/client DeveloperMetrics ClientMetrics
 	// Client related metrics.
 	// Display client related metrics.
@@ -661,6 +673,7 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	ws.GET("/metrics/app", GetMetricsCommon)
 	ws.GET("/metrics/cluster", GetMetricsCommon)
 	ws.GET("/metrics/cloudlet", GetMetricsCommon)
+	ws.GET("/metrics/cloudlet/usage", GetMetricsCommon)
 	ws.GET("/metrics/client", GetMetricsCommon)
 
 	if config.NotifySrvAddr != "" {

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -382,12 +382,13 @@ type RegionClusterInstMetrics struct {
 }
 
 type RegionCloudletMetrics struct {
-	Region    string
-	Cloudlet  edgeproto.CloudletKey
-	Selector  string
-	StartTime time.Time `json:",omitempty"`
-	EndTime   time.Time `json:",omitempty"`
-	Last      int       `json:",omitempty"`
+	Region       string
+	Cloudlet     edgeproto.CloudletKey
+	Selector     string
+	PlatformType string
+	StartTime    time.Time `json:",omitempty"`
+	EndTime      time.Time `json:",omitempty"`
+	Last         int       `json:",omitempty"`
 }
 
 type RegionClientMetrics struct {


### PR DESCRIPTION
* Added new API for cloudlet resource usage metrics: `api/v1/metrics/cloudlet/usage`
* Fixed e2e-tests:
```
❯ mcctl metrics cloudletusage region=local cloudlet-org=gcp selector=flavorusage platformtype=fake
data:
- series:
  - columns:
    - time
    - cloudlet
    - cloudletorg
    - count
    - flavor
    name: cloudlet-flavor-usage
    values:
    - - "2021-02-05T14:00:09.480437Z"
      - gcp-cloud-5
      - gcp
      - 5
      - x1.small

❯ mcctl metrics cloudletusage region=local cloudlet-org=gcp selector=resourceusage platformtype=fake
data:
- series:
  - columns:
    - time
    - cloudlet
    - cloudletorg
    - diskUsed
    - externalIpsUsed
    - gpusUsed
    - ramUsed
    - vcpusUsed
    name: fake-resource-usage
    values:
    - - "2021-02-05T14:00:09.480437Z"
      - gcp-cloud-5
      - gcp
      - 200
      - 2
      - 0
      - 20480
      - 10
```
* Corresponding PR: https://github.com/mobiledgex/edge-cloud/pull/1206