### PR TITLE
EDGECLOUD-4647 cloudletpoolaccessinvitation create with missing args returns 500

### DIFF
--- a/mc/orm/orgcloudletpools.go
+++ b/mc/orm/orgcloudletpools.go
@@ -339,7 +339,7 @@ func createDeleteCloudletPoolAccess(c echo.Context, action cloudcommon.Action, t
 		return bindErr(c, err)
 	}
 	if err := validateOrgCloudletPool(&in); err != nil {
-		return err
+		return setReply(c, err, nil)
 	}
 	span := log.SpanFromContext(ctx)
 


### PR DESCRIPTION
Fix for error code to be 400 instead of 500.