### PR TITLE
edgecloud-4487 change tags to fields

### DIFF
--- a/shepherd/cluster-worker.go
+++ b/shepherd/cluster-worker.go
@@ -151,7 +151,7 @@ func newMetric(clusterInstKey edgeproto.ClusterInstKey, reservedBy string, name 
 		metric.AddTag("clusterorg", clusterInstKey.Organization)
 	}
 	if key != nil {
-		metric.AddTag("pod", key.Pod)
+		metric.AddStringVal("pod", key.Pod)
 		metric.AddTag("app", key.App)
 		metric.AddTag("ver", key.Version)
 		//TODO: this should be changed when we have the actual app key

--- a/shepherd/proxy-stats.go
+++ b/shepherd/proxy-stats.go
@@ -628,7 +628,7 @@ func MarshallTcpProxyMetric(scrapePoint ProxyScrapePoint, data *shepherd_common.
 		metric.AddTag("apporg", scrapePoint.Key.AppKey.Organization)
 		metric.AddTag("app", util.DNSSanitize(scrapePoint.Key.AppKey.Name))
 		metric.AddTag("ver", util.DNSSanitize(scrapePoint.Key.AppKey.Version))
-		metric.AddTag("port", strconv.Itoa(int(port)))
+		metric.AddIntVal("port", uint64(port))
 
 		metric.AddIntVal("active", data.EnvoyTcpStats[port].ActiveConn)
 		metric.AddIntVal("accepts", data.EnvoyTcpStats[port].Accepts)
@@ -658,7 +658,7 @@ func MarshallUdpProxyMetric(scrapePoint ProxyScrapePoint, data *shepherd_common.
 		metric.AddTag("apporg", scrapePoint.Key.AppKey.Organization)
 		metric.AddTag("app", util.DNSSanitize(scrapePoint.Key.AppKey.Name))
 		metric.AddTag("ver", util.DNSSanitize(scrapePoint.Key.AppKey.Version))
-		metric.AddTag("port", strconv.Itoa(int(port)))
+		metric.AddIntVal("port", uint64(port))
 
 		metric.AddIntVal("bytesSent", data.EnvoyUdpStats[port].SentBytes)
 		metric.AddIntVal("bytesRecvd", data.EnvoyUdpStats[port].RecvBytes)
@@ -686,7 +686,6 @@ func MarshallNginxMetric(scrapePoint ProxyScrapePoint, data *shepherd_common.Pro
 	metric.AddTag("apporg", scrapePoint.Key.AppKey.Organization)
 	metric.AddTag("app", util.DNSSanitize(scrapePoint.Key.AppKey.Name))
 	metric.AddTag("ver", util.DNSSanitize(scrapePoint.Key.AppKey.Version))
-	metric.AddTag("port", "") //nginx doesnt support stats per port
 
 	metric.AddIntVal("active", data.ActiveConn)
 	metric.AddIntVal("accepts", data.Accepts)


### PR DESCRIPTION
change non app/cluster/cloudlet key information in influx from fields to tags in order to reduce influx memory load