### PR TITLE
Cleanup elasticsearch events monthly indexes

### DIFF
--- a/ansible/roles/esproxy/defaults/main.yml
+++ b/ansible/roles/esproxy/defaults/main.yml
@@ -1,1 +1,1 @@
-events_elasticsearch_cleanup_age: 5
+events_elasticsearch_cleanup_age: 28

--- a/ansible/roles/esproxy/templates/index-cleanup.py.j2
+++ b/ansible/roles/esproxy/templates/index-cleanup.py.j2
@@ -26,7 +26,7 @@ r = requests.get(indexes_url, headers=headers)
 if r.status_code != requests.codes.ok:
     raise Exception(f"Failed to get index list: {r.status_code} {r.text}")
 
-limit = (datetime.today() - timedelta(days=CLEANUP_AGE)).strftime("%Y-%m-%d")
+limit = (datetime.today() - timedelta(days=CLEANUP_AGE)).strftime("%Y-%m")
 oldest_index = f"{index_pattern}-{limit}"
 logging.debug(f"Deleting indexes older than {oldest_index}: {CLEANUP_AGE} days")
 


### PR DESCRIPTION
Change in index cleanup strategy now that events use monthly indexes
instead of daily indexes.

Index age is still specified in days, and monthly indexes are
deleted only if all records in the index are older than the specified
number of days.