### PR TITLE
Gitlab version bumps

### DIFF
--- a/ansible/development/list
+++ b/ansible/development/list
@@ -26,7 +26,7 @@ alertmanager_hostname=alertmanager-{{ deploy_environ }}.mobiledgex.net
 influxdb_backup_disabled=true
 etcd_quota_backend="150 MB"
 etcd_auto_compaction_retention=2
-gitlab_version=13.5.7-ee.0
+gitlab_version=13.8.7-ee.0
 
 [notifyroot]
 notifyroot-dev.mobiledgex.net

--- a/ansible/qa/list
+++ b/ansible/qa/list
@@ -30,7 +30,7 @@ etcd_auto_compaction_retention=2
 artifactory_fqdn=https://artifactory-qa.mobiledgex.net/artifactory/
 cloudlet_vm_path=https://artifactory-qa.mobiledgex.net/artifactory/baseimages
 controller_replicas=2
-gitlab_version=13.5.7-ee.0
+gitlab_version=13.8.7-ee.0
 
 [notifyroot]
 notifyroot-qa.mobiledgex.net

--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1,3 +1,3 @@
-gitlab_version: 12.10.14-ee.0
+gitlab_version: 13.5.7-ee.0
 gitlab_force_reconfigure: false
 gitlab_slack_notify_image_version: 2019-07-26

--- a/ansible/staging/list
+++ b/ansible/staging/list
@@ -27,7 +27,7 @@ console_prod=yes
 alertmanager_hostname=alertmanager-{{ deploy_environ }}.mobiledgex.net
 influxdb_backup_disabled=true
 controller_replicas=2
-gitlab_version=13.5.7-ee.0
+gitlab_version=13.8.7-ee.0
 
 [notifyroot]
 notifyroot-stage.mobiledgex.net


### PR DESCRIPTION
Default is deliberately a release behind at 13.5.7-ee.0.