### PR TITLE
EDGECLOUD-4674 EDGECLOUD-4676 mc api err msg fixes

### DIFF
--- a/mc/orm/alert_mc2_test.go
+++ b/mc/orm/alert_mc2_test.go
@@ -34,6 +34,12 @@ func badPermShowAlert(t *testing.T, mcClient *ormclient.Client, uri, token, regi
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowAlert(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Alert)) {
+	_, st, err := testutil.TestPermShowAlert(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowAlert(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Alert)) {
 	_, status, err := testutil.TestPermShowAlert(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)

--- a/mc/orm/app_mc2_test.go
+++ b/mc/orm/app_mc2_test.go
@@ -34,6 +34,12 @@ func badPermCreateApp(t *testing.T, mcClient *ormclient.Client, uri, token, regi
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.App)) {
+	_, st, err := testutil.TestPermCreateApp(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
 	_, status, err := testutil.TestPermCreateApp(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -46,6 +52,12 @@ func badPermDeleteApp(t *testing.T, mcClient *ormclient.Client, uri, token, regi
 	_, status, err := testutil.TestPermDeleteApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.App)) {
+	_, st, err := testutil.TestPermDeleteApp(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
@@ -62,6 +74,12 @@ func badPermUpdateApp(t *testing.T, mcClient *ormclient.Client, uri, token, regi
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.App)) {
+	_, st, err := testutil.TestPermUpdateApp(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
 	_, status, err := testutil.TestPermUpdateApp(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -74,6 +92,12 @@ func badPermShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, region
 	_, status, err := testutil.TestPermShowApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.App)) {
+	_, st, err := testutil.TestPermShowApp(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowApp(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
@@ -90,6 +114,12 @@ func badPermAddAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, 
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badAddAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
+	_, st, err := testutil.TestPermAddAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermAddAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
 	_, status, err := testutil.TestPermAddAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -102,6 +132,12 @@ func badPermRemoveAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, ur
 	_, status, err := testutil.TestPermRemoveAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRemoveAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
+	_, st, err := testutil.TestPermRemoveAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRemoveAppAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {

--- a/mc/orm/appinst_mc2_test.go
+++ b/mc/orm/appinst_mc2_test.go
@@ -34,6 +34,12 @@ func badPermCreateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, 
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, st, err := testutil.TestPermCreateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
 	_, status, err := testutil.TestPermCreateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
@@ -46,6 +52,12 @@ func badPermDeleteAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, 
 	_, status, err := testutil.TestPermDeleteAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, st, err := testutil.TestPermDeleteAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
@@ -62,6 +74,12 @@ func badPermRefreshAppInst(t *testing.T, mcClient *ormclient.Client, uri, token,
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badRefreshAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, st, err := testutil.TestPermRefreshAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermRefreshAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
 	_, status, err := testutil.TestPermRefreshAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
@@ -76,6 +94,12 @@ func badPermUpdateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, 
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
+	_, st, err := testutil.TestPermUpdateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
 	_, status, err := testutil.TestPermUpdateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
@@ -88,6 +112,12 @@ func badPermShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, re
 	_, status, err := testutil.TestPermShowAppInst(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AppInst)) {
+	_, st, err := testutil.TestPermShowAppInst(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInst)) {
@@ -169,6 +199,12 @@ func badPermRequestAppInstLatency(t *testing.T, mcClient *ormclient.Client, uri,
 	_, status, err := testutil.TestPermRequestAppInstLatency(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRequestAppInstLatency(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AppInstLatency)) {
+	_, st, err := testutil.TestPermRequestAppInstLatency(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRequestAppInstLatency(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstLatency)) {

--- a/mc/orm/appinstclient_mc2_test.go
+++ b/mc/orm/appinstclient_mc2_test.go
@@ -34,6 +34,12 @@ func badPermShowAppInstClient(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowAppInstClient(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AppInstClientKey)) {
+	_, st, err := testutil.TestPermShowAppInstClient(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowAppInstClient(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstClientKey)) {
 	_, status, err := testutil.TestPermShowAppInstClient(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)

--- a/mc/orm/authz_cloudlet.go
+++ b/mc/orm/authz_cloudlet.go
@@ -67,7 +67,7 @@ func (s *AuthzCloudlet) populate(ctx context.Context, region, username, orgfilte
 	if opts.requiresOrg != "" {
 		// edgeboxOnly check is not required for Show command
 		noEdgeboxOnly := false
-		if err := checkRequiresOrg(ctx, opts.requiresOrg, s.admin, noEdgeboxOnly); err != nil {
+		if err := checkRequiresOrg(ctx, opts.requiresOrg, resource, s.admin, noEdgeboxOnly); err != nil {
 			return err
 		}
 	}

--- a/mc/orm/autoprovpolicy_mc2_test.go
+++ b/mc/orm/autoprovpolicy_mc2_test.go
@@ -35,6 +35,12 @@ func badPermCreateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, 
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, st, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
 	_, status, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -47,6 +53,12 @@ func badPermDeleteAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, 
 	_, status, err := testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, st, err := testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
@@ -63,6 +75,12 @@ func badPermUpdateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, 
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, st, err := testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
 	_, status, err := testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -75,6 +93,12 @@ func badPermShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, to
 	_, status, err := testutil.TestPermShowAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
+	_, st, err := testutil.TestPermShowAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowAutoProvPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
@@ -91,6 +115,12 @@ func badPermAddAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, 
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badAddAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
+	_, st, err := testutil.TestPermAddAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermAddAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
 	_, status, err := testutil.TestPermAddAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -103,6 +133,12 @@ func badPermRemoveAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Clien
 	_, status, err := testutil.TestPermRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRemoveAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
+	_, st, err := testutil.TestPermRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRemoveAutoProvPolicyCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {

--- a/mc/orm/autoscalepolicy_mc2_test.go
+++ b/mc/orm/autoscalepolicy_mc2_test.go
@@ -33,6 +33,12 @@ func badPermCreateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri,
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, st, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
 	_, status, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -45,6 +51,12 @@ func badPermDeleteAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri,
 	_, status, err := testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, st, err := testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
@@ -61,6 +73,12 @@ func badPermUpdateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri,
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, st, err := testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
 	_, status, err := testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -73,6 +91,12 @@ func badPermShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, t
 	_, status, err := testutil.TestPermShowAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
+	_, st, err := testutil.TestPermShowAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowAutoScalePolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {

--- a/mc/orm/cloudlet_mc2_test.go
+++ b/mc/orm/cloudlet_mc2_test.go
@@ -34,6 +34,12 @@ func badPermCreateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token,
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, st, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
 	_, status, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -46,6 +52,12 @@ func badPermDeleteCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token,
 	_, status, err := testutil.TestPermDeleteCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, st, err := testutil.TestPermDeleteCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
@@ -62,6 +74,12 @@ func badPermUpdateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token,
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, st, err := testutil.TestPermUpdateCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
 	_, status, err := testutil.TestPermUpdateCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -74,6 +92,12 @@ func badPermShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	_, status, err := testutil.TestPermShowCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Cloudlet)) {
+	_, st, err := testutil.TestPermShowCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
@@ -90,6 +114,12 @@ func badPermGetCloudletManifest(t *testing.T, mcClient *ormclient.Client, uri, t
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badGetCloudletManifest(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, st, err := testutil.TestPermGetCloudletManifest(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermGetCloudletManifest(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
 	_, status, err := testutil.TestPermGetCloudletManifest(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -102,6 +132,12 @@ func badPermGetCloudletProps(t *testing.T, mcClient *ormclient.Client, uri, toke
 	_, status, err := testutil.TestPermGetCloudletProps(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badGetCloudletProps(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletProps)) {
+	_, st, err := testutil.TestPermGetCloudletProps(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermGetCloudletProps(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletProps)) {
@@ -118,6 +154,12 @@ func badPermGetCloudletResourceQuotaProps(t *testing.T, mcClient *ormclient.Clie
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badGetCloudletResourceQuotaProps(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletResourceQuotaProps)) {
+	_, st, err := testutil.TestPermGetCloudletResourceQuotaProps(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermGetCloudletResourceQuotaProps(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResourceQuotaProps)) {
 	_, status, err := testutil.TestPermGetCloudletResourceQuotaProps(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -130,6 +172,12 @@ func badPermGetCloudletResourceUsage(t *testing.T, mcClient *ormclient.Client, u
 	_, status, err := testutil.TestPermGetCloudletResourceUsage(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badGetCloudletResourceUsage(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletResourceUsage)) {
+	_, st, err := testutil.TestPermGetCloudletResourceUsage(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermGetCloudletResourceUsage(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResourceUsage)) {
@@ -146,6 +194,12 @@ func badPermAddCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri,
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badAddCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletResMap)) {
+	_, st, err := testutil.TestPermAddCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermAddCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) {
 	_, status, err := testutil.TestPermAddCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -158,6 +212,12 @@ func badPermRemoveCloudletResMapping(t *testing.T, mcClient *ormclient.Client, u
 	_, status, err := testutil.TestPermRemoveCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRemoveCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletResMap)) {
+	_, st, err := testutil.TestPermRemoveCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRemoveCloudletResMapping(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) {
@@ -174,6 +234,12 @@ func badPermFindFlavorMatch(t *testing.T, mcClient *ormclient.Client, uri, token
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badFindFlavorMatch(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.FlavorMatch)) {
+	_, st, err := testutil.TestPermFindFlavorMatch(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermFindFlavorMatch(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.FlavorMatch)) {
 	_, status, err := testutil.TestPermFindFlavorMatch(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -188,6 +254,12 @@ func badPermRevokeAccessKey(t *testing.T, mcClient *ormclient.Client, uri, token
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badRevokeAccessKey(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, st, err := testutil.TestPermRevokeAccessKey(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermRevokeAccessKey(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
 	_, status, err := testutil.TestPermRevokeAccessKey(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -200,6 +272,12 @@ func badPermGenerateAccessKey(t *testing.T, mcClient *ormclient.Client, uri, tok
 	_, status, err := testutil.TestPermGenerateAccessKey(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badGenerateAccessKey(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, st, err := testutil.TestPermGenerateAccessKey(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermGenerateAccessKey(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
@@ -283,6 +361,12 @@ func badPermShowCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, toke
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, st, err := testutil.TestPermShowCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
 	_, status, err := testutil.TestPermShowCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -297,6 +381,12 @@ func badPermInjectCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, to
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badInjectCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, st, err := testutil.TestPermInjectCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermInjectCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
 	_, status, err := testutil.TestPermInjectCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -309,6 +399,12 @@ func badPermEvictCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, tok
 	_, status, err := testutil.TestPermEvictCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badEvictCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletInfo)) {
+	_, st, err := testutil.TestPermEvictCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermEvictCloudletInfo(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {

--- a/mc/orm/cloudletpool_mc2_test.go
+++ b/mc/orm/cloudletpool_mc2_test.go
@@ -34,6 +34,12 @@ func badPermCreateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, to
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, st, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
 	_, status, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -46,6 +52,12 @@ func badPermDeleteCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, to
 	_, status, err := testutil.TestPermDeleteCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, st, err := testutil.TestPermDeleteCloudletPool(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
@@ -62,6 +74,12 @@ func badPermUpdateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, to
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, st, err := testutil.TestPermUpdateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
 	_, status, err := testutil.TestPermUpdateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -74,6 +92,12 @@ func badPermShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, toke
 	_, status, err := testutil.TestPermShowCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletPool)) {
+	_, st, err := testutil.TestPermShowCloudletPool(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowCloudletPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
@@ -90,6 +114,12 @@ func badPermAddCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri,
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badAddCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
+	_, st, err := testutil.TestPermAddCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermAddCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
 	_, status, err := testutil.TestPermAddCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -102,6 +132,12 @@ func badPermRemoveCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, u
 	_, status, err := testutil.TestPermRemoveCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRemoveCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
+	_, st, err := testutil.TestPermRemoveCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRemoveCloudletPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) {

--- a/mc/orm/clusterinst_mc2_test.go
+++ b/mc/orm/clusterinst_mc2_test.go
@@ -34,6 +34,12 @@ func badPermCreateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, st, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
 	_, status, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
@@ -46,6 +52,12 @@ func badPermDeleteClusterInst(t *testing.T, mcClient *ormclient.Client, uri, tok
 	_, status, err := testutil.TestPermDeleteClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, st, err := testutil.TestPermDeleteClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
@@ -62,6 +74,12 @@ func badPermUpdateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, st, err := testutil.TestPermUpdateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
 	_, status, err := testutil.TestPermUpdateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.Nil(t, err)
@@ -76,6 +94,12 @@ func badPermShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ClusterInst)) {
+	_, st, err := testutil.TestPermShowClusterInst(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterInst)) {
 	_, status, err := testutil.TestPermShowClusterInst(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -88,6 +112,12 @@ func badPermDeleteIdleReservableClusterInsts(t *testing.T, mcClient *ormclient.C
 	_, status, err := testutil.TestPermDeleteIdleReservableClusterInsts(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteIdleReservableClusterInsts(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.IdleReservableClusterInsts)) {
+	_, st, err := testutil.TestPermDeleteIdleReservableClusterInsts(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteIdleReservableClusterInsts(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.IdleReservableClusterInsts)) {

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -248,10 +248,23 @@ func TestController(t *testing.T) {
 	goodPermTestAppInst(t, mcClient, uri, tokenAd, ctrl.Region, org2, tc3, dcnt)
 	goodPermTestClusterInst(t, mcClient, uri, tokenAd, ctrl.Region, org1, tc3, dcnt)
 	goodPermTestClusterInst(t, mcClient, uri, tokenAd, ctrl.Region, org2, tc3, dcnt)
-	goodPermTestCloudletPool(t, mcClient, uri, tokenAd, ctrl.Region, org1, dcnt)
-	goodPermTestCloudletPool(t, mcClient, uri, tokenAd, ctrl.Region, org2, dcnt)
+	goodPermTestCloudletPool(t, mcClient, uri, tokenAd, ctrl.Region, org3, dcnt)
+	goodPermTestCloudletPool(t, mcClient, uri, tokenAd, ctrl.Region, org4, dcnt)
 	goodPermTestAutoProvPolicy(t, mcClient, uri, tokenAd, ctrl.Region, org1, dcnt)
 	goodPermTestAutoProvPolicy(t, mcClient, uri, tokenAd, ctrl.Region, org2, dcnt)
+
+	// some create actions are restricted by org type, even for admin
+	sbr := http.StatusBadRequest
+	badCreateCloudlet(t, mcClient, uri, tokenAd, ctrl.Region, org1, sbr)
+	badCreateCloudlet(t, mcClient, uri, tokenAd, ctrl.Region, org2, sbr)
+	badCreateApp(t, mcClient, uri, tokenAd, ctrl.Region, org3, sbr)
+	badCreateApp(t, mcClient, uri, tokenAd, ctrl.Region, org4, sbr)
+	badCreateAppInst(t, mcClient, uri, tokenAd, ctrl.Region, org3, sbr, tc3)
+	badCreateAppInst(t, mcClient, uri, tokenAd, ctrl.Region, org4, sbr, tc3)
+	badCreateClusterInst(t, mcClient, uri, tokenAd, ctrl.Region, org3, sbr, tc3)
+	badCreateClusterInst(t, mcClient, uri, tokenAd, ctrl.Region, org4, sbr, tc3)
+	badCreateCloudletPool(t, mcClient, uri, tokenAd, ctrl.Region, org1, sbr)
+	badCreateCloudletPool(t, mcClient, uri, tokenAd, ctrl.Region, org2, sbr)
 
 	// test non-existent org check
 	// (no check by admin because it returns a different error code)

--- a/mc/orm/debug_mc2_test.go
+++ b/mc/orm/debug_mc2_test.go
@@ -33,6 +33,12 @@ func badPermEnableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badEnableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, st, err := testutil.TestPermEnableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermEnableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
 	_, status, err := testutil.TestPermEnableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -45,6 +51,12 @@ func badPermDisableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, to
 	_, status, err := testutil.TestPermDisableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDisableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, st, err := testutil.TestPermDisableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDisableDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
@@ -61,6 +73,12 @@ func badPermShowDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, st, err := testutil.TestPermShowDebugLevels(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowDebugLevels(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
 	_, status, err := testutil.TestPermShowDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -73,6 +91,12 @@ func badPermRunDebug(t *testing.T, mcClient *ormclient.Client, uri, token, regio
 	_, status, err := testutil.TestPermRunDebug(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRunDebug(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.DebugRequest)) {
+	_, st, err := testutil.TestPermRunDebug(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRunDebug(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {

--- a/mc/orm/device_mc2_test.go
+++ b/mc/orm/device_mc2_test.go
@@ -34,6 +34,12 @@ func badPermInjectDevice(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badInjectDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Device)) {
+	_, st, err := testutil.TestPermInjectDevice(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermInjectDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
 	_, status, err := testutil.TestPermInjectDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -46,6 +52,12 @@ func badPermShowDevice(t *testing.T, mcClient *ormclient.Client, uri, token, reg
 	_, status, err := testutil.TestPermShowDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Device)) {
+	_, st, err := testutil.TestPermShowDevice(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
@@ -62,6 +74,12 @@ func badPermEvictDevice(t *testing.T, mcClient *ormclient.Client, uri, token, re
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badEvictDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Device)) {
+	_, st, err := testutil.TestPermEvictDevice(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermEvictDevice(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
 	_, status, err := testutil.TestPermEvictDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -74,6 +92,12 @@ func badPermShowDeviceReport(t *testing.T, mcClient *ormclient.Client, uri, toke
 	_, status, err := testutil.TestPermShowDeviceReport(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowDeviceReport(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.DeviceReport)) {
+	_, st, err := testutil.TestPermShowDeviceReport(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowDeviceReport(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DeviceReport)) {

--- a/mc/orm/exec_mc2_test.go
+++ b/mc/orm/exec_mc2_test.go
@@ -32,6 +32,12 @@ func badPermRunCommand(t *testing.T, mcClient *ormclient.Client, uri, token, reg
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badRunCommand(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, st, err := testutil.TestPermRunCommand(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermRunCommand(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
 	_, status, err := testutil.TestPermRunCommand(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -44,6 +50,12 @@ func badPermRunConsole(t *testing.T, mcClient *ormclient.Client, uri, token, reg
 	_, status, err := testutil.TestPermRunConsole(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRunConsole(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, st, err := testutil.TestPermRunConsole(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRunConsole(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
@@ -60,6 +72,12 @@ func badPermShowLogs(t *testing.T, mcClient *ormclient.Client, uri, token, regio
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowLogs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, st, err := testutil.TestPermShowLogs(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowLogs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
 	_, status, err := testutil.TestPermShowLogs(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -72,6 +90,12 @@ func badPermAccessCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token,
 	_, status, err := testutil.TestPermAccessCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badAccessCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ExecRequest)) {
+	_, st, err := testutil.TestPermAccessCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermAccessCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {

--- a/mc/orm/flavor_mc2_test.go
+++ b/mc/orm/flavor_mc2_test.go
@@ -33,6 +33,12 @@ func badPermCreateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Flavor)) {
+	_, st, err := testutil.TestPermCreateFlavor(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermCreateFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -45,6 +51,12 @@ func badPermDeleteFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	_, status, err := testutil.TestPermDeleteFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Flavor)) {
+	_, st, err := testutil.TestPermDeleteFlavor(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
@@ -61,6 +73,12 @@ func badPermUpdateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Flavor)) {
+	_, st, err := testutil.TestPermUpdateFlavor(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermUpdateFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -73,6 +91,12 @@ func badPermShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, reg
 	_, status, err := testutil.TestPermShowFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Flavor)) {
+	_, st, err := testutil.TestPermShowFlavor(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowFlavor(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
@@ -89,6 +113,12 @@ func badPermAddFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badAddFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Flavor)) {
+	_, st, err := testutil.TestPermAddFlavorRes(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermAddFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermAddFlavorRes(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -101,6 +131,12 @@ func badPermRemoveFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token
 	_, status, err := testutil.TestPermRemoveFlavorRes(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRemoveFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Flavor)) {
+	_, st, err := testutil.TestPermRemoveFlavorRes(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRemoveFlavorRes(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {

--- a/mc/orm/node_mc2_test.go
+++ b/mc/orm/node_mc2_test.go
@@ -33,6 +33,12 @@ func badPermShowNode(t *testing.T, mcClient *ormclient.Client, uri, token, regio
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowNode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Node)) {
+	_, st, err := testutil.TestPermShowNode(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowNode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Node)) {
 	_, status, err := testutil.TestPermShowNode(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)

--- a/mc/orm/operatorcode_mc2_test.go
+++ b/mc/orm/operatorcode_mc2_test.go
@@ -33,6 +33,12 @@ func badPermCreateOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, to
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, st, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
 	_, status, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -47,6 +53,12 @@ func badPermDeleteOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, to
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badDeleteOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, st, err := testutil.TestPermDeleteOperatorCode(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermDeleteOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
 	_, status, err := testutil.TestPermDeleteOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -59,6 +71,12 @@ func badPermShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, toke
 	_, status, err := testutil.TestPermShowOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.OperatorCode)) {
+	_, st, err := testutil.TestPermShowOperatorCode(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowOperatorCode(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {

--- a/mc/orm/refs_mc2_test.go
+++ b/mc/orm/refs_mc2_test.go
@@ -32,6 +32,12 @@ func badPermShowCloudletRefs(t *testing.T, mcClient *ormclient.Client, uri, toke
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowCloudletRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletRefs)) {
+	_, st, err := testutil.TestPermShowCloudletRefs(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowCloudletRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletRefs)) {
 	_, status, err := testutil.TestPermShowCloudletRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -46,6 +52,12 @@ func badPermShowClusterRefs(t *testing.T, mcClient *ormclient.Client, uri, token
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badShowClusterRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ClusterRefs)) {
+	_, st, err := testutil.TestPermShowClusterRefs(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermShowClusterRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterRefs)) {
 	_, status, err := testutil.TestPermShowClusterRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -58,6 +70,12 @@ func badPermShowAppInstRefs(t *testing.T, mcClient *ormclient.Client, uri, token
 	_, status, err := testutil.TestPermShowAppInstRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowAppInstRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AppInstRefs)) {
+	_, st, err := testutil.TestPermShowAppInstRefs(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowAppInstRefs(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstRefs)) {

--- a/mc/orm/restagtable_mc2_test.go
+++ b/mc/orm/restagtable_mc2_test.go
@@ -33,6 +33,12 @@ func badPermCreateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, st, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -45,6 +51,12 @@ func badPermDeleteResTagTable(t *testing.T, mcClient *ormclient.Client, uri, tok
 	_, status, err := testutil.TestPermDeleteResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, st, err := testutil.TestPermDeleteResTagTable(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
@@ -61,6 +73,12 @@ func badPermUpdateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, st, err := testutil.TestPermUpdateResTagTable(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermUpdateResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -73,6 +91,12 @@ func badPermShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token
 	_, status, err := testutil.TestPermShowResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, st, err := testutil.TestPermShowResTagTable(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
@@ -89,6 +113,12 @@ func badPermAddResTag(t *testing.T, mcClient *ormclient.Client, uri, token, regi
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badAddResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, st, err := testutil.TestPermAddResTag(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermAddResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermAddResTag(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -103,6 +133,12 @@ func badPermRemoveResTag(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badRemoveResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ResTagTable)) {
+	_, st, err := testutil.TestPermRemoveResTag(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermRemoveResTag(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermRemoveResTag(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -115,6 +151,12 @@ func badPermGetResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token,
 	_, status, err := testutil.TestPermGetResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badGetResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ResTagTableKey)) {
+	_, st, err := testutil.TestPermGetResTagTable(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermGetResTagTable(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTableKey)) {

--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -55,6 +55,8 @@ var OperatorResources = []string{
 	ResourceCloudletPools,
 	ResourceAlert,
 }
+var DeveloperResourcesMap map[string]struct{}
+var OperatorResourcesMap map[string]struct{}
 
 // built-in roles
 const RoleDeveloperManager = "DeveloperManager"
@@ -69,6 +71,17 @@ const RoleAdminViewer = "AdminViewer"
 const RoleBillingManager = "BillingManager"
 
 var AdminRoleID int64
+
+func init() {
+	DeveloperResourcesMap = make(map[string]struct{})
+	OperatorResourcesMap = make(map[string]struct{})
+	for _, res := range DeveloperResources {
+		DeveloperResourcesMap[res] = struct{}{}
+	}
+	for _, res := range OperatorResources {
+		OperatorResourcesMap[res] = struct{}{}
+	}
+}
 
 func InitRolePerms(ctx context.Context) error {
 	log.SpanLog(ctx, log.DebugLevelApi, "init roleperms")

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -252,7 +252,7 @@ func TestServer(t *testing.T) {
 	// EC-31717: Test org exists func. Should be case sensitive, so looking
 	// for "devy" should fail (does not exist), and not hit a false
 	//  positive for org "DevY", which does exist.
-	err = checkRequiresOrg(ctx, "devy", false, false)
+	err = checkRequiresOrg(ctx, "devy", "", false, false)
 	require.NotNil(t, err, "devy should not exist")
 
 	// create new admin user

--- a/mc/orm/settings_mc2_test.go
+++ b/mc/orm/settings_mc2_test.go
@@ -33,6 +33,12 @@ func badPermUpdateSettings(t *testing.T, mcClient *ormclient.Client, uri, token,
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Settings)) {
+	_, st, err := testutil.TestPermUpdateSettings(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
 	_, status, err := testutil.TestPermUpdateSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -47,6 +53,12 @@ func badPermResetSettings(t *testing.T, mcClient *ormclient.Client, uri, token, 
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badResetSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Settings)) {
+	_, st, err := testutil.TestPermResetSettings(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermResetSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
 	_, status, err := testutil.TestPermResetSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -59,6 +71,12 @@ func badPermShowSettings(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	_, status, err := testutil.TestPermShowSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.Settings)) {
+	_, st, err := testutil.TestPermShowSettings(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowSettings(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {

--- a/mc/orm/stream_mc2_test.go
+++ b/mc/orm/stream_mc2_test.go
@@ -33,6 +33,12 @@ func badPermStreamAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, 
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badStreamAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.AppInstKey)) {
+	_, st, err := testutil.TestPermStreamAppInst(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermStreamAppInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstKey)) {
 	_, status, err := testutil.TestPermStreamAppInst(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -47,6 +53,12 @@ func badPermStreamClusterInst(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badStreamClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.ClusterInstKey)) {
+	_, st, err := testutil.TestPermStreamClusterInst(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermStreamClusterInst(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterInstKey)) {
 	_, status, err := testutil.TestPermStreamClusterInst(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -59,6 +71,12 @@ func badPermStreamCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token,
 	_, status, err := testutil.TestPermStreamCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badStreamCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, st, err := testutil.TestPermStreamCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermStreamCloudlet(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {

--- a/mc/orm/trustpolicy_mc2_test.go
+++ b/mc/orm/trustpolicy_mc2_test.go
@@ -33,6 +33,12 @@ func badPermCreateTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.TrustPolicy)) {
+	_, st, err := testutil.TestPermCreateTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.TrustPolicy)) {
 	_, status, err := testutil.TestPermCreateTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -45,6 +51,12 @@ func badPermDeleteTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, tok
 	_, status, err := testutil.TestPermDeleteTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.TrustPolicy)) {
+	_, st, err := testutil.TestPermDeleteTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.TrustPolicy)) {
@@ -61,6 +73,12 @@ func badPermUpdateTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, tok
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.TrustPolicy)) {
+	_, st, err := testutil.TestPermUpdateTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.TrustPolicy)) {
 	_, status, err := testutil.TestPermUpdateTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -73,6 +91,12 @@ func badPermShowTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token
 	_, status, err := testutil.TestPermShowTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.TrustPolicy)) {
+	_, st, err := testutil.TestPermShowTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowTrustPolicy(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.TrustPolicy)) {

--- a/mc/orm/vmpool_mc2_test.go
+++ b/mc/orm/vmpool_mc2_test.go
@@ -35,6 +35,12 @@ func badPermCreateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badCreateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.VMPool)) {
+	_, st, err := testutil.TestPermCreateVMPool(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermCreateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
 	_, status, err := testutil.TestPermCreateVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -47,6 +53,12 @@ func badPermDeleteVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	_, status, err := testutil.TestPermDeleteVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badDeleteVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.VMPool)) {
+	_, st, err := testutil.TestPermDeleteVMPool(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermDeleteVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
@@ -63,6 +75,12 @@ func badPermUpdateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, r
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badUpdateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.VMPool)) {
+	_, st, err := testutil.TestPermUpdateVMPool(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermUpdateVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
 	_, status, err := testutil.TestPermUpdateVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -75,6 +93,12 @@ func badPermShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, reg
 	_, status, err := testutil.TestPermShowVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.VMPool)) {
+	_, st, err := testutil.TestPermShowVMPool(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermShowVMPool(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
@@ -91,6 +115,12 @@ func badPermAddVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func badAddVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.VMPoolMember)) {
+	_, st, err := testutil.TestPermAddVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPermAddVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) {
 	_, status, err := testutil.TestPermAddVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.Nil(t, err)
@@ -103,6 +133,12 @@ func badPermRemoveVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, to
 	_, status, err := testutil.TestPermRemoveVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badRemoveVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.VMPoolMember)) {
+	_, st, err := testutil.TestPermRemoveVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
 }
 
 func goodPermRemoveVMPoolMember(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) {

--- a/protoc-gen-mc2/genmc2.go
+++ b/protoc-gen-mc2/genmc2.go
@@ -739,6 +739,12 @@ func badPerm{{.MethodName}}(t *testing.T, mcClient *ormclient.Client, uri, token
 	require.Equal(t, http.StatusForbidden, status)
 }
 
+func bad{{.MethodName}}(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string, status int{{.TargetCloudletParam}}, modFuncs ...func(*edgeproto.{{.InName}})) {
+	_, st, err := testutil.TestPerm{{.MethodName}}(mcClient, uri, token, region, org{{.TargetCloudletArg}}, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
 func goodPerm{{.MethodName}}(t *testing.T, mcClient *ormclient.Client, uri, token, region, org string{{.TargetCloudletParam}}, modFuncs ...func(*edgeproto.{{.InName}})) {
 	_, status, err := testutil.TestPerm{{.MethodName}}(mcClient, uri, token, region, org{{.TargetCloudletArg}}, modFuncs...)
 	require.Nil(t, err)


### PR DESCRIPTION
Fixes some error messages
4674: The behavior of orgExists() changed recently, change checkRequiresOrg to deal with it
4676: Admin was being allowed to create a cloudlet when specifying a developer org as the cloudlet org. This is because restrictions for what resource (Cloudlet) can be done against what org are based on RBAC, and admin bypasses all that. Although we want to give admin broad powers, I didn't see any reason why it would make sense that an admin can create a Cloudlet on a developer org, or an App on an operator org. So, at least for create, when an org is required, we also check that org matches the correct type if the resource is specific to a typed role (developer/operator). This overlaps a bit with RBAC checks, but since it's built from the same source (the roles code), I think it's ok.