### PR TITLE
VCD VM App disk size fix

### DIFF
--- a/crm-platforms/vcd/vcd-cats.go
+++ b/crm-platforms/vcd/vcd-cats.go
@@ -11,7 +11,7 @@ import (
 
 // catalog releated functionality
 
-const uploadChunkSize = 12 * 1024 // MB
+const uploadChunkSize = 10 * 1024 * 1024 // 10 MB
 func (v *VcdPlatform) GetCatalog(ctx context.Context, catName string, vcdClient *govcd.VCDClient) (*govcd.Catalog, error) {
 
 	org, err := v.GetOrg(ctx, vcdClient)

--- a/crm-platforms/vcd/vcd-vm.go
+++ b/crm-platforms/vcd/vcd-vm.go
@@ -936,6 +936,7 @@ func (v *VcdPlatform) SetVMProperties(vmProperties *vmlayer.VMProperties) {
 	v.vmProperties = vmProperties
 	vmProperties.IptablesBasedFirewall = true
 	vmProperties.RunLbDhcpServerForVmApps = true
+	vmProperties.AppendFlavorToVmAppImage = true
 }
 
 // Should always be a vapp/cluster/group name

--- a/crm-platforms/vsphere/vsphere.go
+++ b/crm-platforms/vsphere/vsphere.go
@@ -27,6 +27,7 @@ func (v *VSpherePlatform) SetVMProperties(vmProperties *vmlayer.VMProperties) {
 	v.vmProperties = vmProperties
 	vmProperties.IptablesBasedFirewall = true
 	vmProperties.RunLbDhcpServerForVmApps = true
+	vmProperties.AppendFlavorToVmAppImage = true
 }
 
 func (v *VSpherePlatform) InitData(ctx context.Context, caches *platform.Caches) {

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -53,6 +53,9 @@ func (v *VMPlatform) PerformOrchestrationForVMApp(ctx context.Context, app *edge
 	var imageInfo infracommon.ImageInfo
 	sourceImageTime, md5Sum, err := infracommon.GetUrlInfo(ctx, v.VMProperties.CommonPf.PlatformConfig.AccessApi, app.ImagePath)
 	imageInfo.LocalImageName = imageName + "-" + md5Sum
+	if v.VMProperties.AppendFlavorToVmAppImage {
+		imageInfo.LocalImageName = imageInfo.LocalImageName + "-" + appInst.Flavor.Name
+	}
 	imageInfo.Md5sum = md5Sum
 	imageInfo.SourceImageTime = sourceImageTime
 	if err != nil {
@@ -538,10 +541,12 @@ func (v *VMPlatform) DeleteAppInst(ctx context.Context, clusterInst *edgeproto.C
 		}
 		_, md5Sum, err := infracommon.GetUrlInfo(ctx, v.VMProperties.CommonPf.PlatformConfig.AccessApi, app.ImagePath)
 		localImageName := imgName + "-" + md5Sum
-
+		if v.VMProperties.AppendFlavorToVmAppImage {
+			localImageName = localImageName + "-" + appInst.Flavor.Name
+		}
 		err = v.VMProvider.DeleteImage(ctx, cloudcommon.GetAppFQN(&app.Key), localImageName)
 		if err != nil {
-			log.SpanLog(ctx, log.DebugLevelInfra, "cannot delete image", "imgName", imgName)
+			log.SpanLog(ctx, log.DebugLevelInfra, "cannot delete image", "localImageName", localImageName)
 		}
 		if appInst.Uri != "" {
 			fqdn := appInst.Uri

--- a/vmlayer/dhcp.go
+++ b/vmlayer/dhcp.go
@@ -80,7 +80,7 @@ func (v *VMPlatform) StartDhcpServerForVmApp(ctx context.Context, client ssh.Cli
 	log.SpanLog(ctx, log.DebugLevelInfra, "DHCP Config params set", "dhcpConfigParams", dhcpConfigParams)
 
 	// install DHCP on the LB
-	cmd := fmt.Sprintf("sudo apt install isc-dhcp-server -y")
+	cmd := fmt.Sprintf("sudo apt-get install isc-dhcp-server -y")
 	if out, err := client.Output(cmd); err != nil {
 		return fmt.Errorf("failed to install isc-dhcp-server: %s, %v", out, err)
 	}

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -24,6 +24,7 @@ type VMProperties struct {
 	UseSecgrpForInternalSubnet bool
 	RequiresWhitelistOwnIp     bool
 	RunLbDhcpServerForVmApps   bool
+	AppendFlavorToVmAppImage   bool
 }
 
 // note that qcow2 must be understood by vsphere and vmdk must


### PR DESCRIPTION
EDGECLOUD-4449

Larger VMs were failing to boot in VCD because the import gets messed up if the size in the OVF smaller than the actual disk capacity.  

- put the VM size in the OVF manifest when uploading the image
- add optional flavor name to uploaded images, used by VCD and vSphere, because the OVFs specify different sizes
- increase chunk size for template upload to speed it up
- use apt instead of apt for DHCP server install, because apt should not be used in scripts
