### PR TITLE
EDGECLOUD-4645: By default operator organization should only be allowed to create edgebox cloudlets

### DIFF
--- a/e2e-tests/data/mc_user1_cloudlet_data.yml
+++ b/e2e-tests/data/mc_user1_cloudlet_data.yml
@@ -1,25 +1,3 @@
-orgs:
-- name: tmus
-  type: operator
-  address: tmus headquarters
-  phone: 123-123-1234
-  adminusername: user1
-- name: azure
-  type: operator
-  address: amazon jungle
-  phone: 123-123-1234
-  adminusername: user1
-- name: gcp
-  type: operator
-  address: mountain view
-  phone: 123-123-1234
-  adminusername: user1
-- name: enterprise
-  type: operator
-  address: enterprise headquarters
-  phone: 123-123-1234
-  adminusername: user1
-
 cloudletpoolaccessinvitations:
 - org: user3org
   region: local

--- a/e2e-tests/data/mc_user1_org_data.yml
+++ b/e2e-tests/data/mc_user1_org_data.yml
@@ -1,0 +1,21 @@
+orgs:
+- name: tmus
+  type: operator
+  address: tmus headquarters
+  phone: 123-123-1234
+  adminusername: user1
+- name: azure
+  type: operator
+  address: amazon jungle
+  phone: 123-123-1234
+  adminusername: user1
+- name: gcp
+  type: operator
+  address: mountain view
+  phone: 123-123-1234
+  adminusername: user1
+- name: enterprise
+  type: operator
+  address: enterprise headquarters
+  phone: 123-123-1234
+  adminusername: user1

--- a/e2e-tests/data/mc_user1_org_update.yml
+++ b/e2e-tests/data/mc_user1_org_update.yml
@@ -1,0 +1,9 @@
+orgs:
+- name: tmus
+  edgeboxonly: false
+- name: azure
+  edgeboxonly: false
+- name: gcp
+  edgeboxonly: false
+- name: enterprise
+  edgeboxonly: false

--- a/e2e-tests/data/mcconfig.yml
+++ b/e2e-tests/data/mcconfig.yml
@@ -4,4 +4,3 @@ passwordmincracktimesec: 2.592e+06
 adminpasswordmincracktimesec: 6.3072e+07
 maxmetricsdatapoints: 10000
 userapikeycreatelimit: 10
-skipoperatoredgeboxorg: true

