### PR TITLE
EDGECLOUD-4672 cloudlet pool in use error message

### DIFF
--- a/mc/mcctl/cliwrapper/org.go
+++ b/mc/mcctl/cliwrapper/org.go
@@ -25,6 +25,6 @@ func (s *Client) ShowOrg(uri, token string) ([]ormapi.Organization, int, error) 
 }
 
 func (s *Client) RestrictedUpdateOrg(uri, token string, org map[string]interface{}) (int, error) {
-	args := []string{"org", "restrictedupdateorg"}
+	args := []string{"restrictedorgupdate"}
 	return s.runObjs(uri, token, args, org, nil)
 }

--- a/mc/orm/authz_cloudletpool.go
+++ b/mc/orm/authz_cloudletpool.go
@@ -3,6 +3,7 @@ package orm
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
@@ -24,5 +25,9 @@ func authzDeleteCloudletPool(ctx context.Context, region, username string, obj *
 	if res.RecordNotFound() || len(pools) == 0 {
 		return nil
 	}
-	return fmt.Errorf("Cannot delete CloudletPool region %s name %s because it is in use by OrgCloudletPool org %s", region, obj.Key.Name, pools[0].Org)
+	usedBy := make([]string, 0)
+	for _, pool := range pools {
+		usedBy = append(usedBy, fmt.Sprintf("%s %s", pool.Org, pool.Type))
+	}
+	return fmt.Errorf("Cannot delete CloudletPool region %s name %s because it is referenced by %s", region, obj.Key.Name, strings.Join(usedBy, ", "))
 }


### PR DESCRIPTION
Tweaks the cloudlet pool in use error message to match the new org cloudlet pool types. Old message used to say "in use by org cloudlet pool". New message says "references devorg1 invitation, devorg2 invitation".

Also fixed some unit test and e2e test failures.