### PR TITLE
Anthos prep work

### DIFF
--- a/crm-platforms/anthos/anthos-props.go
+++ b/crm-platforms/anthos/anthos-props.go
@@ -1,0 +1,43 @@
+package anthos
+
+import (
+	"context"
+
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
+)
+
+var (
+	ResourceExternalIps = "External IPs"
+)
+
+var anthosProps = map[string]*edgeproto.PropertyInfo{
+	// Property: Default-Value
+	"ANTHOS_CONTROL_VIP": {
+		Name:        "Anthos Control VIP",
+		Description: "Virtual IP of Anthos Control Plane",
+		Mandatory:   true,
+	},
+}
+
+func (a *AnthosPlatform) GetControlVip() string {
+	value, _ := a.commonPf.Properties.GetValue("ANTHOS_CONTROL_VIP")
+	return value
+}
+
+func (a *AnthosPlatform) GetCloudletProps(ctx context.Context) (*edgeproto.CloudletProps, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletProps")
+	return &edgeproto.CloudletProps{Properties: anthosProps}, nil
+}
+
+func (a *AnthosPlatform) GetCloudletResourceQuotaProps(ctx context.Context) (*edgeproto.CloudletResourceQuotaProps, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletResourceQuotaProps")
+	return &edgeproto.CloudletResourceQuotaProps{
+		Props: []edgeproto.InfraResource{
+			edgeproto.InfraResource{
+				Name:        ResourceExternalIps,
+				Description: "Limit on external IPs available",
+			},
+		},
+	}, nil
+}

