### PR TITLE
EDGECLOUD-4526: CreateCloudlet fails on VMPool with error " Unable to find MEX_EXTERNAL_NETWORK_GATEWAY"

### DIFF
--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -163,7 +163,7 @@ func (v *VMPlatform) GetChefPlatformApiAccess(ctx context.Context, cloudlet *edg
 		return nil, err
 	}
 	chefApi.ApiEndpoint = apiAddr
-	if cloudlet.InfraApiAccess == edgeproto.InfraApiAccess_DIRECT_ACCESS {
+	if cloudlet.InfraApiAccess == edgeproto.InfraApiAccess_DIRECT_ACCESS && apiAddr != "" {
 		gatewayAddr, err := v.VMProvider.GetExternalGateway(ctx, v.VMProperties.GetCloudletExternalNetwork())
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch gateway IP for external network: %s, %v",


### PR DESCRIPTION
* API Addr is empty for VMPool, we shouldn't look for a gateway address.