### PR TITLE
EDGDCLOUD-4468: Fix metrics error cloudletusage

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -709,7 +709,10 @@ func GetMetricsCommon(c echo.Context) error {
 				platformTypes[pfType] = struct{}{}
 			})
 			if err != nil {
-				return err
+				return setReply(c, err, nil)
+			}
+			if len(platformTypes) == 0 {
+				return setReply(c, nil, nil)
 			}
 		}
 		rc.region = in.Region


### PR DESCRIPTION
* Return empty data if cloudlet/cloudlet-org is invalid. This makes it consistent with other metrics APIs.