### PR TITLE
EDGECLOUD-4374 DeleteCloudlet cleanup of reservable ClusterInsts

### DIFF
--- a/e2e-tests/data/mc_admin_reservable.yml
+++ b/e2e-tests/data/mc_admin_reservable.yml
@@ -66,5 +66,3 @@ regiondata:
       nummasters: 1
       numnodes: 1
       reservable: true
-    idlereservableclusterinsts:
-      idletime: 0


### PR DESCRIPTION
Test changes for https://github.com/mobiledgex/edge-cloud/pull/1211. Remove the delete of idle reservable auto-clusters, they should get deleted with the cloudlet, so no explicit clean up should be needed.