### PR TITLE
Edgecloud-4435 remove span from send metric context

### DIFF
--- a/shepherd/appinst-worker.go
+++ b/shepherd/appinst-worker.go
@@ -71,7 +71,7 @@ func (p *AppInstWorker) sendMetrics() {
 	log.SpanLog(ctx, log.DebugLevelMetrics, "metrics for app", "key", key, "metrics", stat)
 	appMetrics := MarshalAppMetrics(&key, &stat)
 	for _, metric := range appMetrics {
-		p.send(ctx, metric)
+		p.send(context.Background(), metric)
 	}
 }
 

--- a/shepherd/cluster-worker.go
+++ b/shepherd/cluster-worker.go
@@ -117,12 +117,12 @@ func (p *ClusterWorker) RunNotify() {
 					"AppInst key", key, "stats", stat)
 				appMetrics := MarshalAppMetrics(&key, stat)
 				for _, metric := range appMetrics {
-					p.send(ctx, metric)
+					p.send(context.Background(), metric)
 				}
 			}
 			clusterMetrics := p.MarshalClusterMetrics(clusterStats)
 			for _, metric := range clusterMetrics {
-				p.send(ctx, metric)
+				p.send(context.Background(), metric)
 			}
 
 			clusterAlerts := p.clusterStat.GetAlerts(actx)
@@ -155,7 +155,11 @@ func newMetric(clusterInstKey edgeproto.ClusterInstKey, reservedBy string, name 
 		metric.AddTag("app", key.App)
 		metric.AddTag("ver", key.Version)
 		//TODO: this should be changed when we have the actual app key
-		metric.AddTag("apporg", key.ClusterInstKey.Organization)
+		if reservedBy != "" {
+			metric.AddTag("apporg", reservedBy)
+		} else {
+			metric.AddTag("apporg", clusterInstKey.Organization)
+		}
 	}
 	return &metric
 }


### PR DESCRIPTION
the notify framework currently generates a separate log for every single cluster and appinst when sending metrics every 5 seconds. I decided to create a new context without span when calling p.send() so it doesnt do that. Shepherd will still generate its own logs when sending metrics, so now we're just not flooding crm and controller with the same logs. 

Also included a quick followup to 4404, putting the reservedOrg in the apporg as well as the clusterorg