### PR TITLE
Edgecloud-4574 operator viewing non-cloudletpool app/cluster metrics

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -824,5 +824,8 @@ func checkPermissionsAndGetCloudletList(ctx context.Context, claims *UserClaims,
 			}
 		}
 	}
+	if operOrgPermOk && !devOrgPermOk && len(cloudletList) == 0 {
+		return []string{}, fmt.Errorf("No non-empty CloudletPools to show")
+	}
 	return cloudletList, nil
 }


### PR DESCRIPTION
Root cause was if the operator had only empty cloudletpools, then the resulting influx query would not filter based on any cloudlets and just return everything based on the other specified filters, which would not restrict the search to just cloudletpools