### PR TITLE
EDGECLOUD-4461: Orange VMpool cloudlet fail to add few VM's to VMpool

### DIFF
--- a/crm-platforms/vmpool/vmpool-cmd.go
+++ b/crm-platforms/vmpool/vmpool-cmd.go
@@ -48,12 +48,11 @@ func (s *VMPoolPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.Flavor
 	for _, vm := range s.caches.VMPool.Vms {
 		var client ssh.Client
 		if vm.NetInfo.ExternalIp != "" {
-			client, err = s.VMProperties.CommonPf.GetSSHClientFromIPAddr(ctx, accessIP)
+			client, err = s.VMProperties.CommonPf.GetSSHClientFromIPAddr(ctx, vm.NetInfo.ExternalIp)
 			if err != nil {
 				return nil, fmt.Errorf("failed to verify vm %s, can't get ssh client for %s, %v", vm.Name, vm.NetInfo.ExternalIp, err)
 			}
 		} else if vm.NetInfo.InternalIp != "" {
-
 			client, err = accessClient.AddHop(vm.NetInfo.InternalIp, 22)
 			if err != nil {
 				return nil, fmt.Errorf("failed to verify vm %s, can't get ssh client for %s, %v", vm.Name, vm.NetInfo.InternalIp, err)

--- a/crm-platforms/vmpool/vmpool-vmspec.go
+++ b/crm-platforms/vmpool/vmpool-vmspec.go
@@ -16,6 +16,9 @@ func getFlavorBasedVM(ctx context.Context, vmList []edgeproto.VM, vmSpec *edgepr
 	cli := edgeproto.CloudletInfo{}
 	cli.Flavors = []*edgeproto.FlavorInfo{}
 	for _, newVM := range vmList {
+		if newVM.Flavor == nil {
+			continue
+		}
 		cli.Flavors = append(cli.Flavors, newVM.Flavor)
 	}
 	vmFlavorSpec, err := vmspec.GetVMSpec(ctx, vmSpec.Flavor, cli, nil)


### PR DESCRIPTION
* Fixes an issue see on TMNL cloudlet
* Also fixes a crash when VM flavor is nil, which happens if flavor for the VM was not calculated (although we calculate it now as part of the corresponding PR)