### PR TITLE
EDGECLOUD-4760: Edgebox cloudlet bringup fails

### DIFF
--- a/crm-platforms/edgebox/edgebox.go
+++ b/crm-platforms/edgebox/edgebox.go
@@ -36,12 +36,10 @@ var edgeboxProps = map[string]*edgeproto.PropertyInfo{
 	"MEX_EDGEBOX_DOCKER_USER": &edgeproto.PropertyInfo{
 		Name:        "EdgeBox Docker Username",
 		Description: "Username to login to docker registry server",
-		Mandatory:   true,
 	},
 	"MEX_EDGEBOX_DOCKER_PASS": &edgeproto.PropertyInfo{
 		Name:        "EdgeBox Docker Password",
 		Description: "Password to login to docker registry server",
-		Mandatory:   true,
 		Secret:      true,
 	},
 }
@@ -50,6 +48,7 @@ func (e *EdgeboxPlatform) Init(ctx context.Context, platformConfig *platform.Pla
 	err := e.generic.Init(ctx, platformConfig, caches, updateCallback)
 	// Set the test Mode based on what is in PlatformConfig
 	infracommon.SetTestMode(platformConfig.TestMode)
+	infracommon.SetEdgeboxMode(true)
 
 	if err := e.commonPf.InitInfraCommon(ctx, platformConfig, edgeboxProps); err != nil {
 		return err

--- a/e2e-tests/setups/local_edgebox.yml
+++ b/e2e-tests/setups/local_edgebox.yml
@@ -61,7 +61,7 @@ controllers:
   notifyrootaddrs: "127.0.0.1:53001"
   vaultaddr: "http://127.0.0.1:8200"
   hostname: "127.0.0.1"
-  testmode: true
+  testmode: false
   checkpointinterval: 3m
   requirenotifyaccesskey: true
   envvars:

--- a/infracommon/common-platform.go
+++ b/infracommon/common-platform.go
@@ -30,6 +30,7 @@ type CommonPlatform struct {
 
 // Package level test mode variable
 var testMode = false
+var edgeboxMode = false
 
 func (c *CommonPlatform) InitInfraCommon(ctx context.Context, platformConfig *pf.PlatformConfig, platformSpecificProps map[string]*edgeproto.PropertyInfo) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "InitInfraCommon", "cloudletKey", platformConfig.CloudletKey)
@@ -54,7 +55,7 @@ func (c *CommonPlatform) InitInfraCommon(ctx context.Context, platformConfig *pf
 		return fmt.Errorf("unable to init Mapped IPs: %v", err)
 	}
 
-	if testMode {
+	if testMode || edgeboxMode {
 		return nil
 	}
 
@@ -104,6 +105,10 @@ func (c *CommonPlatform) GetCloudletDNSZone() string {
 
 func SetTestMode(tMode bool) {
 	testMode = tMode
+}
+
+func SetEdgeboxMode(mode bool) {
+	edgeboxMode = mode
 }
 
 // initMappedIPs takes the env var MEX_EXTERNAL_IP_MAP contents like:


### PR DESCRIPTION
* In my previous testing, `testMode` flag was set and hence I never encountered this issue. Removed it for edgebox, as everything should work locally.
* Added new flag `edgeboxMode` to skip chef related code
* Also, made docker creds optional, so that developer with only public docker image can still try out our platform