### PR TITLE
edgecloud-4613: add show nonVmApps flag to mcctl

### DIFF
--- a/mc/mcctl/ormctl/usage.go
+++ b/mc/mcctl/ormctl/usage.go
@@ -124,4 +124,5 @@ var CloudletPoolUsageComments = map[string]string{
 	"cloudletpoolorg": "Organization or Company Name that a Operator is part of",
 	"starttime":       "Time to start displaying usage from",
 	"endtime":         "Time up to which to display usage",
+	"shownonvmapps":   "Display all appinsts instead of just vm based ones",
 }


### PR DESCRIPTION
added a new flag for cloudletpool usage `shownonvmapps` in a [previous pr](https://github.com/mobiledgex/edge-cloud-infra/pull/1389). Updated mcctl to reflect this change as well