### PR TITLE
EDGECLOUD-4404 - fix reserved cluster orgs in influx

### DIFF
--- a/shepherd/appinst-worker.go
+++ b/shepherd/appinst-worker.go
@@ -69,7 +69,7 @@ func (p *AppInstWorker) sendMetrics() {
 		return
 	}
 	log.SpanLog(ctx, log.DebugLevelMetrics, "metrics for app", "key", key, "metrics", stat)
-	appMetrics := MarshalAppMetrics(&key, &stat)
+	appMetrics := MarshalAppMetrics(&key, &stat, "")
 	for _, metric := range appMetrics {
 		p.send(ctx, metric)
 	}

--- a/shepherd/cluster-worker.go
+++ b/shepherd/cluster-worker.go
@@ -115,7 +115,7 @@ func (p *ClusterWorker) RunNotify() {
 			for key, stat := range appStatsMap {
 				log.SpanLog(ctx, log.DebugLevelMetrics, "App metrics",
 					"AppInst key", key, "stats", stat)
-				appMetrics := MarshalAppMetrics(&key, stat)
+				appMetrics := MarshalAppMetrics(&key, stat, p.reservedBy)
 				for _, metric := range appMetrics {
 					p.send(ctx, metric)
 				}
@@ -225,7 +225,7 @@ func (p *ClusterWorker) MarshalClusterMetrics(cm *shepherd_common.ClusterMetrics
 	return metrics
 }
 
-func MarshalAppMetrics(key *shepherd_common.MetricAppInstKey, stat *shepherd_common.AppMetrics) []*edgeproto.Metric {
+func MarshalAppMetrics(key *shepherd_common.MetricAppInstKey, stat *shepherd_common.AppMetrics, reservedBy string) []*edgeproto.Metric {
 	var metrics []*edgeproto.Metric
 	var metric *edgeproto.Metric
 
@@ -235,21 +235,21 @@ func MarshalAppMetrics(key *shepherd_common.MetricAppInstKey, stat *shepherd_com
 	}
 
 	if stat.CpuTS != nil {
-		metric = newMetric(key.ClusterInstKey, "", "appinst-cpu", key, stat.CpuTS)
+		metric = newMetric(key.ClusterInstKey, reservedBy, "appinst-cpu", key, stat.CpuTS)
 		metric.AddDoubleVal("cpu", stat.Cpu)
 		metrics = append(metrics, metric)
 		stat.CpuTS = nil
 	}
 
 	if stat.MemTS != nil {
-		metric = newMetric(key.ClusterInstKey, "", "appinst-mem", key, stat.MemTS)
+		metric = newMetric(key.ClusterInstKey, reservedBy, "appinst-mem", key, stat.MemTS)
 		metric.AddIntVal("mem", stat.Mem)
 		metrics = append(metrics, metric)
 		stat.MemTS = nil
 	}
 
 	if stat.DiskTS != nil {
-		metric = newMetric(key.ClusterInstKey, "", "appinst-disk", key, stat.DiskTS)
+		metric = newMetric(key.ClusterInstKey, reservedBy, "appinst-disk", key, stat.DiskTS)
 		metric.AddIntVal("disk", stat.Disk)
 		metrics = append(metrics, metric)
 		stat.DiskTS = nil
@@ -257,7 +257,7 @@ func MarshalAppMetrics(key *shepherd_common.MetricAppInstKey, stat *shepherd_com
 
 	if stat.NetSentTS != nil && stat.NetRecvTS != nil {
 		//for measurements with multiple values just pick one timestamp to use
-		metric = newMetric(key.ClusterInstKey, "", "appinst-network", key, stat.NetSentTS)
+		metric = newMetric(key.ClusterInstKey, reservedBy, "appinst-network", key, stat.NetSentTS)
 		metric.AddIntVal("sendBytes", stat.NetSent)
 		metric.AddIntVal("recvBytes", stat.NetRecv)
 		metrics = append(metrics, metric)

--- a/shepherd/prom-stats_test.go
+++ b/shepherd/prom-stats_test.go
@@ -378,5 +378,5 @@ func TestPromStats(t *testing.T) {
 	}
 	// Check null handling for Marshal functions
 	assert.Nil(t, testPromStats.MarshalClusterMetrics(nil), "Nil metrics should marshal into a nil")
-	assert.Nil(t, MarshalAppMetrics(&testAppKey, nil), "Nil metrics should marshal into a nil")
+	assert.Nil(t, MarshalAppMetrics(&testAppKey, nil, ""), "Nil metrics should marshal into a nil")
 }


### PR DESCRIPTION
reserved clusters will now correctly write the org to influx instead of MobiledgeX