### PR TITLE
vmapp tls fix

### DIFF
--- a/crm-platforms/k8s-baremetal/k8sbm-appinst.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-appinst.go
@@ -17,6 +17,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+var DockerUser = "1000"
+
 func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, appFlavor *edgeproto.Flavor, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "CreateAppInst", "appInst", appInst)
 
@@ -100,7 +102,7 @@ func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *e
 			} else {
 				updateCallback(edgeproto.UpdateTask, "Configuring Service: LB, Firewall Rules add DNS")
 				ops := infracommon.ProxyDnsSecOpts{AddProxy: true, AddDnsAndPatchKubeSvc: true, AddSecurityRules: true, ProxyNamePrefix: k8smgmt.GetKconfName(clusterInst) + "-"}
-				err = k.commonPf.AddProxySecurityRulesAndPatchDNS(ctx, client, names, app, appInst, getDnsAction, k.WhitelistSecurityRules, rootLBName, lbinfo.ExternalIpAddr, lbinfo.InternalIpAddr, ops, proxy.WithDockerPublishPorts(), proxy.WithDockerNetwork(""))
+				err = k.commonPf.AddProxySecurityRulesAndPatchDNS(ctx, client, names, app, appInst, getDnsAction, k.WhitelistSecurityRules, rootLBName, lbinfo.ExternalIpAddr, lbinfo.InternalIpAddr, ops, proxy.WithDockerPublishPorts(), proxy.WithDockerNetwork(""), proxy.WithDockerUser(DockerUser))
 			}
 		}
 

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -280,6 +280,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 			if err != nil {
 				return err
 			}
+			proxycerts.NewDedicatedLB(ctx, &appInst.Key.ClusterInstKey.CloudletKey, orchVals.lbName, client, v.VMProperties.CommonPf.PlatformConfig.NodeMgr)
 			// clusterInst is empty but that is ok here
 			names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
 			if err != nil {
@@ -329,8 +330,6 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 			} else {
 				log.SpanLog(ctx, log.DebugLevelInfra, "External router in use, no internal interface for rootlb")
 			}
-			proxycerts.NewDedicatedLB(ctx, &appInst.Key.ClusterInstKey.CloudletKey, orchVals.lbName, client, v.VMProperties.CommonPf.PlatformConfig.NodeMgr)
-			// DNS entry is already added while setting up RootLB
 			return nil
 		}
 		updateCallback(edgeproto.UpdateTask, "Adding DNS Entry")


### PR DESCRIPTION
See edge-cloud fix for more details, but this adds
- Add optional docker user for k8s bare metal
- Move NewDedicatedLB call to be before the proxy create in the VM App case