--- a/crm-platforms/anthos/anthos.go
+++ b/crm-platforms/anthos/anthos.go
@@ -1,0 +1,198 @@
+package anthos
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/mobiledgex/edge-cloud-infra/infracommon"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
+	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/vault"
+	ssh "github.com/mobiledgex/golang-ssh"
+)
+
+type AnthosPlatform struct {
+	commonPf   infracommon.CommonPlatform
+	caches     *platform.Caches
+	FlavorList []*edgeproto.FlavorInfo
+}
+
+var RootLBFlavor = edgeproto.Flavor{
+	Key:   edgeproto.FlavorKey{Name: "rootlb-flavor"},
+	Vcpus: uint64(2),
+	Ram:   uint64(4096),
+	Disk:  uint64(40),
+}
+
+func (a *AnthosPlatform) Init(ctx context.Context, platformConfig *platform.PlatformConfig, caches *platform.Caches, updateCallback edgeproto.CacheUpdateCallback) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "Init")
+
+	if err := a.commonPf.InitInfraCommon(ctx, platformConfig, anthosProps); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *AnthosPlatform) GatherCloudletInfo(ctx context.Context, info *edgeproto.CloudletInfo) error {
+	return nil
+}
+
+func (a *AnthosPlatform) CreateClusterInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, updateCallback edgeproto.CacheUpdateCallback, timeout time.Duration) error {
+	return fmt.Errorf("CreateClusterInst todo")
+}
+
+func (a *AnthosPlatform) UpdateClusterInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("UpdateClusterInst todo")
+}
+
+func (a *AnthosPlatform) DeleteClusterInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("UpdateClusterInst todo")
+}
+
+func (a *AnthosPlatform) GetCloudletInfraResources(ctx context.Context) (*edgeproto.InfraResourcesSnapshot, error) {
+	var resources edgeproto.InfraResourcesSnapshot
+	return &resources, nil
+}
+
+// called by controller, make sure it doesn't make any calls to infra API
+func (a *AnthosPlatform) GetClusterAdditionalResources(ctx context.Context, cloudlet *edgeproto.Cloudlet, vmResources []edgeproto.VMResource, infraResMap map[string]edgeproto.InfraResource) map[string]edgeproto.InfraResource {
+	resInfo := make(map[string]edgeproto.InfraResource)
+	return resInfo
+}
+
+func (a *AnthosPlatform) GetClusterAdditionalResourceMetric(ctx context.Context, cloudlet *edgeproto.Cloudlet, resMetric *edgeproto.Metric, resources []edgeproto.VMResource) error {
+	externalIpsUsed := uint64(0)
+	for _, vmRes := range resources {
+		if vmRes.Type == cloudcommon.VMTypeRootLB {
+			externalIpsUsed += 1
+		}
+	}
+	resMetric.AddIntVal("externalIpsUsed", externalIpsUsed)
+	return nil
+}
+
+func (a *AnthosPlatform) GetClusterInfraResources(ctx context.Context, clusterKey *edgeproto.ClusterInstKey) (*edgeproto.InfraResources, error) {
+	var resources edgeproto.InfraResources
+	return &resources, nil
+}
+
+func (a *AnthosPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, flavor *edgeproto.Flavor, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("CreateAppInst TODO")
+}
+
+func (a *AnthosPlatform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("DeleteAppInst TODO")
+}
+
+func (a *AnthosPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("UpdateAppInst TODO")
+}
+
+func (a *AnthosPlatform) GetAppInstRuntime(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst) (*edgeproto.AppInstRuntime, error) {
+	return &edgeproto.AppInstRuntime{}, nil
+}
+
+func (a *AnthosPlatform) GetClusterPlatformClient(ctx context.Context, clusterInst *edgeproto.ClusterInst, clientType string) (ssh.Client, error) {
+	return nil, fmt.Errorf("GetClusterPlatformClient TODO")
+}
+
+func (a *AnthosPlatform) GetNodePlatformClient(ctx context.Context, node *edgeproto.CloudletMgmtNode, ops ...pc.SSHClientOp) (ssh.Client, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetNodePlatformClient", "node", node)
+
+	if node == nil || node.Name == "" {
+		return nil, fmt.Errorf("cannot GetNodePlatformClient, as node details are empty")
+	}
+	controlVip := a.GetControlVip()
+	return a.commonPf.GetSSHClientFromIPAddr(ctx, controlVip, ops...)
+}
+
+func (a *AnthosPlatform) ListCloudletMgmtNodes(ctx context.Context, clusterInsts []edgeproto.ClusterInst) ([]edgeproto.CloudletMgmtNode, error) {
+	return []edgeproto.CloudletMgmtNode{}, nil
+}
+
+func (a *AnthosPlatform) GetContainerCommand(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, req *edgeproto.ExecRequest) (string, error) {
+	return "", fmt.Errorf("GetContainerCommand TODO")
+}
+
+func (a *AnthosPlatform) GetConsoleUrl(ctx context.Context, app *edgeproto.App) (string, error) {
+	return "", fmt.Errorf("GetConsoleUrl not supported on Anthos")
+}
+
+func (a *AnthosPlatform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, flavor *edgeproto.Flavor, caches *platform.Caches, accessApi platform.AccessApi, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("CreateCloudlet TODO")
+}
+
+func (a *AnthosPlatform) UpdateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("UpdateCloudlet TODO")
+}
+
+func (a *AnthosPlatform) UpdateTrustPolicy(ctx context.Context, TrustPolicy *edgeproto.TrustPolicy) error {
+	return fmt.Errorf("UpdateTrustPolicy TODO")
+}
+
+func (a *AnthosPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, caches *platform.Caches, accessApi platform.AccessApi, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("DeleteCloudlet TODO")
+}
+
+func (a *AnthosPlatform) SaveCloudletAccessVars(ctx context.Context, cloudlet *edgeproto.Cloudlet, accessVarsIn map[string]string, pfConfig *edgeproto.PlatformConfig, vaultConfig *vault.Config, updateCallback edgeproto.CacheUpdateCallback) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "SaveCloudletAccessVars", "cloudletName", cloudlet.Key.Name)
+	return nil
+}
+
+func (a *AnthosPlatform) GetCloudletAccessVars(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, vaultConfig *vault.Config) (map[string]string, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletAccessVars", "cloudletName", cloudlet.Key.Name)
+	return map[string]string{}, nil
+}
+
+func (a *AnthosPlatform) DeleteCloudletAccessVars(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, vaultConfig *vault.Config, updateCallback edgeproto.CacheUpdateCallback) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "DeleteCloudletAccessVars", "cloudletName", cloudlet.Key.Name)
+	return nil
+}
+
+func (a *AnthosPlatform) SetPowerState(ctx context.Context, app *edgeproto.App, appInst *edgeproto.AppInst, updateCallback edgeproto.CacheUpdateCallback) error {
+	return fmt.Errorf("SetPowerState not supported on Anthos")
+}
+
+func (a *AnthosPlatform) runDebug(ctx context.Context, req *edgeproto.DebugRequest) string {
+	return "runDebug todo"
+}
+
+func (a *AnthosPlatform) SyncControllerCache(ctx context.Context, caches *platform.Caches, cloudletState dme.CloudletState) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "SyncControllerCache", "state", cloudletState)
+	return nil
+}
+
+func (a *AnthosPlatform) GetCloudletManifest(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, accessApi platform.AccessApi, flavor *edgeproto.Flavor, caches *platform.Caches) (*edgeproto.CloudletManifest, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "Get cloudlet manifest", "cloudletName", cloudlet.Key.Name)
+	return &edgeproto.CloudletManifest{Manifest: "fake manifest\n" + pfConfig.CrmAccessPrivateKey}, nil
+}
+
+func (a *AnthosPlatform) VerifyVMs(ctx context.Context, vms []edgeproto.VM) error {
+	return nil
+}
+
+func (a *AnthosPlatform) GetAccessData(ctx context.Context, cloudlet *edgeproto.Cloudlet, region string, vaultConfig *vault.Config, dataType string, arg []byte) (map[string]string, error) {
+	return nil, fmt.Errorf("GetAccessData TODO")
+}
+
+func (a *AnthosPlatform) GetRestrictedCloudletStatus(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, accessApi platform.AccessApi, updateCallback edgeproto.CacheUpdateCallback) error {
+	updateCallback(edgeproto.UpdateTask, "Setting up cloudlet")
+	return nil
+}
+
+func (a *AnthosPlatform) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
+	return nil, nil
+}
+
+func (a *AnthosPlatform) GetVersionProperties() map[string]string {
+	return map[string]string{}
+}
+
+func (a *AnthosPlatform) GetRootLBFlavor(ctx context.Context) (*edgeproto.Flavor, error) {
+	return &RootLBFlavor, nil
+}