--- a/e2e-tests/e2e-setup/mcapi.go
+++ b/e2e-tests/e2e-setup/mcapi.go
@@ -2,6 +2,7 @@ package e2esetup
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -288,6 +289,34 @@ func runMcDataAPI(api, uri, apiFile, curUserFile, outputDir string, mods []strin
 	case "stream":
 		dataOut := streamMcData(uri, token, tag, data, &rc)
 		util.PrintToYamlFile("show-commands.yml", outputDir, dataOut, true)
+	case "restrictedupdateorg":
+		val, ok := dataMap["orgs"]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "mcapi: no orgs in %v\n", dataMap)
+			os.Exit(1)
+		}
+		arr, ok := val.([]interface{})
+		if !ok {
+			fmt.Fprintf(os.Stderr, "mcapi: orgs in map not []interface{}: %v\n", dataMap)
+			os.Exit(1)
+		}
+		output := &AllDataOut{}
+		for ii, orgIntf := range arr {
+			var orgMap map[string]interface{}
+			orgObj, err := json.Marshal(orgIntf)
+			if err != nil {
+				log.Printf("error in marshal org for %v: %v\n", orgIntf, err)
+				return false
+			}
+			err = json.Unmarshal(orgObj, &orgMap)
+			if err != nil {
+				log.Printf("error in unmarshal org for %s: %v\n", string(orgObj), err)
+				return false
+			}
+			st, err := mcClient.RestrictedUpdateOrg(uri, token, orgMap)
+			outMcErr(output, fmt.Sprintf("RestrictedUpdateOrg[%d]", ii), st, err)
+		}
+		errs = output.Errors
 	}
 	if tag != "expecterr" && errs != nil {
 		// no errors expected

--- a/e2e-tests/testfiles/deploy_start_create.yml
+++ b/e2e-tests/testfiles/deploy_start_create.yml
@@ -28,9 +28,19 @@ tests:
       yaml2: '{{datadir2}}/mc_admin_data.yml'
       filetype: mcdata
 
-  - name: user1 creates operator/cloudlets; verify it is there
+  - name: user1 creates operators
+    actions: [mcapi-create]
+    apifile: '{{datadir2}}/mc_user1_org_data.yml'
+    curuserfile: '{{datadir2}}/mc_user1.yml'
+
+  - name: admin marks operator orgs an non-edgebox only
+    actions: [mcapi-restrictedupdateorg]
+    apifile: '{{datadir2}}/mc_user1_org_update.yml'
+    curuserfile: '{{datadir2}}/mc_admin.yml'
+
+  - name: user1 creates cloudlets; verify it is there
     actions: [mcapi-create, mcapi-show]
-    apifile: '{{datadir2}}/mc_user1_data.yml'
+    apifile: '{{datadir2}}/mc_user1_cloudlet_data.yml'
     curuserfile: '{{datadir2}}/mc_user1.yml'
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'

--- a/e2e-tests/testfiles/mc_add_delete.yml
+++ b/e2e-tests/testfiles/mc_add_delete.yml
@@ -50,9 +50,19 @@ tests:
     yaml2: '{{datadir2}}/mc_admin_data.yml'
     filetype: mcdata
 
-- name: user1 creates operator/cloudlets; verify it is there
+- name: user1 creates operators
+  actions: [mcapi-create]
+  apifile: '{{datadir2}}/mc_user1_org_data.yml'
+  curuserfile: '{{datadir2}}/mc_user1.yml'
+
+- name: admin marks operator orgs an non-edgebox only
+  actions: [mcapi-restrictedupdateorg]
+  apifile: '{{datadir2}}/mc_user1_org_update.yml'
+  curuserfile: '{{datadir2}}/mc_admin.yml'
+
+- name: user1 creates cloudlets; verify it is there
   actions: [mcapi-create, mcapi-show]
-  apifile: '{{datadir2}}/mc_user1_data.yml'
+  apifile: '{{datadir2}}/mc_user1_cloudlet_data.yml'
   curuserfile: '{{datadir2}}/mc_user1.yml'
   compareyaml:
     yaml1: '{{outputdir}}/show-commands.yml'

--- a/mc/mcctl/cliwrapper/org.go
+++ b/mc/mcctl/cliwrapper/org.go
@@ -23,3 +23,8 @@ func (s *Client) ShowOrg(uri, token string) ([]ormapi.Organization, int, error) 
 	st, err := s.runObjs(uri, token, args, nil, &orgs)
 	return orgs, st, err
 }
+
+func (s *Client) RestrictedUpdateOrg(uri, token string, org map[string]interface{}) (int, error) {
+	args := []string{"org", "restrictedupdateorg"}
+	return s.runObjs(uri, token, args, org, nil)
+}

