### PR TITLE
EDGECLOUD-4643: undeploy vapp regardless of power state

### DIFF
--- a/crm-platforms/vcd/vcd-vapp.go
+++ b/crm-platforms/vcd/vcd-vapp.go
@@ -219,18 +219,15 @@ func (v *VcdPlatform) DeleteVapp(ctx context.Context, vapp *govcd.VApp, vcdClien
 	if err != nil {
 		return err
 	}
-	if vappStatus != "POWERED_OFF" {
-		task, err := vapp.Undeploy()
-		if err != nil {
-			return err
-		}
-		err = task.WaitTaskCompletion()
-		if err != nil {
-			return err
-		}
-		log.SpanLog(ctx, log.DebugLevelInfra, "DeleteVapp undeployed", "Vapp", vappName, "status", vappStatus)
+	task, err := vapp.Undeploy()
+	if err != nil {
+		return err
 	}
-
+	err = task.WaitTaskCompletion()
+	if err != nil {
+		return err
+	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "DeleteVapp undeployed", "Vapp", vappName, "status", vappStatus)
 	// If GetVappIsoNetwork actually fails
 	// don't fail the delete cluster operation here.
 	netName, err := v.GetVappIsoNetwork(ctx, vdc, vapp)
@@ -268,12 +265,12 @@ func (v *VcdPlatform) DeleteVapp(ctx context.Context, vapp *govcd.VApp, vcdClien
 					log.SpanLog(ctx, log.DebugLevelInfra, "DeleteVapp wait for PowerOff failed", "vm", vmName, "error", err)
 					return err
 				}
-
-				err = vm.Delete()
-				if err != nil {
-					log.SpanLog(ctx, log.DebugLevelInfra, "DeleteVapp PowerOff failed", "vm", vmName, "error", err)
-					return err
-				}
+			}
+			log.SpanLog(ctx, log.DebugLevelInfra, "DeleteVapp delete powered off", "vm", vmName)
+			err = vm.Delete()
+			if err != nil {
+				log.SpanLog(ctx, log.DebugLevelInfra, "DeleteVapp PowerOff failed", "vm", vmName, "error", err)
+				return err
 			}
 		}
 		task, err := vapp.RemoveAllNetworks()
@@ -313,7 +310,7 @@ func (v *VcdPlatform) DeleteVapp(ctx context.Context, vapp *govcd.VApp, vcdClien
 		log.SpanLog(ctx, log.DebugLevelInfra, "DeleteVapp GetVappIsoNetwork failed ignoring", "vapp", vappName, "netName", netName, "err", err)
 	}
 
-	task, err := vapp.Delete()
+	task, err = vapp.Delete()
 	if err != nil {
 		return err
 	}

--- a/crm-platforms/vcd/vcd_vapp_test.go
+++ b/crm-platforms/vcd/vcd_vapp_test.go
@@ -569,6 +569,18 @@ func testDeleteVApp(t *testing.T, ctx context.Context, name string) error {
 			fmt.Printf("Error waiting undeploy of the vapp first %s \n", name)
 			return err
 		}
+	} else {
+		task, err := vapp.Undeploy()
+		if err != nil {
+			fmt.Printf("Error from vapp.Undploy the vapp  as : %s\n", err.Error())
+			return err
+		}
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			fmt.Printf("Error waiting undeploy of the vapp first %s \n", name)
+			return err
+		}
+
 	}
 	vappStatus, err = vapp.GetStatus()
 


### PR DESCRIPTION
Undeploy vapp.
Delete VM explicitly. 