### PR TITLE
EDGECLOUD-4380 fix developer autocluster bug

### DIFF
--- a/e2e-tests/data/mc_admin_eventsterms_exp.yml
+++ b/e2e-tests/data/mc_admin_eventsterms_exp.yml
@@ -27,6 +27,7 @@
     - /api/v1/login
     - /ws/api/v1/auth/ctrl/RunCommand
     - /ws/api/v1/auth/ctrl/ShowLogs
+    - AutoCluster create
     - AutoProv create AppInst
     - AutoProv delete AppInst
     - Cloudlet maintenance start

--- a/e2e-tests/data/mc_admin_reservable.yml
+++ b/e2e-tests/data/mc_admin_reservable.yml
@@ -66,3 +66,5 @@ regiondata:
       nummasters: 1
       numnodes: 1
       reservable: true
+    idlereservableclusterinsts:
+      idletime: 0

--- a/e2e-tests/data/mc_showaudit_tags.yml
+++ b/e2e-tests/data/mc_showaudit_tags.yml
@@ -83,6 +83,25 @@
   org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
+  starttime: "2021-02-08T13:54:11.711235-08:00"
+  duration: 325.992ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"autoclusterAcme"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"MobiledgeX"}},"cloudlet_loc":{},"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{},"updated_at":{}}}'
+  response: |
+    {"data":{"message":"Deleted AppInst successfully"}}
+  traceid: 1bfbe8c0b9a5a4f7
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-2
+    cloudletorg: tmus
+    cluster: autoclusterAcme
+    clusterorg: MobiledgeX
+- operationname: /api/v1/auth/ctrl/DeleteAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
   starttime: "2020-11-18T14:20:29.929907+05:30"
   duration: 234.658ms
   request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{},"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{},"updated_at":{}}}'
@@ -186,25 +205,3 @@
     app: someapplication1
     apporg: AcmeAppCo
     appver: "1.0"
-- operationname: /api/v1/auth/ctrl/CreateAppInst
-  username: user2
-  org: AcmeAppCo
-  clientip: 127.0.0.1
-  status: 200
-  starttime: "2020-11-18T14:19:24.406386+05:30"
-  duration: 188.596ms
-  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{},"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{},"updated_at":{}}}'
-  response: |
-    {"data":{"message":"Creating"}}
-    {"data":{"message":"Creating App Inst"}}
-    {"data":{"message":"Ready"}}
-    {"data":{"message":"Created AppInst successfully"}}
-  traceid: 36c53e0ef6076dfc
-  tags:
-    app: someapplication1
-    apporg: AcmeAppCo
-    appver: "1.0"
-    cloudlet: tmus-cloud-2
-    cloudletorg: tmus
-    cluster: SmallCluster
-    clusterorg: AcmeAppCo

--- a/e2e-tests/data/mc_showaudit_user2oper.yml
+++ b/e2e-tests/data/mc_showaudit_user2oper.yml
@@ -47,6 +47,35 @@
   org: AcmeAppCo
   clientip: 127.0.0.1
   status: 200
