### PR TITLE
Edgecloud-4409 Operator can see developer metrics, cloudletpool metrics api

### DIFF
--- a/mc/mcctl/cliwrapper/metrics.go
+++ b/mc/mcctl/cliwrapper/metrics.go
@@ -30,3 +30,17 @@ func (s *Client) ShowClientMetrics(uri, token string, query *ormapi.RegionClient
 	st, err := s.runObjs(uri, token, args, query, &metrics)
 	return &metrics, st, err
 }
+
+func (s *Client) ShowCloudletPoolAppMetrics(uri, token string, query *ormapi.RegionCloudletPoolAppInstMetrics) (*ormapi.AllMetrics, int, error) {
+	args := []string{"metrics", "cloudletpoolapp"}
+	metrics := ormapi.AllMetrics{}
+	st, err := s.runObjs(uri, token, args, query, &metrics)
+	return &metrics, st, err
+}
+
+func (s *Client) ShowCloudletPoolClusterMetrics(uri, token string, query *ormapi.RegionCloudletPoolClusterInstMetrics) (*ormapi.AllMetrics, int, error) {
+	args := []string{"metrics", "cloudletpoolcluster"}
+	metrics := ormapi.AllMetrics{}
+	st, err := s.runObjs(uri, token, args, query, &metrics)
+	return &metrics, st, err
+}

--- a/mc/mcctl/ormctl/metrics.go
+++ b/mc/mcctl/ormctl/metrics.go
@@ -55,6 +55,24 @@ func GetMetricsCommand() *cobra.Command {
 		ReqData:      &ormapi.RegionClientMetrics{},
 		ReplyData:    &ormapi.AllMetrics{},
 		Run:          runRest("/auth/metrics/client"),
+	}, &cli.Command{
+		Use:          "cloudletpoolapp",
+		RequiredArgs: strings.Join(append([]string{"region"}, CloudletPoolMetricsRequiredArgs...), " "),
+		OptionalArgs: strings.Join(append([]string{"app-org"}, AppMetricOptionalArgs...), " "),
+		AliasArgs:    strings.Join(append(CloudletPoolMetricsRequiredAliasArgs, AppMetricAliasArgs...), " "),
+		Comments:     mergeMetricComments(addRegionComment(MetricCommentsCommon), CloudletPoolAppMetricComments),
+		ReqData:      &ormapi.RegionCloudletPoolAppInstMetrics{},
+		ReplyData:    &ormapi.AllMetrics{},
+		Run:          runRest("/auth/metrics/cloudletpool/app"),
+	}, &cli.Command{
+		Use:          "cloudletpoolcluster",
+		RequiredArgs: strings.Join(append([]string{"region"}, CloudletPoolMetricsRequiredArgs...), " "),
+		OptionalArgs: strings.Join(append([]string{"cluster-org"}, ClusterMetricOptionalArgs...), " "),
+		AliasArgs:    strings.Join(append(CloudletPoolMetricsRequiredAliasArgs, ClusterMetricAliasArgs...), " "),
+		Comments:     mergeMetricComments(addRegionComment(MetricCommentsCommon), CloudletPoolClusterMetricComments),
+		ReqData:      &ormapi.RegionCloudletPoolClusterInstMetrics{},
+		ReplyData:    &ormapi.AllMetrics{},
+		Run:          runRest("/auth/metrics/cloudletpool/cluster"),
 	}}
 	return cli.GenGroup("metrics", "view metrics ", cmds)
 }
@@ -189,6 +207,29 @@ var MetricCommentsCommon = map[string]string{
 	"last":         "Display the last X metrics",
 	"starttime":    "Time to start displaying stats from in RFC3339 format (ex. 2002-12-31T15:00:00Z)",
 	"endtime":      "Time up to which to display stats in RFC3339 format (ex. 2002-12-31T10:00:00-05:00)",
+}
+
+var CloudletPoolMetricsRequiredArgs = []string{
+	"pool",
+	"org",
+	"selector",
+}
+
+var CloudletPoolMetricsRequiredAliasArgs = []string{
+	"pool=cloudletpool.name",
+	"org=cloudletpool.organization",
+}
+
+var CloudletPoolAppMetricComments = map[string]string{
+	"selector": "Comma separated list of metrics to view. Available metrics: \"" + strings.Join(orm.AppSelectors, "\", \"") + "\"",
+	"pool":     "CloudletPool name",
+	"org":      "Organization or Company name of the CloudletPool",
+}
+
+var CloudletPoolClusterMetricComments = map[string]string{
+	"selector": "Comma separated list of metrics to view. Available metrics: \"" + strings.Join(orm.ClusterSelectors, "\", \"") + "\"",
+	"pool":     "CloudletPool name",
+	"org":      "Organization or Company name of the CloudletPool",
 }
 
 // merge two maps - entries in b will overwrite values in a

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -557,6 +557,30 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	//   404: notFound
 	auth.POST("/metrics/client", GetMetricsCommon)
 
