### PR TITLE
EDGECLOUD-4357: Cannot run edgectl against local controller without TLS

### DIFF
--- a/operator-api-gw/tdg/tdg-qos/qosclient/qosclient.go
+++ b/operator-api-gw/tdg/tdg-qos/qosclient/qosclient.go
@@ -53,7 +53,9 @@ func GetQOSPositionFromApiGW(serverUrl string, mreq *dme.QosPositionRequest, qos
 
 	log.DebugLog(log.DebugLevelDmereq, "Connecting to QOS API GW", "serverUrl", serverUrl)
 
-	tlsConfig, err := edgetls.GetTLSClientConfig(serverUrl, nil, clientCertFile, serverCertFile, false, true, false)
+	// normal tls for outside endpoints
+	tlsMode := edgetls.Tls
+	tlsConfig, err := edgetls.GetTLSClientConfig(serverUrl, tlsMode, nil, clientCertFile, serverCertFile, true)
 	if err != nil {
 		return grpc.Errorf(codes.Unavailable, "Unable get TLS Client config: %v", err)
 	}


### PR DESCRIPTION
Corresponding EC pr: https://github.com/mobiledgex/edge-cloud/pull/1208