### PR TITLE
avoid calling DisableLease if override is on

### DIFF
--- a/crm-platforms/vcd/vcd.go
+++ b/crm-platforms/vcd/vcd.go
@@ -78,10 +78,12 @@ func (v *VcdPlatform) InitProvider(ctx context.Context, caches *platform.Caches,
 	if stage == vmlayer.ProviderInitPlatformStart {
 		log.SpanLog(ctx, log.DebugLevelInfra, "InitProvider DisableRuntimeLeases", "stage", stage)
 		overrideLeaseDisable := v.GetLeaseOverride()
-		err := v.DisableOrgRuntimeLease(ctx, overrideLeaseDisable)
-		if err != nil {
-			log.SpanLog(ctx, log.DebugLevelInfra, "InitProvider DisableOrgRuntimeLease failed", "stage", stage, "override", overrideLeaseDisable, "error", err)
-			return err
+		if !overrideLeaseDisable {
+			err := v.DisableOrgRuntimeLease(ctx, overrideLeaseDisable)
+			if err != nil {
+				log.SpanLog(ctx, log.DebugLevelInfra, "InitProvider DisableOrgRuntimeLease failed", "stage", stage, "override", overrideLeaseDisable, "error", err)
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
wwt sees org.Update() fail after setting runtime lease to zero. This change avoids calling DisableLease primitive altogether if lease disable override flag is on.