### PR TITLE
Edgecloud-4405

### DIFF
--- a/shepherd/shepherd-docker.go
+++ b/shepherd/shepherd-docker.go
@@ -39,6 +39,7 @@ type ContainerStats struct {
 	Memory    ContainerMem
 	Cpu       string
 	IO        ContainerIO
+	coreCount uint64
 }
 
 type DockerStats struct {
@@ -121,14 +122,18 @@ func (c *DockerClusterStats) GetContainerStats(ctx context.Context) (*DockerStat
 			cData, found = containers[cID]
 
 			if found {
+				flavor := edgeproto.Flavor{}
+				if FlavorCache.Get(&obj.Flavor, &flavor) {
+					cData.coreCount = flavor.Vcpus
+				}
 				cData.App = util.DNSSanitize(obj.Key.AppKey.Name)
 				cData.Version = util.DNSSanitize(obj.Key.AppKey.Version)
 				dockerResp.Containers = append(dockerResp.Containers, *cData)
-
 			}
 		}
 	})
 	// Keep track of those containers not associated with any App, just in case
+	// Also avg out the cpu based on how many cores, since docker stats just returns a sum %
 	for _, container := range containers {
 		if container.App == "" {
 			// container and app are the same here
@@ -322,7 +327,6 @@ func (c *DockerClusterStats) collectDockerAppMetrics(ctx context.Context, p *Doc
 		appKey.App = containerStats.App
 		appKey.Version = containerStats.Version
 		stat, found := appStatsMap[appKey]
-		stat.Containers += 1
 		if !found {
 			stat = &shepherd_common.AppMetrics{}
 			appStatsMap[appKey] = stat
@@ -332,12 +336,15 @@ func (c *DockerClusterStats) collectDockerAppMetrics(ctx context.Context, p *Doc
 		stat.CpuTS, stat.MemTS, stat.DiskTS, stat.NetSentTS, stat.NetRecvTS = ts, ts, ts, ts, ts
 		// cpu is in the form "0.00%" - remove the % at the end and cast to float
 		cpu, err := parsePercentStr(containerStats.Cpu)
+		if containerStats.coreCount > 0 {
+			cpu = cpu / float64(containerStats.coreCount)
+		}
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelMetrics, "Failed to parse CPU usage", "App", appKey, "stats", containerStats, "err", err)
 		}
 		// TODO EDGECLOUD-1316 - add stats for all containers together
 		// since cpu is a percentage it needs to be averaged
-		stat.Cpu = ((stat.Cpu * (stat.Containers - 1)) + cpu) / stat.Containers
+		stat.Cpu += cpu
 
 		memData, err := parseComputeUnitsDelim(ctx, containerStats.Memory.Raw)
 		if err != nil {

--- a/shepherd/shepherd.go
+++ b/shepherd/shepherd.go
@@ -56,6 +56,7 @@ var workerMap map[string]*ClusterWorker
 var workerMapMutex *sync.Mutex
 var vmAppWorkerMap map[string]*AppInstWorker
 var MEXPrometheusAppName = cloudcommon.MEXPrometheusAppName
+var FlavorCache edgeproto.FlavorCache
 var AppInstCache edgeproto.AppInstCache
 var ClusterInstCache edgeproto.ClusterInstCache
 var AppCache edgeproto.AppCache
@@ -396,6 +397,7 @@ func start() {
 	}
 
 	// register shepherd to receive appinst and clusterinst notifications from crm
+	edgeproto.InitFlavorCache(&FlavorCache)
 	edgeproto.InitAppInstCache(&AppInstCache)
 	AppInstCache.SetUpdatedCb(appInstCb)
 	AppInstCache.SetDeletedCb(appInstDeletedCb)
@@ -421,6 +423,7 @@ func start() {
 	notifyClient.RegisterRecvSettingsCache(&SettingsCache)
 	notifyClient.RegisterRecvVMPoolCache(&VMPoolCache)
 	notifyClient.RegisterRecvVMPoolInfoCache(&VMPoolInfoCache)
+	notifyClient.RegisterRecvFlavorCache(&FlavorCache)
 	notifyClient.RegisterRecvAppInstCache(&AppInstCache)
 	notifyClient.RegisterRecvClusterInstCache(&ClusterInstCache)
 	notifyClient.RegisterRecvAppCache(&AppCache)

--- a/shepherd/shepherd_common/shepherd-types.go
+++ b/shepherd/shepherd_common/shepherd-types.go
@@ -42,9 +42,8 @@ type AppMetrics struct {
 	NetSent   uint64
 	NetSentTS *types.Timestamp
 	// NetRecv is bytes/second average
-	NetRecv    uint64
-	NetRecvTS  *types.Timestamp
-	Containers float64
+	NetRecv   uint64
+	NetRecvTS *types.Timestamp
 }
 
 type ClusterMetrics struct {


### PR DESCRIPTION
in the cpu % returned by the `docker stats` command it was possible for it to be over 100%, if there were multiple cores it just adds up the % utilization for all of them. Added a flavor cache to shepherd to be able to track how many cpus a docker container would have allocated to it. 

However this does not fix this issue for the containers that aren't associated with any app that we still track (for example sshing onto the cluster and starting a random docker container). This is because if the container isn't associated with an app, there is no flavor I can pull to see how many cpus are allocated to that container. I considered using `nproc` or `cat /sys/fs/cgroup/cpuset/cpuset.cpus` but this would increase the amount of ssh commands run by shepherd by a lot, basically one per appinst every `collectInterval` (5s), as currently we just run one docker stats command per cluster