### PR TITLE
EDGECLOUD-4492: RequestAppInstLatency - request doesnt work with reservable cluster alias

### DIFF
--- a/mc/mcctl/ormctl/appinst.mc2.go
+++ b/mc/mcctl/ormctl/appinst.mc2.go
@@ -566,12 +566,12 @@ var AppInstLatencyRequiredArgs = []string{
 	"app-org",
 	"appname",
 	"appvers",
-	"cluster",
 	"cloudlet-org",
 	"cloudlet",
-	"cluster-org",
 }
 var AppInstLatencyOptionalArgs = []string{
+	"cluster",
+	"cluster-org",
 	"message",
 }
 var AppInstLatencyAliasArgs = []string{


### PR DESCRIPTION
Infra updates for https://github.com/mobiledgex/edge-cloud/pull/1291