### PR TITLE
EDGECLOUD-4604 Address docker rate limiting

### DIFF
--- a/openstack-tenant/packages/build.sh
+++ b/openstack-tenant/packages/build.sh
@@ -29,7 +29,8 @@ CTRLFILE="${DEBDIR}/control"
 DEBFILE="${PKGDIR}.deb"
 
 if [[ -f "$DEPS_FILE" ]]; then
-	DEPS=$( awk '{ printf("%s (%s), \n", $1, $2) }' "$DEPS_FILE" \
+	DEPS=$( grep -v '^#' "$DEPS_FILE" \
+		| awk '{ printf("%s (%s), \n", $1, $2) }' \
 		| tr -d "\n" \
 		| sed 's/, $//' )
 fi

--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.3.1
+VERSION = 4.3.2
 DISTRIBUTION = cirrus
 COMPONENT = main
 

--- a/openstack-tenant/packages/mobiledgex/dependencies.common
+++ b/openstack-tenant/packages/mobiledgex/dependencies.common
@@ -8,6 +8,9 @@ helm                            =2.17.0
 iptables-persistent             >=1.0.4+nmu2ubuntu1
 ipvsadm                         >=1:1.28-3ubuntu0.18.04.1
 jq                              >=1.5+dfsg-2
+# NOTE: If changing kubernetes package versions, also fix
+#       the list of docker images to be cached in
+#       ../packer/docker-image-cache.txt
 kubeadm                         =1.16.3-00
 kubectl                         =1.16.3-00
 kubelet                         =1.16.3-00

--- a/openstack-tenant/packer/docker-image-cache.txt
+++ b/openstack-tenant/packer/docker-image-cache.txt
@@ -1,0 +1,11 @@
+ghcr.io/helm/tiller:v2.17.0
+jettech/kube-webhook-certgen:v1.0.0
+quay.io/coreos/configmap-reload:v0.0.1
+quay.io/coreos/kube-state-metrics:v1.8.0
+quay.io/coreos/prometheus-config-reloader:v0.32.0
+quay.io/coreos/prometheus-operator:v0.32.0
+quay.io/prometheus/node-exporter:v0.18.0
+quay.io/prometheus/prometheus:v2.12.0
+squareup/ghostunnel:v1.4.1
+weaveworks/weave-kube:2.8.1
+weaveworks/weave-npc:2.8.1

--- a/openstack-tenant/packer/packer_template.mobiledgex.json
+++ b/openstack-tenant/packer/packer_template.mobiledgex.json
@@ -30,6 +30,11 @@
 	    "destination": "/tmp/pkg-cleanup.txt"
 	},
 	{
+	    "type": "file",
+	    "source": "docker-image-cache.txt",
+	    "destination": "/tmp/docker-image-cache.txt"
+	},
+	{
 	    "type": "shell",
 	    "script": "setup.sh",
 	    "environment_vars": [

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -32,7 +32,7 @@ type VMProperties struct {
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.3.1"
+var MEXInfraVersion = "4.3.2"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
"kubeadm config images pull" will pull in the core kubernetes images for
a specific kubernetes version, but other images like weave and the
prometheus images are pulled independently. Listing those in a file
which will need to be updated if the versions change.