### PR TITLE
EDGECLOUD-4613: Show non vm apps in cloudletpool usage

### DIFF
--- a/mc/orm/cloudletpool_usage.go
+++ b/mc/orm/cloudletpool_usage.go
@@ -33,7 +33,9 @@ func cloudletPoolEventsQuery(obj *ormapi.RegionCloudletPoolUsage, cloudletList [
 	} else if queryType == APPINST {
 		arg.Measurement = EVENT_APPINST
 		arg.Selector = strings.Join(append(AppFields, appUsageEventFields...), ",")
-		arg.DeploymentType = cloudcommon.DeploymentTypeVM
+		if !obj.ShowNonVmApps {
+			arg.DeploymentType = cloudcommon.DeploymentTypeVM
+		}
 	} else {
 		return ""
 	}
@@ -53,7 +55,9 @@ func cloudletPoolCheckpointsQuery(obj *ormapi.RegionCloudletPoolUsage, cloudletL
 	} else if queryType == APPINST {
 		arg.Measurement = cloudcommon.AppInstCheckpoints
 		arg.Selector = strings.Join(AppCheckpointFields, ",")
-		arg.DeploymentType = cloudcommon.DeploymentTypeVM
+		if !obj.ShowNonVmApps {
+			arg.DeploymentType = cloudcommon.DeploymentTypeVM
+		}
 	} else {
 		return ""
 	}
@@ -117,7 +121,7 @@ func GetCloudletPoolUsageCommon(c echo.Context) error {
 			return setReply(c, fmt.Errorf("Error calculating usage records: %v", err), nil)
 		}
 
-		// check VM appinsts
+		// check appinsts
 		eventCmd = cloudletPoolEventsQuery(&in, cloudletList, APPINST)
 		checkpointCmd = cloudletPoolCheckpointsQuery(&in, cloudletList, APPINST)
 		eventResp, checkResp, err = GetEventAndCheckpoint(ctx, rc, eventCmd, checkpointCmd)

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -502,10 +502,11 @@ type RegionClusterInstUsage struct {
 }
 
 type RegionCloudletPoolUsage struct {
-	Region       string
-	CloudletPool edgeproto.CloudletPoolKey
-	StartTime    time.Time `json:",omitempty"`
-	EndTime      time.Time `json:",omitempty"`
+	Region        string
+	CloudletPool  edgeproto.CloudletPoolKey
+	StartTime     time.Time `json:",omitempty"`
+	EndTime       time.Time `json:",omitempty"`
+	ShowNonVmApps bool      `json:",omitempty"`
 }
 
 type RegionCloudletPoolUsageRegister struct {


### PR DESCRIPTION
Originally I did not show non vm apps in this because the cloudletpool api was originally intended for only showing billable usages. Since resources are allocated at the clusterinst level, with the exception of vm apps, cloudletpool usage did not show app usage within the cloudletpool to avoid double charging on usage. 

Added an option for operators to see non-vm apps if they want with a new field in the cloudletpoolusage api, `showNonVmApps`. By default the api will continue with its original behavior and not show non-vm apps. That flag must be set to true to see regular appinsts