+	// swagger:route POST /auth/metrics/client OperatorMetrics AppMetrics
+	// App related metrics for cloudletpools.
+	// Display app related metrics for AppInsts in a CloudletPool.
+	// Security:
+	//   Bearer:
+	// responses:
+	//   200: success
+	//   400: badRequest
+	//   403: forbidden
+	//   404: notFound
+	auth.POST("/metrics/cloudletpool/app", GetMetricsCommon)
+
+	// swagger:route POST /auth/metrics/client OperatorMetrics ClusterMetrics
+	// Cluster related metrics for cloudletpools.
+	// Display cluster related metrics for ClusterInsts in a CloudletPool.
+	// Security:
+	//   Bearer:
+	// responses:
+	//   200: success
+	//   400: badRequest
+	//   403: forbidden
+	//   404: notFound
+	auth.POST("/metrics/cloudletpool/cluster", GetMetricsCommon)
+
 	auth.POST("/events/app", GetEventsCommon)
 	auth.POST("/events/cluster", GetEventsCommon)
 	auth.POST("/events/cloudlet", GetEventsCommon)
@@ -676,6 +700,8 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	ws.GET("/metrics/cloudlet", GetMetricsCommon)
 	ws.GET("/metrics/cloudlet/usage", GetMetricsCommon)
 	ws.GET("/metrics/client", GetMetricsCommon)
+	ws.GET("/metrics/cloudletpool/app", GetMetricsCommon)
+	ws.GET("/metrics/cloudletpool/cluster", GetMetricsCommon)
 
 	if config.NotifySrvAddr != "" {
 		server.notifyServer = &notify.ServerMgr{}

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -381,6 +381,26 @@ type RegionClusterInstMetrics struct {
 	Last        int       `json:",omitempty"`
 }
 
+type RegionCloudletPoolAppInstMetrics struct {
+	Region       string
+	AppInst      edgeproto.AppInstKey
+	CloudletPool edgeproto.CloudletPoolKey
+	Selector     string
+	StartTime    time.Time `json:",omitempty"`
+	EndTime      time.Time `json:",omitempty"`
+	Last         int       `json:",omitempty"`
+}
+
+type RegionCloudletPoolClusterInstMetrics struct {
+	Region       string
+	ClusterInst  edgeproto.ClusterInstKey
+	CloudletPool edgeproto.CloudletPoolKey
+	Selector     string
+	StartTime    time.Time `json:",omitempty"`
+	EndTime      time.Time `json:",omitempty"`
+	Last         int       `json:",omitempty"`
+}
+
 type RegionCloudletMetrics struct {
 	Region       string
 	Cloudlet     edgeproto.CloudletKey

--- a/mc/ormclient/clientapi.go
+++ b/mc/ormclient/clientapi.go
@@ -45,6 +45,8 @@ type Api interface {
 	ShowClusterMetrics(uri, token string, query *ormapi.RegionClusterInstMetrics) (*ormapi.AllMetrics, int, error)
 	ShowCloudletMetrics(uri, token string, query *ormapi.RegionCloudletMetrics) (*ormapi.AllMetrics, int, error)
 	ShowClientMetrics(uri, token string, query *ormapi.RegionClientMetrics) (*ormapi.AllMetrics, int, error)
+	ShowCloudletPoolAppMetrics(uri, token string, query *ormapi.RegionCloudletPoolAppInstMetrics) (*ormapi.AllMetrics, int, error)
+	ShowCloudletPoolClusterMetrics(uri, token string, query *ormapi.RegionCloudletPoolClusterInstMetrics) (*ormapi.AllMetrics, int, error)
 
 	ShowAppEvents(uri, token string, query *ormapi.RegionAppInstEvents) (*ormapi.AllMetrics, int, error)
 	ShowClusterEvents(uri, token string, query *ormapi.RegionClusterInstEvents) (*ormapi.AllMetrics, int, error)

--- a/mc/ormclient/rest_client.go
+++ b/mc/ormclient/rest_client.go
@@ -304,6 +304,18 @@ func (s *Client) ShowClientMetrics(uri, token string, query *ormapi.RegionClient
 	return &metrics, status, err
 }
 
+func (s *Client) ShowCloudletPoolAppMetrics(uri, token string, query *ormapi.RegionCloudletPoolAppInstMetrics) (*ormapi.AllMetrics, int, error) {
+	metrics := ormapi.AllMetrics{}
+	status, err := s.PostJson(uri+"/auth/metrics/cloudletpool/app", token, query, &metrics)
+	return &metrics, status, err
+}
+
+func (s *Client) ShowCloudletPoolClusterMetrics(uri, token string, query *ormapi.RegionCloudletPoolClusterInstMetrics) (*ormapi.AllMetrics, int, error) {
+	metrics := ormapi.AllMetrics{}
+	status, err := s.PostJson(uri+"/auth/metrics/cloudletpool/cluster", token, query, &metrics)
+	return &metrics, status, err
+}
+
 func (s *Client) ShowAppEvents(uri, token string, query *ormapi.RegionAppInstEvents) (*ormapi.AllMetrics, int, error) {
 	metrics := ormapi.AllMetrics{}
 	status, err := s.PostJson(uri+"/auth/events/app", token, query, &metrics)


### PR DESCRIPTION
Added two new api endpoints, `cloudletpool/cluster` and `cloudletpool/metrics` for operators.
These apis show the same data as the original `cluster` and `metrics` apis, limited within a cloudletpool so that operators can have access to developer metrics. 