### PR TITLE
EDGECLOUD-4529 autoprov service deadlock

### DIFF
--- a/autoprov/autoprov_aggr.go
+++ b/autoprov/autoprov_aggr.go
@@ -82,10 +82,12 @@ func (s *AutoProvAggr) Start() {
 
 func (s *AutoProvAggr) Stop() {
 	s.mux.Lock()
-	defer s.mux.Unlock()
 	close(s.stop)
+	s.mux.Unlock()
 	s.waitGroup.Wait()
+	s.mux.Lock()
 	s.stop = nil
+	s.mux.Unlock()
 }
 
 func (s *AutoProvAggr) UpdateSettings(ctx context.Context, intervalSec, offsetSec float64) {


### PR DESCRIPTION
Fixed deadlock caused by waitGroup.Wait() being called while under lock (it doesn't release the lock like a C pthread_cond_wait).