### PR TITLE
fixes

### DIFF
--- a/crm-platforms/vcd/vcd-vapp.go
+++ b/crm-platforms/vcd/vcd-vapp.go
@@ -348,6 +348,7 @@ func (v *VcdPlatform) populateProductSection(ctx context.Context, vm *govcd.VM, 
 	}
 	guestCustomSec.Enabled = TakeBoolPointer(true)
 	guestCustomSec.ComputerName = vmparams.HostName
+	guestCustomSec.AdminPasswordEnabled = TakeBoolPointer(false) // we have our own baseimage password
 	_, err = vm.SetGuestCustomizationSection(guestCustomSec)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "SetGuestCustomizationSection failed", "err", err)

--- a/crm-platforms/vsphere/vsphere-security.go
+++ b/crm-platforms/vsphere/vsphere-security.go
@@ -29,11 +29,6 @@ func (v *VSpherePlatform) PrepareRootLB(ctx context.Context, client ssh.Client, 
 	log.SpanLog(ctx, log.DebugLevelInfra, "PrepareRootLB", "rootLBName", rootLBName)
 	// configure iptables based security
 	// allow our external vsphere network
-	sshCidrsAllowed := []string{}
-	externalNet, err := v.GetExternalIpNetworkCidr(ctx)
-	if err != nil {
-		return err
-	}
-	sshCidrsAllowed = append(sshCidrsAllowed, externalNet)
+	sshCidrsAllowed := []string{infracommon.RemoteCidrAll}
 	return v.vmProperties.SetupIptablesRulesForRootLB(ctx, client, sshCidrsAllowed, TrustPolicy)
 }

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ replace (
 	github.com/Sirupsen/logrus v1.6.0 => github.com/sirupsen/logrus v1.6.0
 )
 
-replace github.com/vmware/go-vcloud-director/v2 v2.11.0 => github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241
+replace github.com/vmware/go-vcloud-director/v2 v2.11.0 => github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241.1
 
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.1
 

--- a/go.sum
+++ b/go.sum
@@ -600,6 +600,8 @@ github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mjibson/esc v0.2.0/go.mod h1:9Hw9gxxfHulMF5OJKCyhYD7PzlSdhzXyaGEBRPH1OPs=
 github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241 h1:RSm6957vFVXbyaqiKC3V1dSpIJOS+mF1H6FK4YjnN0A=
 github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
+github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241.1 h1:nd623YPZD0Td/bMO5RG6cwb+TRiRi4YYQzmHVZcyyF0=
+github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241.1/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/mobiledgex/golang-ssh v0.0.10 h1:GwcGZGAsKkC4XgIDQ15+XbDWkpGZM8tHbT/6YOYrCDo=
 github.com/mobiledgex/golang-ssh v0.0.10/go.mod h1:lOpuGpjEhPMO4gxtlLkeC04vN+pB1xmZsYeQZWg0mMI=
 github.com/mobiledgex/jaeger v1.13.1 h1:ccldpM70eSW7JLCKhv+cht4OVIdp/wjdioegeWOk4Zc=


### PR DESCRIPTION
EDGECLOUD-4695
- Fix shared VCD client code which was not accounting for the fact that when it runs from the controller, there are multiple cloudlets possible, each of which may have different token schemes.  So the global client object is replaced with a map

EDGECLOUD-4696
- If a rootLB is unreachable for whatever reason (powered down, IP address lost, VM messed up, whatever) the cloudlet init fails in VCD because ConfigureCloudletSecurityRules is unable to write the iptables for that VM.  So for cases in which we have iptables based firewall, treat ConfigureCloudletSecurityRules failure as non-fatal but generate an event.  This event we may make into an alert port 241HF1

Other:
- open SSH port to all remote destinations for VCD and vSphere.  We do this already for OpenStack
- Tell VCD not to replace our vault-generated baseimage password with a random one so we can use the console with the normal password (plus TOTP code of course)
- pickup latest go-vcloud-director release 