--- a/crm-platforms/vmpool/vmpool-cmd.go
+++ b/crm-platforms/vmpool/vmpool-cmd.go
@@ -33,7 +33,7 @@ func (s *VMPoolPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.Flavor
 	if accessIP == "" {
 		return nil, fmt.Errorf("At least one VM should have access to external network")
 	}
-	accessClient, err := s.VMProperties.GetSSHClientFromIPAddr(ctx, accessIP)
+	accessClient, err := s.VMProperties.CommonPf.GetSSHClientFromIPAddr(ctx, accessIP)
 	if err != nil {
 		return nil, fmt.Errorf("can't get ssh client for %s, %v", accessIP, err)
 	}
@@ -48,7 +48,7 @@ func (s *VMPoolPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.Flavor
 	for _, vm := range s.caches.VMPool.Vms {
 		var client ssh.Client
 		if vm.NetInfo.ExternalIp != "" {
-			client, err = s.VMProperties.GetSSHClientFromIPAddr(ctx, vm.NetInfo.ExternalIp)
+			client, err = s.VMProperties.CommonPf.GetSSHClientFromIPAddr(ctx, accessIP)
 			if err != nil {
 				return nil, fmt.Errorf("failed to verify vm %s, can't get ssh client for %s, %v", vm.Name, vm.NetInfo.ExternalIp, err)
 			}

--- a/infracommon/common-platform.go
+++ b/infracommon/common-platform.go
@@ -25,6 +25,7 @@ type CommonPlatform struct {
 	ChefClient        *chef.Client
 	ChefServerPath    string
 	DeploymentTag     string
+	SshKey            CloudletSSHKey
 }
 
 // Package level test mode variable

--- a/infracommon/common-ssh.go
+++ b/infracommon/common-ssh.go
@@ -1,0 +1,140 @@
+package infracommon
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
+	"github.com/mobiledgex/edge-cloud/log"
+	ssh "github.com/mobiledgex/golang-ssh"
+	"github.com/tmc/scp"
+)
+
+var CloudletSSHKeyRefreshInterval = 24 * time.Hour
+
+func SetCloudletSignedSSHKey(ctx context.Context, accessApi platform.AccessApi, sshKey *CloudletSSHKey) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "Sign cloudlet public key from Vault")
+
+	signedKey, err := accessApi.SignSSHKey(ctx, sshKey.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	sshKey.Mux.Lock()
+	sshKey.Mux.Unlock()
+	sshKey.SignedPublicKey = signedKey
+
+	return nil
+}
+
+func TriggerRefreshCloudletSSHKeys(sshKey *CloudletSSHKey) {
+	select {
+	case sshKey.RefreshTrigger <- true:
+	default:
+	}
+}
+
+func (cp *CommonPlatform) RefreshCloudletSSHKeys(accessApi platform.AccessApi) {
+	interval := CloudletSSHKeyRefreshInterval
+	for {
+		select {
+		case <-time.After(interval):
+		case <-cp.SshKey.RefreshTrigger:
+		}
+		span := log.StartSpan(log.DebugLevelInfra, "refresh Cloudlet SSH Key")
+		ctx := log.ContextWithSpan(context.Background(), span)
+		err := SetCloudletSignedSSHKey(ctx, accessApi, &cp.SshKey)
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfra, "refresh cloudlet ssh key failure", "err", err)
+			// retry again soon
+			interval = time.Hour
+		} else {
+			interval = CloudletSSHKeyRefreshInterval
+		}
+		span.Finish()
+	}
+}
+
+func (cp *CommonPlatform) InitCloudletSSHKeys(ctx context.Context, accessApi platform.AccessApi) error {
+	// Generate Cloudlet SSH Keys
+	cloudletPubKey, cloudletPrivKey, err := ssh.GenKeyPair()
+	if err != nil {
+		return fmt.Errorf("failed to generate cloudlet SSH key pair: %v", err)
+	}
+	cp.SshKey.PublicKey = cloudletPubKey
+	cp.SshKey.PrivateKey = cloudletPrivKey
+	err = SetCloudletSignedSSHKey(ctx, accessApi, &cp.SshKey)
+	if err != nil {
+		return err
+	}
+	cp.SshKey.RefreshTrigger = make(chan bool, 1)
+	return nil
+}
+
+//GetSSHClientFromIPAddr returns ssh client handle for the given IP.
+func (cp *CommonPlatform) GetSSHClientFromIPAddr(ctx context.Context, ipaddr string, ops ...pc.SSHClientOp) (ssh.Client, error) {
+	opts := pc.SSHOptions{Timeout: DefaultConnectTimeout, User: SSHUser}
+	opts.Apply(ops)
+	var client ssh.Client
+	var err error
+
+	if cp.SshKey.PrivateKey == "" {
+		return nil, fmt.Errorf("missing cloudlet private key")
+	}
+	if cp.SshKey.PrivateKey == "" {
+		return nil, fmt.Errorf("missing cloudlet signed public Key")
+	}
+
+	cp.SshKey.Mux.Lock()
+	auth := ssh.Auth{
+		KeyPairs: []ssh.KeyPair{
+			{
+				PublicRawKey:  []byte(cp.SshKey.SignedPublicKey),
+				PrivateRawKey: []byte(cp.SshKey.PrivateKey),
+			},
+		},
+	}
+	cp.SshKey.Mux.Unlock()
+
+	if cp.SshKey.UseMEXPrivateKey {
+		auth = ssh.Auth{RawKeys: [][]byte{
+			[]byte(cp.SshKey.MEXPrivateKey),
+		}}
+	}
+	gwhost, gwport := cp.Properties.GetCloudletCRMGatewayIPAndPort()
+	if gwhost != "" {
+		// start the client to GW and add the addr as next hop
+		client, err = ssh.NewNativeClient(opts.User, ClientVersion, gwhost, gwport, &auth, opts.Timeout, nil)
+		if err != nil {
+			return nil, err
+		}
+		client, err = client.AddHop(ipaddr, 22)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		client, err = ssh.NewNativeClient(SSHUser, ClientVersion, ipaddr, 22, &auth, opts.Timeout, nil)
+		if err != nil {
+			return nil, fmt.Errorf("cannot get ssh client for addr %s, %v", ipaddr, err)
+		}
+	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "Created SSH Client", "ipaddr", ipaddr, "gwhost", gwhost, "timeout", opts.Timeout)
+	return client, nil
+}
+
+func SCPFilePath(sshClient ssh.Client, srcPath, dstPath string) error {
+	client, ok := sshClient.(*ssh.NativeClient)
+	if !ok {
+		return fmt.Errorf("unable to cast client to native client")
+	}
+	session, sessionInfo, err := client.Session(client.DefaultClientConfig.Timeout)
+	if err != nil {
+		return err
+	}
+	defer sessionInfo.CloseAll()
+	err = scp.CopyPath(srcPath, dstPath, session)
+	return err
+}

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -743,7 +743,7 @@ var CloudletComments = map[string]string{
 	"state":                               "Current state of the cloudlet, one of TrackedStateUnknown, NotPresent, CreateRequested, Creating, CreateError, Ready, UpdateRequested, Updating, UpdateError, DeleteRequested, Deleting, DeleteError, DeletePrepare, CrmInitok, CreatingDependencies, DeleteDone",
 	"crmoverride":                         "Override actions to CRM, one of NoOverride, IgnoreCrmErrors, IgnoreCrm, IgnoreTransientState, IgnoreCrmAndTransientState",
 	"deploymentlocal":                     "Deploy cloudlet services locally",
-	"platformtype":                        "Platform type, one of PlatformTypeFake, PlatformTypeDind, PlatformTypeOpenstack, PlatformTypeAzure, PlatformTypeGcp, PlatformTypeEdgebox, PlatformTypeFakeinfra, PlatformTypeVsphere, PlatformTypeAwsEks, PlatformTypeVmPool, PlatformTypeAwsEc2, PlatformTypeVcd",
+	"platformtype":                        "Platform type, one of PlatformTypeFake, PlatformTypeDind, PlatformTypeOpenstack, PlatformTypeAzure, PlatformTypeGcp, PlatformTypeEdgebox, PlatformTypeFakeinfra, PlatformTypeVsphere, PlatformTypeAwsEks, PlatformTypeVmPool, PlatformTypeAwsEc2, PlatformTypeVcd, PlatformTypeAnthos",
 	"notifysrvaddr":                       "Address for the CRM notify listener to run on",
 	"flavor.name":                         "Flavor name",
 	"physicalname":                        "Physical infrastructure cloudlet name",
@@ -878,7 +878,7 @@ var CloudletPropsAliasArgs = []string{
 	"properties:#.value.internal=cloudletprops.properties:#.value.internal",
 }
 var CloudletPropsComments = map[string]string{
-	"platformtype":                   "Platform type, one of PlatformTypeFake, PlatformTypeDind, PlatformTypeOpenstack, PlatformTypeAzure, PlatformTypeGcp, PlatformTypeEdgebox, PlatformTypeFakeinfra, PlatformTypeVsphere, PlatformTypeAwsEks, PlatformTypeVmPool, PlatformTypeAwsEc2, PlatformTypeVcd",
+	"platformtype":                   "Platform type, one of PlatformTypeFake, PlatformTypeDind, PlatformTypeOpenstack, PlatformTypeAzure, PlatformTypeGcp, PlatformTypeEdgebox, PlatformTypeFakeinfra, PlatformTypeVsphere, PlatformTypeAwsEks, PlatformTypeVmPool, PlatformTypeAwsEc2, PlatformTypeVcd, PlatformTypeAnthos",
 	"properties:#.value.name":        "Name of the property",
 	"properties:#.value.description": "Description of the property",
 	"properties:#.value.value":       "Default value of the property",
@@ -909,7 +909,7 @@ var CloudletResourceQuotaPropsAliasArgs = []string{
 	"props:#.alertthreshold=cloudletresourcequotaprops.props:#.alertthreshold",
 }
 var CloudletResourceQuotaPropsComments = map[string]string{
-	"platformtype":           "Platform type, one of PlatformTypeFake, PlatformTypeDind, PlatformTypeOpenstack, PlatformTypeAzure, PlatformTypeGcp, PlatformTypeEdgebox, PlatformTypeFakeinfra, PlatformTypeVsphere, PlatformTypeAwsEks, PlatformTypeVmPool, PlatformTypeAwsEc2, PlatformTypeVcd",
+	"platformtype":           "Platform type, one of PlatformTypeFake, PlatformTypeDind, PlatformTypeOpenstack, PlatformTypeAzure, PlatformTypeGcp, PlatformTypeEdgebox, PlatformTypeFakeinfra, PlatformTypeVsphere, PlatformTypeAwsEks, PlatformTypeVmPool, PlatformTypeAwsEc2, PlatformTypeVcd, PlatformTypeAnthos",
 	"props:#.name":           "Resource name",
 	"props:#.value":          "Resource value",
 	"props:#.inframaxvalue":  "Resource infra max value",

--- a/plugin/platform/platform-plugin.go
+++ b/plugin/platform/platform-plugin.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/mobiledgex/edge-cloud-infra/crm-platforms/anthos"
 	awsec2 "github.com/mobiledgex/edge-cloud-infra/crm-platforms/aws/aws-ec2"
 	awseks "github.com/mobiledgex/edge-cloud-infra/crm-platforms/aws/aws-eks"
 	"github.com/mobiledgex/edge-cloud-infra/crm-platforms/azure"
@@ -75,6 +76,8 @@ func GetPlatform(plat string) (platform.Platform, error) {
 		outPlatform = &edgebox.EdgeboxPlatform{}
 	case "PLATFORM_TYPE_FAKEINFRA":
 		outPlatform = &fakeinfra.Platform{}
+	case "PLATFORM_TYPE_ANTHOS":
+		outPlatform = &anthos.AnthosPlatform{}
 	default:
 		return nil, fmt.Errorf("unknown platform %s", plat)
 	}

--- a/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
+++ b/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
@@ -5,11 +5,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
-	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
-
 	"github.com/mobiledgex/edge-cloud-infra/shepherd/shepherd_common"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
@@ -34,12 +33,12 @@ func (s *ShepherdPlatform) Init(ctx context.Context, pc *platform.PlatformConfig
 	s.platformConfig = pc
 	s.appDNSRoot = pc.AppDNSRoot
 
-	err := s.VMPlatform.InitCloudletSSHKeys(ctx, pc.AccessApi)
+	err := s.VMPlatform.VMProperties.CommonPf.InitCloudletSSHKeys(ctx, pc.AccessApi)
 	if err != nil {
 		return err
 	}
 
-	go s.VMPlatform.RefreshCloudletSSHKeys(pc.AccessApi)
+	go s.VMPlatform.VMProperties.CommonPf.RefreshCloudletSSHKeys(pc.AccessApi)
 
 	if err = s.VMPlatform.InitProps(ctx, pc); err != nil {
 		return err

--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -169,7 +169,7 @@ func (v *VMPlatform) CreateCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 	log.SpanLog(ctx, log.DebugLevelInfra, "Creating cloudlet", "cloudletName", cloudlet.Key.Name)
 
 	if !pfConfig.TestMode {
-		err = v.InitCloudletSSHKeys(ctx, accessApi)
+		err = v.VMProperties.CommonPf.InitCloudletSSHKeys(ctx, accessApi)
 		if err != nil {
 			return err
 		}
@@ -361,7 +361,7 @@ func (v *VMPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 	updateCallback(edgeproto.UpdateTask, "Deleting cloudlet")
 
 	if !pfConfig.TestMode {
-		err := v.InitCloudletSSHKeys(ctx, accessApi)
+		err := v.VMProperties.CommonPf.InitCloudletSSHKeys(ctx, accessApi)
 		if err != nil {
 			return err
 		}

--- a/vmlayer/lb.go
+++ b/vmlayer/lb.go
@@ -476,7 +476,7 @@ func CopyResourceTracker(client ssh.Client) error {
 	if err != nil {
 		return err
 	}
-	err = SCPFilePath(client, path, "/tmp/resource-tracker")
+	err = infracommon.SCPFilePath(client, path, "/tmp/resource-tracker")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Initial Anthos prep work.  Anthos will be a bare metal solution that will require SSH keys etc similar to VMProviders, but it is not going to implement VMProvider.  

- define Anthos platform with just mainly stubs for now
- The vmlayer SSH code which will be reusable for Anthos s split out into common-ssh in infracommon.  The CloudletSSHKey field is moved from VMProvider to CommonPlatform.  This is most of the changes, much of it just renaming
- MEX_CRM_GATEWAY_ADDR is moved to a common property since it is used by the common-ssh code
- Unrelated: MEX_CLOUDLET_FIREWALL_WHITELIST_EGRESS is tweaked to open all TCP and UDP ports by default, this was affecting some vCD functionality