### PR TITLE
Fix influxdb backup

### DIFF
--- a/ansible/roles/influxdb/vars/main.yml
+++ b/ansible/roles/influxdb/vars/main.yml
@@ -4,4 +4,4 @@ influxdb_image: registry.mobiledgex.net:5000/mobiledgex/influxdb:v1.0.0
 influxdb_volume_name: influxdb-data-managed-disk
 influxdb_configmap: influxdb-conf
 tls_cert_manifest: "/tmp/influxdb-{{ deploy_environ }}-{{ region }}-cert.yaml"
-influxdb_backup_version: v1.2.2-68-g55d034b7
+influxdb_backup_version: v1.2.4-87-gd0e1d20b

--- a/docker/influxdb-backup
+++ b/docker/influxdb-backup
@@ -10,7 +10,10 @@ REGION="$2"
 
 set -e
 
-POD=$( kubectl get pods --selector=k8s-app=influxdb --output='jsonpath={.items[*].metadata.name}' )
+POD=$( kubectl get pods \
+	--selector=k8s-app=influxdb \
+	--field-selector status.phase=Running \
+	--output='jsonpath={.items[*].metadata.name}' )
 
 echo "Backing up influxdb"
 kubectl exec "$POD" -- rm -rf "$BACKUPDIR"


### PR DESCRIPTION
Backup would fail if there was more than one influxdb pod in the
cluster, which could happen if pods have been evicted and not cleaned
up.

Fixed to match the currently running influxdb pod only.