### PR TITLE
EDGECLOUD-4671 OrgCloudletPool upgrade failure

### DIFF
--- a/e2e-tests/data/mc_admin_eventsterms_exp.yml
+++ b/e2e-tests/data/mc_admin_eventsterms_exp.yml
@@ -34,6 +34,8 @@
       count: 4
     - key: /api/v1/auth/ctrl/UpdateCloudlet
       count: 4
+    - key: /api/v1/auth/restricted/org/update
+      count: 4
     - key: AutoProv delete AppInst
       count: 4
     - key: cluster-svc create App


### PR DESCRIPTION
More fixes for upgrade failures.

Two problems, one is that an even older version of the OrgCloudletPool records had the cloudlet_pool_org column with null values. This caused the upgrade code to fail and continuously repeat.
The second problem is I assumed that you couldn't put another unique constraint that had the same set of fields, but postgres allows this (don't know why, since it would have no effect). This was causing an excess of unique constraints to build up on the table.

So this code now drops any really old data that had the cloudlet_pool_org empty. It also tweaks the constraint to only be added if a matching one doesn't already exist.

I've also added these checks to the unit-test to make sure it gets rid of really old data, and that the upgrade function is idempotent.