### PR TITLE
EDGECLOUD-4461: TMNL VMpool cloudlet bringup fails

### DIFF
--- a/crm-platforms/vmpool/vmpool-cmd.go
+++ b/crm-platforms/vmpool/vmpool-cmd.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
@@ -41,10 +39,6 @@ func (s *VMPoolPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.Flavor
 	flavorMap := make(map[string]struct{})
 	updatedVMs := []edgeproto.VM{}
 
-	wgError := make(chan error)
-	wgDone := make(chan bool)
-	var mux sync.Mutex
-	var wg sync.WaitGroup
 	for _, vm := range s.caches.VMPool.Vms {
 		var client ssh.Client
 		if vm.NetInfo.ExternalIp != "" {
@@ -60,81 +54,52 @@ func (s *VMPoolPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.Flavor
 		} else {
 			return nil, fmt.Errorf("VM %s is missing network info", vm.Name)
 		}
-		wg.Add(1)
-		go func(clientIn ssh.Client, vmIn edgeproto.VM, wg *sync.WaitGroup) {
-			out, err := clientIn.Output("sudo bash /etc/mobiledgex/get-flavor.sh")
-			if err != nil {
-				wgError <- fmt.Errorf("failed to get flavor info for %s: %s - %v", vmIn.Name, out, err)
-				return
-			}
-			log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorList, found resource", "vm", vmIn.Name, "resource info", out)
+		out, err := client.Output("sudo bash /etc/mobiledgex/get-flavor.sh")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get flavor info for %s: %s - %v", vm.Name, out, err)
+		}
+		log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorList, found resource", "vm", vm.Name, "resource info", out)
 
-			parts := strings.Split(out, ",")
-			if len(parts) != 3 {
-				wgError <- fmt.Errorf("invalid flavor info for %s: %s", vmIn.Name, out)
-				return
-			}
+		parts := strings.Split(out, ",")
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("invalid flavor info for %s: %s", vm.Name, out)
+		}
 
-			memMb, err := strconv.Atoi(parts[0])
-			if err != nil || memMb <= 0 {
-				wgError <- fmt.Errorf("invalid memory info %s for %s: %v", parts[0], vmIn.Name, err)
-				return
-			}
+		memMb, err := strconv.Atoi(parts[0])
+		if err != nil || memMb <= 0 {
+			return nil, fmt.Errorf("invalid memory info %s for %s: %v", parts[0], vm.Name, err)
+		}
 
-			vcpus, err := strconv.Atoi(parts[1])
-			if err != nil || vcpus <= 0 {
-				wgError <- fmt.Errorf("invalid vcpu info %s for %s: %v", parts[1], vmIn.Name, err)
-				return
-			}
+		vcpus, err := strconv.Atoi(parts[1])
+		if err != nil || vcpus <= 0 {
+			return nil, fmt.Errorf("invalid vcpu info %s for %s: %v", parts[1], vm.Name, err)
+		}
 
-			diskGb, err := strconv.Atoi(parts[2])
-			if err != nil || diskGb <= 0 {
-				wgError <- fmt.Errorf("invalid disk info %s for %s: %v", parts[2], vmIn.Name, err)
-				return
-			}
+		diskGb, err := strconv.Atoi(parts[2])
+		if err != nil || diskGb <= 0 {
+			return nil, fmt.Errorf("invalid disk info %s for %s: %v", parts[2], vm.Name, err)
+		}
 
-			defer wg.Done()
+		flavorName := fmt.Sprintf("vcpu/%d-ram/%d-disk/%d", uint64(vcpus), uint64(memMb), uint64(diskGb))
+		vm.Flavor = &edgeproto.FlavorInfo{
+			Name:  vm.Name + "-flavor",
+			Vcpus: uint64(vcpus),
+			Ram:   uint64(memMb),
+			Disk:  uint64(diskGb),
+		}
 
-			flavorName := fmt.Sprintf("vcpu/%d-ram/%d-disk/%d", uint64(vcpus), uint64(memMb), uint64(diskGb))
-			vmIn.Flavor = &edgeproto.FlavorInfo{
-				Name:  vmIn.Name + "-flavor",
-				Vcpus: uint64(vcpus),
-				Ram:   uint64(memMb),
-				Disk:  uint64(diskGb),
-			}
+		updatedVMs = append(updatedVMs, vm)
+		if _, ok := flavorMap[flavorName]; ok {
+			continue
+		}
+		flavorMap[flavorName] = struct{}{}
 
-			mux.Lock()
-			updatedVMs = append(updatedVMs, vmIn)
-			if _, ok := flavorMap[flavorName]; ok {
-				mux.Unlock()
-				return
-			}
-			flavorMap[flavorName] = struct{}{}
-
-			var flavInfo edgeproto.FlavorInfo
-			flavInfo.Name = flavorName
-			flavInfo.Ram = uint64(memMb)
-			flavInfo.Vcpus = uint64(vcpus)
-			flavInfo.Disk = uint64(diskGb)
-			flavors = append(flavors, &flavInfo)
-			mux.Unlock()
-		}(client, vm, &wg)
-	}
-
-	go func() {
-		wg.Wait()
-		close(wgDone)
-	}()
-
-	// Wait until either WaitGroup is done or an error is received through the channel
-	select {
-	case <-wgDone:
-		break
-	case err := <-wgError:
-		close(wgError)
-		return nil, err
-	case <-time.After(AllVMAccessTimeout):
-		return nil, fmt.Errorf("Timed out fetching flavor list from VMs")
+		var flavInfo edgeproto.FlavorInfo
+		flavInfo.Name = flavorName
+		flavInfo.Ram = uint64(memMb)
+		flavInfo.Vcpus = uint64(vcpus)
+		flavInfo.Disk = uint64(diskGb)
+		flavors = append(flavors, &flavInfo)
 	}
 
 	if len(updatedVMs) > 0 {


### PR DESCRIPTION
* On CRM bring up, CRM opens multiple connections in parallel to rootLB VM to get to the VMs on internal network. This is causing the SSH library which CRM uses to fail intermittently for few nodes.
* Wrote a simple [golang script](https://github.com/mobiledgex/edge-utils/tree/master/gssh-client) to test this out:
```
for i in $(seq 10 23); do
./gssh-client -j 84.241.242.230 -d 192.168.26.$i -c "hostname" &
done
```
* Few connections fail intermittently:
```
[1]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[2]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[3]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[4]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[5]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[6]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[7]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[8]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[9]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[10]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[11]   Exit 2                  ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[12]   Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[13]-  Exit 2                  ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
[14]+  Done                    ./gssh -j 84.241.242.230 -d 192.168.26.$i -c "hostname"
```
* Have fixed the code to open SSH connection sequentially. This shouldn't be a problem as it'll only slow up CRM bring up, which is okay.