### PR TITLE
EDGECLOUD-4578 Need docker restart of alertmanager during deployment

### DIFF
--- a/ansible/roles/alertmanager/handlers/main.yml
+++ b/ansible/roles/alertmanager/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: Restart alertmanager
+  docker_compose:
+    project_name: alertmanager
+    project_src: "{{ alertmanager_config_path }}"
+    restarted: yes

--- a/ansible/roles/alertmanager/tasks/main.yml
+++ b/ansible/roles/alertmanager/tasks/main.yml
@@ -49,6 +49,7 @@
   vars:
     begin_def: !unsafe '{{ define "console.link" }}'
     end_def: !unsafe '{{ end }}'
+  notify: Restart alertmanager
 
 - name: Run receiver name upgrade
   script: "files/name_delim_upgrade.sh"


### PR DESCRIPTION
Restart the alertmanager service if the alertmanager.tmpl file is
modified.