### PR TITLE
EDGECLOUD-4426:On failure to add orgvdcnet to vapp, delete network im…

### DIFF
--- a/crm-platforms/vcd/vcd-network.go
+++ b/crm-platforms/vcd/vcd-network.go
@@ -433,22 +433,13 @@ const MaxSubnetsPerSharedLB = 254
 
 func GetNextAvailConIdx(ctx context.Context, ncs *types.NetworkConnectionSection) (int, error) {
 	// return first unused conIdx for a vm
-
-	log.SpanLog(ctx, log.DebugLevelInfra, "GetNextAvailConIdx", "ncs", ncs)
-
 	conIdMap := make(map[int]*types.NetworkConnection)
 	for _, nc := range ncs.NetworkConnection {
-		// Before we add this idx as inuse, does this entry actually point at a connection?
-		if nc.Network == "" || nc.IPAddress == "" || nc.IsConnected == false {
-			log.SpanLog(ctx, log.DebugLevelInfra, "GetNextAvailConIdx skip available empty", "ConIdx", nc.NetworkConnectionIndex, "IP", nc.IPAddress, "isConnected", nc.IsConnected)
-			continue
-		}
 		conIdMap[nc.NetworkConnectionIndex] = nc
 	}
 	curIdx := 0
 	for curIdx = 0; curIdx < MaxSubnetsPerSharedLB; curIdx++ {
 		if _, found := conIdMap[curIdx]; !found {
-			log.SpanLog(ctx, log.DebugLevelInfra, "GetNextAvailConIdx returns", "conIdx", curIdx)
 			return curIdx, nil
 		}
 	}


### PR DESCRIPTION
…mediately

Once the newly create network is added to the vapp successfully, any subsequent create failures that triggers the delete on failure will find and remove the network from DeleteVapp.