### PR TITLE
vcd fixes for TEF vCD

### DIFF
--- a/crm-platforms/vcd/vcd-vm.go
+++ b/crm-platforms/vcd/vcd-vm.go
@@ -953,12 +953,11 @@ func (v *VcdPlatform) GetVMAddresses(ctx context.Context, vm *govcd.VM, vcdClien
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetVMAddresses", "vmname", vm.VM.Name)
 	var serverIPs []vmlayer.ServerIP
-	if vm == nil {
+	if vm == nil || vm.VM == nil || vm.VM.NetworkConnectionSection == nil {
 		return serverIPs, fmt.Errorf("Nil vm received")
 	}
 	vmName := vm.VM.Name
 	//parentVapp, err := vm.GetParentVApp()
-
 	connections := vm.VM.NetworkConnectionSection.NetworkConnection
 
 	for _, connection := range connections {
@@ -1204,7 +1203,10 @@ func (v *VcdPlatform) addNewVMRegenUuid(vapp *govcd.VApp, name string, vappTempl
 	// Inject network config
 	vAppComposition.SourcedItem.InstantiationParams.NetworkConnectionSection = network
 
-	apiEndpoint, _ := url.ParseRequestURI(vapp.VApp.HREF)
+	apiEndpoint, err := url.ParseRequestURI(vapp.VApp.HREF)
+	if err != nil {
+		return govcd.Task{}, fmt.Errorf("Error in addNewVMRegenUuid %v", err)
+	}
 	apiEndpoint.Path += "/action/recomposeVApp"
 
 	// Return the task

--- a/crm-platforms/vcd/vcd.go
+++ b/crm-platforms/vcd/vcd.go
@@ -248,7 +248,7 @@ func (v *VcdPlatform) GetServerDetail(ctx context.Context, serverName string) (*
 	vm, err := v.FindVMByName(ctx, serverName, vcdClient)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "GetServerDetail not found", "vmname", serverName)
-		return nil, err
+		return nil, fmt.Errorf(vmlayer.ServerDoesNotExistError)
 	}
 	detail := vmlayer.ServerDetail{}
 	detail.Name = vm.VM.Name


### PR DESCRIPTION
Address the following for TEF vCD

- I got a crash once out of GetVMAddresses, due to some other weird error conditions.  Fix that rare crash
- fix other weird random in addNewVMRegenUuid 
- Address a problem due to the fact that shepherd starts at basically the same time as CRM, but cannot really do anything until CRM has created the shared rootLb and some other stuff.  This results in shepherd failing initialization a bunch of times and restarting until CRM is ready.  This is normally no big deal, but in TEF, each time shepherd starts, it gets a new oauth token.  TEF apparently tracks how many of these tokens are given out, and starts revoking older tokens.  The end result is CRM eventually is unable to run APIs due to shepherd restarts.  Solution is to 1) let shepherd wait for the rootLb to be ready before proceeding and 2) delay shepherd from existing if init fails to slow down its restart loop 
- also have VCD code return ServerDoesNotExistError to fix another cleanup issue