+  starttime: "2021-02-08T13:41:41.202711-08:00"
+  duration: 803.881ms
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"autoclusterAcme"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"MobiledgeX"}},"cloudlet_loc":{},"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{},"updated_at":{}}}'
+  response: |
+    {"data":{"message":"Creating new auto-cluster named reservable0 to deploy AppInst"}}
+    {"data":{"message":"Defaulting IpAccess to IpAccessShared for deployment kubernetes"}}
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"First Create Task"}}
+    {"data":{"message":"Second Create Task"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created ClusterInst successfully"}}
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 6ea2b2d7aaf812ec
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-2
+    cloudletorg: tmus
+    cluster: autoclusterAcme
+    clusterorg: MobiledgeX
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
   starttime: "2020-11-18T14:14:07.357929+05:30"
   duration: 187.794ms
   request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{},"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{},"updated_at":{}}}'
@@ -130,6 +159,35 @@
     cloudletorg: tmus
     cluster: SmallCluster
     clusterorg: AcmeAppCo
+- operationname: /api/v1/auth/ctrl/CreateAppInst
+  username: user2
+  org: AcmeAppCo
+  clientip: 127.0.0.1
+  status: 200
+  starttime: "2021-02-08T13:39:14.046143-08:00"
+  duration: 1.043076s
+  request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"autoclusterAcme"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"MobiledgeX"}},"cloudlet_loc":{},"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{},"updated_at":{}}}'
+  response: |
+    {"data":{"message":"Creating new auto-cluster named reservable0 to deploy AppInst"}}
+    {"data":{"message":"Defaulting IpAccess to IpAccessShared for deployment kubernetes"}}
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"First Create Task"}}
+    {"data":{"message":"Second Create Task"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created ClusterInst successfully"}}
+    {"data":{"message":"Creating"}}
+    {"data":{"message":"Creating App Inst"}}
+    {"data":{"message":"Ready"}}
+    {"data":{"message":"Created AppInst successfully"}}
+  traceid: 26eef3d63afaf3c1
+  tags:
+    app: someapplication1
+    apporg: AcmeAppCo
+    appver: "1.0"
+    cloudlet: tmus-cloud-2
+    cloudletorg: tmus
+    cluster: autoclusterAcme
+    clusterorg: MobiledgeX
 - operationname: /api/v1/auth/ctrl/CreateAppInst
   username: user2
   org: AcmeAppCo

--- a/e2e-tests/data/mc_user2_data.yml
+++ b/e2e-tests/data/mc_user2_data.yml
@@ -136,6 +136,20 @@ regiondata:
           organization: AcmeAppCo
       flavor:
         name: x1.small
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: someapplication1
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: autoclusterAcme
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-2
+          organization: MobiledgeX
+      flavor:
+        name: x1.small
 
     autoscalepolicies:
     - key:

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -467,6 +467,44 @@ regiondata:
       runtimeinfo:
         containerids:
         - appOnClusterNode0
+    - key:
+        appkey:
+          organization: AcmeAppCo
+          name: someapplication1
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: autoclusterAcme
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-2
+          organization: MobiledgeX
+      cloudletloc:
+        latitude: 35
+        longitude: -95
+      uri: tmus-cloud-2.tmus.mobiledgex.net
+      liveness: LivenessStatic
+      mappedports:
+      - proto: LProtoTcp
+        internalport: 80
+        publicport: 10000
+        fqdnprefix: someapplication110-tcp.
+      - proto: LProtoTcp
+        internalport: 443
+        publicport: 10001
+        fqdnprefix: someapplication110-tcp.
+      - proto: LProtoUdp
+        internalport: 10002
+        publicport: 10000
+        fqdnprefix: someapplication110-udp.
+      flavor:
+        name: x1.small
+      state: Ready
+      runtimeinfo:
+        containerids:
+        - appOnClusterNode0
+      powerstate: PowerOn
+      realclustername: reservable0
 
     autoprovpolicies:
     - key:
@@ -498,6 +536,8 @@ regiondata:
         ? '{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-1"},"organization":"AcmeAppCo"}}'
         : 1
         ? '{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}}'
+        : 1
+        ? '{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"autoclusterAcme"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"MobiledgeX"}}'
         : 1
     - key:
         organization: AcmeAppCo

--- a/e2e-tests/data/mc_user2_data_stream.yml
+++ b/e2e-tests/data/mc_user2_data_stream.yml
@@ -37,6 +37,30 @@ regiondata:
       - message: Ready
       - message: Created AppInst successfully
     - key:
+        appkey:
+          organization: AcmeAppCo
+          name: someapplication1
+          version: "1.0"
+        clusterinstkey:
+          clusterkey:
+            name: autoclusterAcme
+          cloudletkey:
+            organization: tmus
+            name: tmus-cloud-2
+          organization: MobiledgeX
+      msgs:
+      - message: Creating new auto-cluster named reservable0 to deploy AppInst
+      - message: Defaulting IpAccess to IpAccessShared for deployment kubernetes
+      - message: Creating
+      - message: First Create Task
+      - message: Second Create Task
+      - message: Ready
+      - message: Created ClusterInst successfully
+      - message: Creating
+      - message: Creating App Inst
+      - message: Ready
+      - message: Created AppInst successfully
+    - key:
         clusterinstkey:
           clusterkey:
             name: SmallCluster

--- a/e2e-tests/data/mc_user2_eventsshow_exp.yml
+++ b/e2e-tests/data/mc_user2_eventsshow_exp.yml
@@ -493,37 +493,25 @@
       status: "200"
       traceid: 5642eddf217e3dc7
       username: user2
-  - name: /api/v1/auth/ctrl/CreateAppInst
+  - name: Reserve ClusterInst
     org:
     - AcmeAppCo
-    type: audit
-    timestamp: 2020-09-08T10:25:07.877523-07:00
+    type: event
+    region: local
+    timestamp: 2021-02-08T13:23:57.143302-08:00
     mtags:
       app: someapplication1
       apporg: AcmeAppCo
       appver: "1.0"
       cloudlet: tmus-cloud-2
       cloudletorg: tmus
-      cluster: SmallCluster
-      clusterorg: AcmeAppCo
-      duration: 110.076844ms
-      email: user2@email.com
-      hostname: Jon-Mex
-      lineno: orm/auditlog.go:199
-      method: POST
-      org: AcmeAppCo
-      region: local
-      remote-ip: 127.0.0.1
-      request: '{"Region":"local","AppInst":{"key":{"app_key":{"organization":"AcmeAppCo","name":"someapplication1","version":"1.0"},"cluster_inst_key":{"cluster_key":{"name":"SmallCluster"},"cloudlet_key":{"organization":"tmus","name":"tmus-cloud-2"},"organization":"AcmeAppCo"}},"cloudlet_loc":{"latitude":35,"longitude":-95},"liveness":1,"mapped_ports":null,"flavor":{"name":"x1.small"},"runtime_info":{},"created_at":{},"status":{},"resources":{"vms":null}}}'
-      response: |
-        {"data":{"message":"Creating"}}
-        {"data":{"message":"Creating App Inst"}}
-        {"data":{"message":"Ready"}}
-        {"data":{"message":"Created AppInst successfully"}}
-      spanid: 3f85f1d9a2568b93
-      status: "200"
-      traceid: 3f85f1d9a2568b93
-      username: user2
+      cluster: autoclusterAcme
+      clusterorg: MobiledgeX
+      hostname: Jon-Mex.lan
+      lineno: node/events.go:240
+      realcluster: reservable0
+      spanid: 1cb908c6838a2893
+      traceid: 128619e5f4f1976b
 - search:
     match:
       tags:

--- a/e2e-tests/data/mc_user2_eventsterms_exp.yml
+++ b/e2e-tests/data/mc_user2_eventsterms_exp.yml
@@ -13,6 +13,7 @@
     - /api/v1/auth/org/delete
     - /ws/api/v1/auth/ctrl/RunCommand
     - /ws/api/v1/auth/ctrl/ShowLogs
+    - AutoCluster create
     - AutoProv create AppInst
     - AutoProv delete AppInst
     - Free ClusterInst reservation

--- a/e2e-tests/testfiles/mc_add_delete.yml
+++ b/e2e-tests/testfiles/mc_add_delete.yml
@@ -59,11 +59,6 @@ tests:
     yaml2: '{{datadir2}}/mc_user1_data_show.yml'
     filetype: mcdata
 
-- name: admin creates reservable clusterinst on user1 cloudlet
-  actions: [mcapi-create]
-  apifile: '{{datadir2}}/mc_admin_reservable.yml'
-  curuserfile: '{{datadir2}}/mc_admin.yml'
-
 - name: user2 creates apps; verify it is there
   actions: [mcapi-create, mcapi-show]
   apifile: '{{datadir2}}/mc_user2_data.yml'
@@ -81,6 +76,11 @@ tests:
     yaml1: '{{outputdir}}/show-commands.yml'
     yaml2: '{{datadir2}}/mc_user2_data_stream.yml'
     filetype: mcstream
+
+- name: admin creates reservable clusterinst on user1 cloudlet
+  actions: [mcapi-create]
+  apifile: '{{datadir2}}/mc_admin_reservable.yml'
+  curuserfile: '{{datadir2}}/mc_admin.yml'
 
 - name: enterprise user3 creates apps; verify it is there
   actions: [mcapi-create, mcapi-show]

--- a/mc/orm/authz_cloudlet.go
+++ b/mc/orm/authz_cloudlet.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	fmt "fmt"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
 
@@ -184,11 +186,16 @@ func authzCreateAppInst(ctx context.Context, region, username string, obj *edgep
 	if !authzCloudlet.Ok(&cloudlet) {
 		return echo.ErrForbidden
 	}
-	// Enforce that target ClusterInst org is the same as AppInst org.
-	// This prevents Developers from using reservable ClusterInsts directly.
-	// Only auto-provisioning service (which goes direct to controller API)
-	// can instantiate AppInsts with mismatched orgs.
-	if !authzCloudlet.admin && obj.Key.ClusterInstKey.Organization != "" && obj.Key.ClusterInstKey.Organization != obj.Key.AppKey.Organization {
+	// Developers can't create AppInsts on other developer's ClusterInsts,
+	// except for autoclusters where ClusterInst org is MobiledgeX.
+	autocluster := false
+	if strings.HasPrefix(obj.Key.ClusterInstKey.ClusterKey.Name, cloudcommon.AutoClusterPrefix) {
+		if obj.Key.ClusterInstKey.Organization != cloudcommon.OrganizationMobiledgeX {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("Autocluster AppInst's ClusterInst organization must be %s", cloudcommon.OrganizationMobiledgeX))
+		}
+		autocluster = true
+	}
+	if !authzCloudlet.admin && !autocluster && obj.Key.ClusterInstKey.Organization != "" && obj.Key.ClusterInstKey.Organization != obj.Key.AppKey.Organization {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("AppInst organization must match ClusterInst organization"))
 	}
 	return nil


### PR DESCRIPTION
Because autoclusters are now reservable and use org MobiledgeX, the org check in authz_cloudlet.go was wrong. Fixed that, and added a developer autocluster to the infra e2e-tests to check this case.