--- a/mc/mcctl/ormctl/config.go
+++ b/mc/mcctl/ormctl/config.go
@@ -10,7 +10,7 @@ func GetConfigCommand() *cobra.Command {
 	cmds := []*cli.Command{&cli.Command{
 		Use:          "update",
 		Short:        "Update master controller global configuration",
-		OptionalArgs: "locknewaccounts notifyemailaddress, skipverifyemail, maxmetricsdatapoints, passwordmincracktimesec, adminpasswordmincracktimesec userapikeycreatelimit billingenable skipoperatoredgeboxorg",
+		OptionalArgs: "locknewaccounts notifyemailaddress, skipverifyemail, maxmetricsdatapoints, passwordmincracktimesec, adminpasswordmincracktimesec userapikeycreatelimit billingenable",
 		ReqData:      &ormapi.Config{},
 		Run:          runRest("/auth/config/update"),
 	}, &cli.Command{

--- a/mc/mcctl/ormctl/org.go
+++ b/mc/mcctl/ormctl/org.go
@@ -43,7 +43,8 @@ func GetRestrictedOrgUpdateCmd() *cobra.Command {
 	cmd := cli.Command{
 		Use:          "restrictedorgupdate",
 		Short:        "Admin-only update of org fields, requires name",
-		OptionalArgs: "name edgeboxorg",
+		RequiredArgs: "name",
+		OptionalArgs: "edgeboxonly",
 		Comments:     ormapi.OrganizationComments,
 		ReqData:      &ormapi.Organization{},
 		Run:          runRest("/auth/restricted/org/update"),

--- a/mc/orm/config.go
+++ b/mc/orm/config.go
@@ -19,7 +19,6 @@ var defaultConfig = ormapi.Config{
 	MaxMetricsDataPoints:         10000,
 	UserApiKeyCreateLimit:        10,
 	BillingEnable:                false, // TODO: eventually set the default to true?
-	SkipOperatorEdgeboxOrg:       false,
 }
 
 func InitConfig(ctx context.Context) error {

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -47,9 +47,6 @@ func TestController(t *testing.T) {
 	testAlertMgrAddr, err := InitAlertmgrMock()
 	require.Nil(t, err)
 
-	// disable edgebox org for new operator
-	defaultConfig.SkipOperatorEdgeboxOrg = true
-
 	config := ServerConfig{
 		ServAddr:                addr,
 		SqlAddr:                 "127.0.0.1:5445",
@@ -604,7 +601,7 @@ func TestController(t *testing.T) {
 	require.Equal(t, http.StatusOK, status)
 
 	testOrgCloudletPoolUpgrade(t, ctx)
-	testEdgeboxOrgCloudletCreate(t, ctx, mcClient, uri, ctrl.Region)
+	testEdgeboxOnlyCloudletCreate(t, ctx, mcClient, uri, ctrl.Region)
 
 	// delete controller
 	status, err = mcClient.DeleteController(uri, token, &ctrl)
@@ -1394,23 +1391,16 @@ func testOrgCloudletPoolUpgrade(t *testing.T, ctx context.Context) {
 	}
 }
 
-func testEdgeboxOrgCloudletCreate(t *testing.T, ctx context.Context, mcClient *ormclient.Client, uri, region string) {
+func testEdgeboxOnlyCloudletCreate(t *testing.T, ctx context.Context, mcClient *ormclient.Client, uri, region string) {
 	// login as super user
 	token, _, err := mcClient.DoLogin(uri, DefaultSuperuser, DefaultSuperpass, NoOTP, NoApiKeyId, NoApiKey)
 	require.Nil(t, err, "login as superuser")
-
-	// set config to be enable edgeboxorg as default operator org
-	configReq := make(map[string]interface{})
-	configReq["skipoperatoredgeboxorg"] = false
-	status, err := mcClient.UpdateConfig(uri, token, configReq)
-	require.Nil(t, err)
-	require.Equal(t, http.StatusOK, status)
 
 	operOrg := ormapi.Organization{
 		Type: "operator",
 		Name: "EdgeboxOperOrg",
 	}
-	status, err = mcClient.CreateOrg(uri, token, &operOrg)
+	status, err := mcClient.CreateOrg(uri, token, &operOrg)
 	require.Nil(t, err, "create org")
 	require.Equal(t, http.StatusOK, status, "create org status")
 
@@ -1441,12 +1431,12 @@ func testEdgeboxOrgCloudletCreate(t *testing.T, ctx context.Context, mcClient *o
 	// toggle edgebox org flag for operator org
 	orgReq := make(map[string]interface{})
 	orgReq["name"] = operOrg.Name
-	orgReq["edgeboxorg"] = false
-	status, err = mcClient.RestrictedOrgUpdate(uri, token, orgReq)
+	orgReq["edgeboxonly"] = false
+	status, err = mcClient.RestrictedUpdateOrg(uri, token, orgReq)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 
-	// cloudlet creation should work for other platforms as edgeboxorg flag is set to false
+	// cloudlet creation should work for other platforms as edgeboxonly flag is set to false
 	regCloudlet.Cloudlet.PlatformType = edgeproto.PlatformType_PLATFORM_TYPE_FAKE
 	_, status, err = mcClient.CreateCloudlet(uri, token, &regCloudlet)
 	require.Nil(t, err)
@@ -1454,9 +1444,4 @@ func testEdgeboxOrgCloudletCreate(t *testing.T, ctx context.Context, mcClient *o
 	// cleanup cloudlet
 	_, status, err = mcClient.DeleteCloudlet(uri, token, &regCloudlet)
 	require.Nil(t, err)
-
-	configReq["skipoperatoredgeboxorg"] = true
-	status, err = mcClient.UpdateConfig(uri, token, configReq)
-	require.Nil(t, err)
-	require.Equal(t, http.StatusOK, status)
 }

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -484,7 +484,7 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 	auth.POST("/config/show", ShowConfig)
 	auth.POST("/config/version", ShowVersion)
 	auth.POST("/restricted/user/update", RestrictedUserUpdate)
-	auth.POST("/restricted/org/update", RestrictedOrgUpdate)
+	auth.POST("/restricted/org/update", RestrictedUpdateOrg)
 	auth.POST("/audit/showself", ShowAuditSelf)
 	auth.POST("/audit/showorg", ShowAuditOrg)
 	auth.POST("/audit/operations", GetAuditOperations)

--- a/mc/ormapi/api.comments.go
+++ b/mc/ormapi/api.comments.go
@@ -27,11 +27,11 @@ var UserApiKeyComments = map[string]string{
 }
 
 var OrganizationComments = map[string]string{
-	"name":       `Organization name. Can only contain letters, digits, underscore, period, hyphen. It cannot have leading or trailing spaces or period. It cannot start with hyphen`,
-	"type":       `Organization type: "developer" or "operator"`,
-	"address":    `Organization address`,
-	"phone":      `Organization phone number`,
-	"edgeboxorg": `Edgebox Organization: true or false`,
+	"name":        `Organization name. Can only contain letters, digits, underscore, period, hyphen. It cannot have leading or trailing spaces or period. It cannot start with hyphen`,
+	"type":        `Organization type: "developer" or "operator"`,
+	"address":     `Organization address`,
+	"phone":       `Organization phone number`,
+	"edgeboxonly": `Edgebox only organization: true or false`,
 }
 
 var BillingOrganizationComments = map[string]string{
@@ -66,7 +66,6 @@ var ConfigComments = map[string]string{
 	"maxmetricsdatapoints":         `InfluxDB max number of data points returned`,
 	"userapikeycreatelimit":        `Max number of API keys a user can create`,
 	"billingenable":                `Toggle for enabling billing (primarily for testing purposes)`,
-	"skipoperatoredgeboxorg":       `By default, set new operator org as edgebox org`,
 }
 
 var OrgCloudletPoolComments = map[string]string{

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -107,7 +107,7 @@ type Organization struct {
 	// read only: true
 	Parent string `json:",omitempty"`
 	// read only: true
-	EdgeboxOrg bool `json:",omitempty"`
+	EdgeboxOnly bool `json:",omitempty"`
 }
 
 // used for CreateBillingOrg, so we can pass through payment details to the billing service without actually storing them
@@ -202,8 +202,6 @@ type Config struct {
 	UserApiKeyCreateLimit int
 	// Toggle for enabling billing (primarily for testing purposes)
 	BillingEnable bool
-	// Skip setting new operator organization as Edgebox org
-	SkipOperatorEdgeboxOrg bool
 }
 
 type OrgCloudletPool struct {

--- a/mc/ormclient/clientapi.go
+++ b/mc/ormclient/clientapi.go
@@ -26,6 +26,7 @@ type Api interface {
 	DeleteOrg(uri, token string, org *ormapi.Organization) (int, error)
 	UpdateOrg(uri, token string, jsonData string) (int, error)
 	ShowOrg(uri, token string) ([]ormapi.Organization, int, error)
+	RestrictedUpdateOrg(uri, token string, org map[string]interface{}) (int, error)
 
 	CreateBillingOrg(uri, token string, org *ormapi.BillingOrganization) (int, error)
 	DeleteBillingOrg(uri, token string, org *ormapi.BillingOrganization) (int, error)

--- a/mc/ormclient/rest_client.go
+++ b/mc/ormclient/rest_client.go
@@ -122,8 +122,8 @@ func (s *Client) ShowOrg(uri, token string) ([]ormapi.Organization, int, error) 
 	return orgs, status, err
 }
 
-func (s *Client) RestrictedOrgUpdate(uri, token string, user map[string]interface{}) (int, error) {
-	return s.PostJson(uri+"/auth/restricted/org/update", token, user, nil)
+func (s *Client) RestrictedUpdateOrg(uri, token string, org map[string]interface{}) (int, error) {
+	return s.PostJson(uri+"/auth/restricted/org/update", token, org, nil)
 }
 
 func (s *Client) CreateBillingOrg(uri, token string, bOrg *ormapi.BillingOrganization) (int, error) {


### PR DESCRIPTION
* By default, any new operator org created will only allow its users to create Edgebox cloudlets. This is done by maintaining a new flag on `Organization` called `EdgeboxOrg`. The default value is controlled by MC config `skipoperatoredgeboxorg` flag.
* A mexadmin only API will be used to allow the manager of operator org to create cloudlets of other platform types:
  * Defined new mcctl command `restrictedorgupdate` (just like `restricteduserupdate`) to update `edgeboxorg` flag
* No upgrade function is required for existing orgs, as `EdgeboxOrg` will be `false` for them
* Added unit-tests & fixed e2e-test