### PR TITLE
EDGECLOUD-4622 mcctl reorg fix command conflicts

### DIFF
--- a/mc/mcctl/cliwrapper/app.mc2.go
+++ b/mc/mcctl/cliwrapper/app.mc2.go
@@ -68,7 +68,7 @@ func (s *Client) ShowApp(uri, token string, in *ormapi.RegionApp) ([]edgeproto.A
 }
 
 func (s *Client) AddAppAutoProvPolicy(uri, token string, in *ormapi.RegionAppAutoProvPolicy) (*edgeproto.Result, int, error) {
-	args := []string{"app", "add"}
+	args := []string{"app", "addautoprovpolicy"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -79,7 +79,7 @@ func (s *Client) AddAppAutoProvPolicy(uri, token string, in *ormapi.RegionAppAut
 }
 
 func (s *Client) RemoveAppAutoProvPolicy(uri, token string, in *ormapi.RegionAppAutoProvPolicy) (*edgeproto.Result, int, error) {
-	args := []string{"app", "remove"}
+	args := []string{"app", "removeautoprovpolicy"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))

--- a/mc/mcctl/cliwrapper/autoprovpolicy.mc2.go
+++ b/mc/mcctl/cliwrapper/autoprovpolicy.mc2.go
@@ -69,7 +69,7 @@ func (s *Client) ShowAutoProvPolicy(uri, token string, in *ormapi.RegionAutoProv
 }
 
 func (s *Client) AddAutoProvPolicyCloudlet(uri, token string, in *ormapi.RegionAutoProvPolicyCloudlet) (*edgeproto.Result, int, error) {
-	args := []string{"autoprovpolicy", "add"}
+	args := []string{"autoprovpolicy", "addcloudlet"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -80,7 +80,7 @@ func (s *Client) AddAutoProvPolicyCloudlet(uri, token string, in *ormapi.RegionA
 }
 
 func (s *Client) RemoveAutoProvPolicyCloudlet(uri, token string, in *ormapi.RegionAutoProvPolicyCloudlet) (*edgeproto.Result, int, error) {
-	args := []string{"autoprovpolicy", "remove"}
+	args := []string{"autoprovpolicy", "removecloudlet"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))

--- a/mc/mcctl/cliwrapper/cloudlet.mc2.go
+++ b/mc/mcctl/cliwrapper/cloudlet.mc2.go
@@ -71,7 +71,7 @@ func (s *Client) ShowCloudlet(uri, token string, in *ormapi.RegionCloudlet) ([]e
 }
 
 func (s *Client) GetCloudletManifest(uri, token string, in *ormapi.RegionCloudletKey) (*edgeproto.CloudletManifest, int, error) {
-	args := []string{"cloudlet", "getcloudletmanifest"}
+	args := []string{"cloudlet", "getmanifest"}
 	out := edgeproto.CloudletManifest{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -82,7 +82,7 @@ func (s *Client) GetCloudletManifest(uri, token string, in *ormapi.RegionCloudle
 }
 
 func (s *Client) GetCloudletProps(uri, token string, in *ormapi.RegionCloudletProps) (*edgeproto.CloudletProps, int, error) {
-	args := []string{"cloudlet", "get"}
+	args := []string{"cloudlet", "getprops"}
 	out := edgeproto.CloudletProps{}
 	noconfig := strings.Split("Properties", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -93,7 +93,7 @@ func (s *Client) GetCloudletProps(uri, token string, in *ormapi.RegionCloudletPr
 }
 
 func (s *Client) GetCloudletResourceQuotaProps(uri, token string, in *ormapi.RegionCloudletResourceQuotaProps) (*edgeproto.CloudletResourceQuotaProps, int, error) {
-	args := []string{"cloudlet", "get"}
+	args := []string{"cloudlet", "getresourcequotaprops"}
 	out := edgeproto.CloudletResourceQuotaProps{}
 	noconfig := strings.Split("Properties", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -104,7 +104,7 @@ func (s *Client) GetCloudletResourceQuotaProps(uri, token string, in *ormapi.Reg
 }
 
 func (s *Client) GetCloudletResourceUsage(uri, token string, in *ormapi.RegionCloudletResourceUsage) (*edgeproto.CloudletResourceUsage, int, error) {
-	args := []string{"cloudlet", "get"}
+	args := []string{"cloudlet", "getresourceusage"}
 	out := edgeproto.CloudletResourceUsage{}
 	noconfig := strings.Split("Info", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -115,7 +115,7 @@ func (s *Client) GetCloudletResourceUsage(uri, token string, in *ormapi.RegionCl
 }
 
 func (s *Client) AddCloudletResMapping(uri, token string, in *ormapi.RegionCloudletResMap) (*edgeproto.Result, int, error) {
-	args := []string{"cloudlet", "addcloudletresmapping"}
+	args := []string{"cloudlet", "addresmapping"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -126,7 +126,7 @@ func (s *Client) AddCloudletResMapping(uri, token string, in *ormapi.RegionCloud
 }
 
 func (s *Client) RemoveCloudletResMapping(uri, token string, in *ormapi.RegionCloudletResMap) (*edgeproto.Result, int, error) {
-	args := []string{"cloudlet", "removecloudletresmapping"}
+	args := []string{"cloudlet", "removeresmapping"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -137,7 +137,7 @@ func (s *Client) RemoveCloudletResMapping(uri, token string, in *ormapi.RegionCl
 }
 
 func (s *Client) FindFlavorMatch(uri, token string, in *ormapi.RegionFlavorMatch) (*edgeproto.FlavorMatch, int, error) {
-	args := []string{"cloudlet", "find"}
+	args := []string{"cloudlet", "findflavormatch"}
 	out := edgeproto.FlavorMatch{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))

--- a/mc/mcctl/cliwrapper/cloudletpool.mc2.go
+++ b/mc/mcctl/cliwrapper/cloudletpool.mc2.go
@@ -68,7 +68,7 @@ func (s *Client) ShowCloudletPool(uri, token string, in *ormapi.RegionCloudletPo
 }
 
 func (s *Client) AddCloudletPoolMember(uri, token string, in *ormapi.RegionCloudletPoolMember) (*edgeproto.Result, int, error) {
-	args := []string{"cloudletpool", "add"}
+	args := []string{"cloudletpool", "addmember"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -79,7 +79,7 @@ func (s *Client) AddCloudletPoolMember(uri, token string, in *ormapi.RegionCloud
 }
 
 func (s *Client) RemoveCloudletPoolMember(uri, token string, in *ormapi.RegionCloudletPoolMember) (*edgeproto.Result, int, error) {
-	args := []string{"cloudletpool", "remove"}
+	args := []string{"cloudletpool", "removemember"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))

--- a/mc/mcctl/cliwrapper/clusterinst.mc2.go
+++ b/mc/mcctl/cliwrapper/clusterinst.mc2.go
@@ -71,7 +71,7 @@ func (s *Client) ShowClusterInst(uri, token string, in *ormapi.RegionClusterInst
 }
 
 func (s *Client) DeleteIdleReservableClusterInsts(uri, token string, in *ormapi.RegionIdleReservableClusterInsts) (*edgeproto.Result, int, error) {
-	args := []string{"clusterinst", "delete"}
+	args := []string{"clusterinst", "deleteidlereservables"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))

--- a/mc/mcctl/cliwrapper/device.mc2.go
+++ b/mc/mcctl/cliwrapper/device.mc2.go
@@ -57,7 +57,7 @@ func (s *Client) EvictDevice(uri, token string, in *ormapi.RegionDevice) (*edgep
 }
 
 func (s *Client) ShowDeviceReport(uri, token string, in *ormapi.RegionDeviceReport) ([]edgeproto.Device, int, error) {
-	args := []string{"device", "show"}
+	args := []string{"device", "showreport"}
 	outlist := []edgeproto.Device{}
 	noconfig := strings.Split("", ",")
 	ops := []runOp{

--- a/mc/mcctl/cliwrapper/flavor.mc2.go
+++ b/mc/mcctl/cliwrapper/flavor.mc2.go
@@ -67,7 +67,7 @@ func (s *Client) ShowFlavor(uri, token string, in *ormapi.RegionFlavor) ([]edgep
 }
 
 func (s *Client) AddFlavorRes(uri, token string, in *ormapi.RegionFlavor) (*edgeproto.Result, int, error) {
-	args := []string{"flavor", "addflavorres"}
+	args := []string{"flavor", "addres"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -78,7 +78,7 @@ func (s *Client) AddFlavorRes(uri, token string, in *ormapi.RegionFlavor) (*edge
 }
 
 func (s *Client) RemoveFlavorRes(uri, token string, in *ormapi.RegionFlavor) (*edgeproto.Result, int, error) {
-	args := []string{"flavor", "removeflavorres"}
+	args := []string{"flavor", "removeres"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))

--- a/mc/mcctl/cliwrapper/restagtable.mc2.go
+++ b/mc/mcctl/cliwrapper/restagtable.mc2.go
@@ -89,7 +89,7 @@ func (s *Client) RemoveResTag(uri, token string, in *ormapi.RegionResTagTable) (
 }
 
 func (s *Client) GetResTagTable(uri, token string, in *ormapi.RegionResTagTableKey) (*edgeproto.ResTagTable, int, error) {
-	args := []string{"restagtable", "getrestagtable"}
+	args := []string{"restagtable", "get"}
 	out := edgeproto.ResTagTable{}
 	noconfig := strings.Split("", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))

--- a/mc/mcctl/cliwrapper/vmpool.mc2.go
+++ b/mc/mcctl/cliwrapper/vmpool.mc2.go
@@ -69,7 +69,7 @@ func (s *Client) ShowVMPool(uri, token string, in *ormapi.RegionVMPool) ([]edgep
 }
 
 func (s *Client) AddVMPoolMember(uri, token string, in *ormapi.RegionVMPoolMember) (*edgeproto.Result, int, error) {
-	args := []string{"vmpool", "add"}
+	args := []string{"vmpool", "addmember"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("Vm.GroupName,Vm.State,Vm.UpdatedAt.Seconds,Vm.UpdatedAt.Nanos,Vm.InternalName,Vm.Flavor", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))
@@ -80,7 +80,7 @@ func (s *Client) AddVMPoolMember(uri, token string, in *ormapi.RegionVMPoolMembe
 }
 
 func (s *Client) RemoveVMPoolMember(uri, token string, in *ormapi.RegionVMPoolMember) (*edgeproto.Result, int, error) {
-	args := []string{"vmpool", "remove"}
+	args := []string{"vmpool", "removemember"}
 	out := edgeproto.Result{}
 	noconfig := strings.Split("Vm.GroupName,Vm.State,Vm.UpdatedAt.Seconds,Vm.UpdatedAt.Nanos,Vm.InternalName,Vm.Flavor,Vm.NetInfo.ExternalIp,Vm.NetInfo.InternalIp,Vm.Flavor", ",")
 	st, err := s.runObjs(uri, token, args, in, &out, withIgnore(noconfig))

--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -100,7 +100,7 @@ var ShowAppCmd = &cli.Command{
 }
 
 var AddAppAutoProvPolicyCmd = &cli.Command{
-	Use:          "add",
+	Use:          "addautoprovpolicy",
 	Short:        "Add an AutoProvPolicy to the App",
 	RequiredArgs: "region " + strings.Join(AppAutoProvPolicyRequiredArgs, " "),
 	OptionalArgs: strings.Join(AppAutoProvPolicyOptionalArgs, " "),
@@ -113,7 +113,7 @@ var AddAppAutoProvPolicyCmd = &cli.Command{
 }
 
 var RemoveAppAutoProvPolicyCmd = &cli.Command{
-	Use:          "remove",
+	Use:          "removeautoprovpolicy",
 	Short:        "Remove an AutoProvPolicy from the App",
 	RequiredArgs: "region " + strings.Join(AppAutoProvPolicyRequiredArgs, " "),
 	OptionalArgs: strings.Join(AppAutoProvPolicyOptionalArgs, " "),

--- a/mc/mcctl/ormctl/autoprovpolicy.mc2.go
+++ b/mc/mcctl/ormctl/autoprovpolicy.mc2.go
@@ -101,7 +101,7 @@ var ShowAutoProvPolicyCmd = &cli.Command{
 }
 
 var AddAutoProvPolicyCloudletCmd = &cli.Command{
-	Use:          "add",
+	Use:          "addcloudlet",
 	Short:        "Add a Cloudlet to the Auto Provisioning Policy",
 	RequiredArgs: "region " + strings.Join(AutoProvPolicyCloudletRequiredArgs, " "),
 	OptionalArgs: strings.Join(AutoProvPolicyCloudletOptionalArgs, " "),
@@ -114,7 +114,7 @@ var AddAutoProvPolicyCloudletCmd = &cli.Command{
 }
 
 var RemoveAutoProvPolicyCloudletCmd = &cli.Command{
-	Use:          "remove",
+	Use:          "removecloudlet",
 	Short:        "Remove a Cloudlet from the Auto Provisioning Policy",
 	RequiredArgs: "region " + strings.Join(AutoProvPolicyCloudletRequiredArgs, " "),
 	OptionalArgs: strings.Join(AutoProvPolicyCloudletOptionalArgs, " "),

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -106,7 +106,7 @@ var ShowCloudletCmd = &cli.Command{
 }
 
 var GetCloudletManifestCmd = &cli.Command{
-	Use:          "getcloudletmanifest",
+	Use:          "getmanifest",
 	Short:        "Get Cloudlet Manifest. Shows deployment manifest required to setup cloudlet",
 	RequiredArgs: "region " + strings.Join(CloudletKeyRequiredArgs, " "),
 	OptionalArgs: strings.Join(CloudletKeyOptionalArgs, " "),
@@ -119,7 +119,7 @@ var GetCloudletManifestCmd = &cli.Command{
 }
 
 var GetCloudletPropsCmd = &cli.Command{
-	Use:          "get",
+	Use:          "getprops",
 	Short:        "Get Cloudlet Properties. Shows all the infra properties used to setup cloudlet",
 	RequiredArgs: "region " + strings.Join(GetCloudletPropsRequiredArgs, " "),
 	OptionalArgs: strings.Join(GetCloudletPropsOptionalArgs, " "),
@@ -132,7 +132,7 @@ var GetCloudletPropsCmd = &cli.Command{
 }
 
 var GetCloudletResourceQuotaPropsCmd = &cli.Command{
-	Use:          "get",
+	Use:          "getresourcequotaprops",
 	Short:        "Get Cloudlet Resource Quota Properties. Shows all the resource quota properties of the cloudlet",
 	RequiredArgs: "region " + strings.Join(GetCloudletResourceQuotaPropsRequiredArgs, " "),
 	OptionalArgs: strings.Join(GetCloudletResourceQuotaPropsOptionalArgs, " "),
@@ -145,7 +145,7 @@ var GetCloudletResourceQuotaPropsCmd = &cli.Command{
 }
 
 var GetCloudletResourceUsageCmd = &cli.Command{
-	Use:          "get",
+	Use:          "getresourceusage",
 	Short:        "Get Cloudlet resource information. Shows cloudlet resources used and their limits",
 	RequiredArgs: "region " + strings.Join(GetCloudletResourceUsageRequiredArgs, " "),
 	OptionalArgs: strings.Join(GetCloudletResourceUsageOptionalArgs, " "),
@@ -158,7 +158,7 @@ var GetCloudletResourceUsageCmd = &cli.Command{
 }
 
 var AddCloudletResMappingCmd = &cli.Command{
-	Use:          "addcloudletresmapping",
+	Use:          "addresmapping",
 	Short:        "Add Optional Resource tag table",
 	RequiredArgs: "region " + strings.Join(CloudletResMapRequiredArgs, " "),
 	OptionalArgs: strings.Join(CloudletResMapOptionalArgs, " "),
@@ -171,7 +171,7 @@ var AddCloudletResMappingCmd = &cli.Command{
 }
 
 var RemoveCloudletResMappingCmd = &cli.Command{
-	Use:          "removecloudletresmapping",
+	Use:          "removeresmapping",
 	Short:        "Add Optional Resource tag table",
 	RequiredArgs: "region " + strings.Join(CloudletResMapRequiredArgs, " "),
 	OptionalArgs: strings.Join(CloudletResMapOptionalArgs, " "),
@@ -184,7 +184,7 @@ var RemoveCloudletResMappingCmd = &cli.Command{
 }
 
 var FindFlavorMatchCmd = &cli.Command{
-	Use:          "find",
+	Use:          "findflavormatch",
 	Short:        "Discover if flavor produces a matching platform flavor",
 	RequiredArgs: "region " + strings.Join(FlavorMatchRequiredArgs, " "),
 	OptionalArgs: strings.Join(FlavorMatchOptionalArgs, " "),

--- a/mc/mcctl/ormctl/cloudletpool.mc2.go
+++ b/mc/mcctl/ormctl/cloudletpool.mc2.go
@@ -100,7 +100,7 @@ var ShowCloudletPoolCmd = &cli.Command{
 }
 
 var AddCloudletPoolMemberCmd = &cli.Command{
-	Use:          "add",
+	Use:          "addmember",
 	Short:        "Add a Cloudlet to a CloudletPool",
 	RequiredArgs: "region " + strings.Join(CloudletPoolMemberRequiredArgs, " "),
 	OptionalArgs: strings.Join(CloudletPoolMemberOptionalArgs, " "),
@@ -113,7 +113,7 @@ var AddCloudletPoolMemberCmd = &cli.Command{
 }
 
 var RemoveCloudletPoolMemberCmd = &cli.Command{
-	Use:          "remove",
+	Use:          "removemember",
 	Short:        "Remove a Cloudlet from a CloudletPool",
 	RequiredArgs: "region " + strings.Join(CloudletPoolMemberRequiredArgs, " "),
 	OptionalArgs: strings.Join(CloudletPoolMemberOptionalArgs, " "),

--- a/mc/mcctl/ormctl/clusterinst.mc2.go
+++ b/mc/mcctl/ormctl/clusterinst.mc2.go
@@ -106,7 +106,7 @@ var ShowClusterInstCmd = &cli.Command{
 }
 
 var DeleteIdleReservableClusterInstsCmd = &cli.Command{
-	Use:          "delete",
+	Use:          "deleteidlereservables",
 	Short:        "Cleanup Reservable Cluster Instances. Deletes reservable cluster instances that are not in use.",
 	RequiredArgs: "region " + strings.Join(IdleReservableClusterInstsRequiredArgs, " "),
 	OptionalArgs: strings.Join(IdleReservableClusterInstsOptionalArgs, " "),

--- a/mc/mcctl/ormctl/device.mc2.go
+++ b/mc/mcctl/ormctl/device.mc2.go
@@ -65,7 +65,7 @@ var EvictDeviceCmd = &cli.Command{
 }
 
 var ShowDeviceReportCmd = &cli.Command{
-	Use:          "show",
+	Use:          "showreport",
 	Short:        "Device Reports API.",
 	RequiredArgs: "region",
 	OptionalArgs: strings.Join(append(DeviceReportRequiredArgs, DeviceReportOptionalArgs...), " "),

--- a/mc/mcctl/ormctl/flavor.mc2.go
+++ b/mc/mcctl/ormctl/flavor.mc2.go
@@ -99,7 +99,7 @@ var ShowFlavorCmd = &cli.Command{
 }
 
 var AddFlavorResCmd = &cli.Command{
-	Use:          "addflavorres",
+	Use:          "addres",
 	Short:        "Add Optional Resource",
 	RequiredArgs: "region " + strings.Join(FlavorRequiredArgs, " "),
 	OptionalArgs: strings.Join(FlavorOptionalArgs, " "),
@@ -112,7 +112,7 @@ var AddFlavorResCmd = &cli.Command{
 }
 
 var RemoveFlavorResCmd = &cli.Command{
-	Use:          "removeflavorres",
+	Use:          "removeres",
 	Short:        "Remove Optional Resource",
 	RequiredArgs: "region " + strings.Join(FlavorRequiredArgs, " "),
 	OptionalArgs: strings.Join(FlavorOptionalArgs, " "),

--- a/mc/mcctl/ormctl/restagtable.mc2.go
+++ b/mc/mcctl/ormctl/restagtable.mc2.go
@@ -125,7 +125,7 @@ var RemoveResTagCmd = &cli.Command{
 }
 
 var GetResTagTableCmd = &cli.Command{
-	Use:          "getrestagtable",
+	Use:          "get",
 	Short:        "Fetch a copy of the TagTable",
 	RequiredArgs: "region " + strings.Join(ResTagTableKeyRequiredArgs, " "),
 	OptionalArgs: strings.Join(ResTagTableKeyOptionalArgs, " "),

--- a/mc/mcctl/ormctl/vmpool.mc2.go
+++ b/mc/mcctl/ormctl/vmpool.mc2.go
@@ -101,7 +101,7 @@ var ShowVMPoolCmd = &cli.Command{
 }
 
 var AddVMPoolMemberCmd = &cli.Command{
-	Use:          "add",
+	Use:          "addmember",
 	Short:        "Add VMPoolMember. Adds a VM to existing VM Pool.",
 	RequiredArgs: "region " + strings.Join(AddVMPoolMemberRequiredArgs, " "),
 	OptionalArgs: strings.Join(AddVMPoolMemberOptionalArgs, " "),
@@ -114,7 +114,7 @@ var AddVMPoolMemberCmd = &cli.Command{
 }
 
 var RemoveVMPoolMemberCmd = &cli.Command{
-	Use:          "remove",
+	Use:          "removemember",
 	Short:        "Remove VMPoolMember. Removes a VM from existing VM Pool.",
 	RequiredArgs: "region " + strings.Join(RemoveVMPoolMemberRequiredArgs, " "),
 	OptionalArgs: strings.Join(RemoveVMPoolMemberOptionalArgs, " "),


### PR DESCRIPTION
This changes the way the cli command names are generated for the new mcctl reorg. The previous generated way caused the names to conflict (the cloudlet group ended up with 4 different commands all named "get"). So we consider the input type of the first method in a service as the "base" name, and remove it from the command names to avoid redundancy. I.e., GetCloudletManifest under the "cloudlet" group becomes "getmanifest", since cloudlet is already present in the grouping name (mcctl cloudlet getmanifest). Just in case the generated name isn't what we want, it can be overridden by a protogen option.