### PR TITLE
EDGECLOUD-4689 return err if delete cloudletpool not found

### DIFF
--- a/mc/orm/orgcloudletpools.go
+++ b/mc/orm/orgcloudletpools.go
@@ -261,9 +261,12 @@ func deleteOrgCloudletPool(ctx context.Context, op *ormapi.OrgCloudletPool) erro
 		op.CloudletPoolOrg,
 		op.Type,
 	}
-	err := db.Delete(op, args...).Error
-	if err != nil {
-		return dbErr(err)
+	res := db.Delete(op, args...)
+	if res.Error != nil {
+		return dbErr(res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("%s not found", op.Type)
 	}
 	return nil
 }


### PR DESCRIPTION
Return error message if trying to delete non-existent cloudletpool invitation/confirmation.