### PR TITLE
consolidate vmdk convert

### DIFF
--- a/crm-platforms/vcd/vcd-appinst.go
+++ b/crm-platforms/vcd/vcd-appinst.go
@@ -158,7 +158,7 @@ func (v *VcdPlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo *in
 	vmdkFile := fileWithPath
 	if app.ImageType == edgeproto.ImageType_IMAGE_TYPE_QCOW {
 		updateCallback(edgeproto.UpdateTask, "Converting Image to VMDK")
-		vmdkFile, err = v.ConvertQcowToVmdk(ctx, fileWithPath, appFlavor.Disk)
+		vmdkFile, err = vmlayer.ConvertQcowToVmdk(ctx, fileWithPath, appFlavor.Disk)
 		if err != nil {
 			return err
 		}

--- a/crm-platforms/vsphere/vsphere-appinst.go
+++ b/crm-platforms/vsphere/vsphere-appinst.go
@@ -2,21 +2,13 @@ package vsphere
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"path/filepath"
-	"strings"
-	"time"
 
-	"github.com/codeskyblue/go-sh"
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
-
-var qcowConvertTimeout = 10 * time.Minute
 
 func (v *VSpherePlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo *infracommon.ImageInfo, app *edgeproto.App, flavor string, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "AddAppImageIfNotPresent", "app.ImagePath", app.ImagePath, "flavor", flavor)
@@ -35,7 +27,7 @@ func (v *VSpherePlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo
 	vmdkFile := filePath
 	if app.ImageType == edgeproto.ImageType_IMAGE_TYPE_QCOW {
 		updateCallback(edgeproto.UpdateTask, "Converting Image to VMDK")
-		vmdkFile, err = v.ConvertQcowToVmdk(ctx, filePath, f.Disk)
+		vmdkFile, err = vmlayer.ConvertQcowToVmdk(ctx, filePath, f.Disk)
 		if err != nil {
 			return err
 		}
@@ -53,42 +45,4 @@ func (v *VSpherePlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo
 		}
 	}()
 	return v.ImportImage(ctx, cloudcommon.GetAppFQN(&app.Key), vmdkFile)
-}
-
-func (v *VSpherePlatform) ConvertQcowToVmdk(ctx context.Context, sourceFile string, size uint64) (string, error) {
-	log.SpanLog(ctx, log.DebugLevelInfra, "ConvertQcowToVmdk", "sourceFile", sourceFile, "size", size)
-	destFile := strings.TrimSuffix(sourceFile, filepath.Ext(sourceFile))
-	destFile = destFile + ".vmdk"
-
-	convertChan := make(chan string, 1)
-	var convertErr string
-	go func() {
-		//resize to the correct size
-		sizeInGB := fmt.Sprintf("%dG", size)
-		log.SpanLog(ctx, log.DebugLevelInfra, "Resizing to", "size", sizeInGB)
-		out, err := sh.Command("qemu-img", "resize", sourceFile, "--shrink", sizeInGB).CombinedOutput()
-
-		if err != nil {
-			log.SpanLog(ctx, log.DebugLevelInfra, "qemu-img resize failed", "out", string(out), "err", err)
-			convertChan <- fmt.Sprintf("qemu-img resize failed: %s %v", out, err)
-		}
-		log.SpanLog(ctx, log.DebugLevelInfra, "doing qemu-img convert", "destFile", destFile)
-		out, err = sh.Command("qemu-img", "convert", "-O", "vmdk", "-o", "subformat=streamOptimized", sourceFile, destFile).CombinedOutput()
-		if err != nil {
-			log.SpanLog(ctx, log.DebugLevelInfra, "qemu-img convert failed", "out", string(out), "err", err)
-			convertChan <- fmt.Sprintf("qemu-img convert failed: %s %v", out, err)
-		} else {
-			convertChan <- ""
-
-		}
-	}()
-	select {
-	case convertErr = <-convertChan:
-	case <-time.After(qcowConvertTimeout):
-		return "", fmt.Errorf("ConvertQcowToVmdk timed out")
-	}
-	if convertErr != "" {
-		return "", errors.New(convertErr)
-	}
-	return destFile, nil
 }

--- a/crm-platforms/vsphere/vsphere-cloudlet.go
+++ b/crm-platforms/vsphere/vsphere-cloudlet.go
@@ -42,7 +42,7 @@ func (v *VSpherePlatform) CreateImageFromUrl(ctx context.Context, imageName, ima
 		}
 	}()
 
-	vmdkFile, err := v.ConvertQcowToVmdk(ctx, filePath, vmlayer.MINIMUM_DISK_SIZE)
+	vmdkFile, err := vmlayer.ConvertQcowToVmdk(ctx, filePath, vmlayer.MINIMUM_DISK_SIZE)
 	if err != nil {
 		return err
 	}

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -2,10 +2,13 @@ package vmlayer
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/codeskyblue/go-sh"
 	"github.com/mobiledgex/edge-cloud-infra/chefmgmt"
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/access"
@@ -25,6 +28,8 @@ import (
 )
 
 var MaxDockerSeedWait = 1 * time.Minute
+
+var qcowConvertTimeout = 15 * time.Minute
 
 type ProxyDnsSecOpts struct {
 	AddProxy              bool
@@ -741,4 +746,42 @@ func DownloadVMImage(ctx context.Context, accessApi platform.AccessApi, imageNam
 		}
 	}
 	return filePath, nil
+}
+
+func ConvertQcowToVmdk(ctx context.Context, sourceFile string, size uint64) (string, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "ConvertQcowToVmdk", "sourceFile", sourceFile, "size", size, "timeout", qcowConvertTimeout)
+	destFile := strings.TrimSuffix(sourceFile, filepath.Ext(sourceFile))
+	destFile = destFile + ".vmdk"
+
+	convertChan := make(chan string, 1)
+	var convertErr string
+	go func() {
+		//resize to the correct size
+		sizeInGB := fmt.Sprintf("%dG", size)
+		log.SpanLog(ctx, log.DebugLevelInfra, "Resizing to", "size", sizeInGB)
+		out, err := sh.Command("qemu-img", "resize", sourceFile, "--shrink", sizeInGB).CombinedOutput()
+
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfra, "qemu-img resize failed", "out", string(out), "err", err)
+			convertChan <- fmt.Sprintf("qemu-img resize failed: %s %v", out, err)
+		}
+		log.SpanLog(ctx, log.DebugLevelInfra, "doing qemu-img convert", "destFile", destFile)
+		out, err = sh.Command("qemu-img", "convert", "-O", "vmdk", "-o", "subformat=streamOptimized", sourceFile, destFile).CombinedOutput()
+		if err != nil {
+			log.SpanLog(ctx, log.DebugLevelInfra, "qemu-img convert failed", "out", string(out), "err", err)
+			convertChan <- fmt.Sprintf("qemu-img convert failed: %s %v", out, err)
+		} else {
+			convertChan <- ""
+
+		}
+	}()
+	select {
+	case convertErr = <-convertChan:
+	case <-time.After(qcowConvertTimeout):
+		return "", fmt.Errorf("ConvertQcowToVmdk timed out")
+	}
+	if convertErr != "" {
+		return "", errors.New(convertErr)
+	}
+	return destFile, nil
 }


### PR DESCRIPTION
When doing a VM app with an very large (6+GB) image, the conversion from qcow2 to vmdk timed out.

The current timer for VCD is 5min, the same code in vSphere is 10min.  This PR consolidates both those functions as they are identical and sets it to 15