### PR TITLE
cloudlet secgrp cleanup

### DIFF
--- a/crm-platforms/aws/aws-ec2/aws-ec2-security.go
+++ b/crm-platforms/aws/aws-ec2/aws-ec2-security.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	awsgen "github.com/mobiledgex/edge-cloud-infra/crm-platforms/aws/aws-generic"
+	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
 	dme "github.com/mobiledgex/edge-cloud/d-match-engine/dme-proto"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
@@ -238,6 +239,6 @@ func (a *AwsEc2Platform) GetIamAccountForImage(ctx context.Context) (string, err
 	return a.awsGenPf.GetUserAccountIdFromArn(ctx, iamResult.User.Arn)
 }
 
-func (a *AwsEc2Platform) ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, updateCallback edgeproto.CacheUpdateCallback) error {
+func (a *AwsEc2Platform) ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, action vmlayer.ActionType, updateCallback edgeproto.CacheUpdateCallback) error {
 	return nil
 }

--- a/crm-platforms/vcd/vcd-security.go
+++ b/crm-platforms/vcd/vcd-security.go
@@ -242,7 +242,7 @@ func (v *VcdPlatform) GetClient(ctx context.Context, creds *VcdConfigParams) (cl
 }
 
 // New
-func (v *VcdPlatform) ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, updateCallback edgeproto.CacheUpdateCallback) error {
+func (v *VcdPlatform) ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, action vmlayer.ActionType, updateCallback edgeproto.CacheUpdateCallback) error {
 
 	log.SpanLog(ctx, log.DebugLevelInfra, "ConfigureCloudletSecurityRules tbi")
 	return nil

--- a/crm-platforms/vmpool/vmpool-network.go
+++ b/crm-platforms/vmpool/vmpool-network.go
@@ -20,6 +20,6 @@ func (o *VMPoolPlatform) ValidateAdditionalNetworks(ctx context.Context, additio
 	return fmt.Errorf("Additional networks not supported in VMPool cloudlets")
 }
 
-func (v *VMPoolPlatform) ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, updateCallback edgeproto.CacheUpdateCallback) error {
+func (v *VMPoolPlatform) ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, action vmlayer.ActionType, updateCallback edgeproto.CacheUpdateCallback) error {
 	return nil
 }

--- a/crm-platforms/vsphere/vsphere-network.go
+++ b/crm-platforms/vsphere/vsphere-network.go
@@ -140,6 +140,6 @@ func (v *VSpherePlatform) ValidateAdditionalNetworks(ctx context.Context, additi
 	return fmt.Errorf("Additional networks not supported in vSphere cloudlets")
 }
 
-func (v *VSpherePlatform) ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, updateCallback edgeproto.CacheUpdateCallback) error {
+func (v *VSpherePlatform) ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, action vmlayer.ActionType, updateCallback edgeproto.CacheUpdateCallback) error {
 	return nil
 }

--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -352,7 +352,7 @@ func (v *VMPlatform) UpdateCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 func (v *VMPlatform) UpdateTrustPolicy(ctx context.Context, TrustPolicy *edgeproto.TrustPolicy) error {
 	log.DebugLog(log.DebugLevelInfra, "update VMPlatform TrustPolicy", "policy", TrustPolicy)
 	egressRestricted := TrustPolicy.Key.Name != ""
-	return v.VMProvider.ConfigureCloudletSecurityRules(ctx, egressRestricted, TrustPolicy, edgeproto.DummyUpdateCallback)
+	return v.VMProvider.ConfigureCloudletSecurityRules(ctx, egressRestricted, TrustPolicy, ActionUpdate, edgeproto.DummyUpdateCallback)
 }
 
 func (v *VMPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformConfig, caches *pf.Caches, accessApi platform.AccessApi, updateCallback edgeproto.CacheUpdateCallback) error {
@@ -419,6 +419,11 @@ func (v *VMPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 		}
 		updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Deleting RootLB %s", rootLBName))
 		err = v.VMProvider.DeleteVMs(ctx, rootLBName)
+		if err != nil {
+			return fmt.Errorf("DeleteCloudlet error: %v", err)
+		}
+		updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Deleting Cloudlet Security Rules %s", rootLBName))
+		err = v.VMProvider.ConfigureCloudletSecurityRules(ctx, false, &edgeproto.TrustPolicy{}, ActionDelete, edgeproto.DummyUpdateCallback)
 		if err != nil {
 			return fmt.Errorf("DeleteCloudlet error: %v", err)
 		}

--- a/vmlayer/security.go
+++ b/vmlayer/security.go
@@ -86,7 +86,7 @@ func (v *VMPlatform) AddProxySecurityRulesAndPatchDNS(ctx context.Context, clien
 	return nil
 }
 
-func (v *VMPlatform) ConfigureCloudletSecurityRules(ctx context.Context) error {
+func (v *VMPlatform) ConfigureCloudletSecurityRules(ctx context.Context, action ActionType) error {
 	// update security groups based on a configured privacy policy or none
 	privPolName := v.VMProperties.CommonPf.PlatformConfig.TrustPolicy
 	var privPol *edgeproto.TrustPolicy
@@ -102,5 +102,5 @@ func (v *VMPlatform) ConfigureCloudletSecurityRules(ctx context.Context) error {
 		// use an empty policy
 		privPol = &edgeproto.TrustPolicy{}
 	}
-	return v.VMProvider.ConfigureCloudletSecurityRules(ctx, egressRestricted, privPol, edgeproto.DummyUpdateCallback)
+	return v.VMProvider.ConfigureCloudletSecurityRules(ctx, egressRestricted, privPol, action, edgeproto.DummyUpdateCallback)
 }

--- a/vmlayer/vmprovider.go
+++ b/vmlayer/vmprovider.go
@@ -63,7 +63,7 @@ type VMProvider interface {
 	GetServerGroupResources(ctx context.Context, name string) (*edgeproto.InfraResources, error)
 	ValidateAdditionalNetworks(ctx context.Context, additionalNets []string) error
 	GetSessionTokens(ctx context.Context, vaultConfig *vault.Config, account string) (map[string]string, error)
-	ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, updateCallback edgeproto.CacheUpdateCallback) error
+	ConfigureCloudletSecurityRules(ctx context.Context, egressRestricted bool, TrustPolicy *edgeproto.TrustPolicy, action ActionType, updateCallback edgeproto.CacheUpdateCallback) error
 	InitOperationContext(ctx context.Context, operationStage OperationInitStage) (context.Context, OperationInitResult, error)
 	GetCloudletInfraResourcesInfo(ctx context.Context) ([]edgeproto.InfraResource, error)
 	GetCloudletResourceQuotaProps(ctx context.Context) (*edgeproto.CloudletResourceQuotaProps, error)
@@ -365,7 +365,7 @@ func (v *VMPlatform) Init(ctx context.Context, platformConfig *platform.Platform
 	if result == OperationNewlyInitialized {
 		defer v.VMProvider.InitOperationContext(ctx, OperationInitComplete)
 	}
-	if err := v.ConfigureCloudletSecurityRules(ctx); err != nil {
+	if err := v.ConfigureCloudletSecurityRules(ctx, ActionCreate); err != nil {
 		return err
 	}
 	// Set debug command to start crm upgrade


### PR DESCRIPTION
EDGECLOUD-4262

A cloudlet-wide security group is created to handle Trust Policy when we create a cloudlet.   This was not being deleted on DeleteCloudlet