### PR TITLE
Show compatibility version as part of ShowOrgCloudletInfo for developers

### DIFF
--- a/mc/orm/orgcloudletpools.go
+++ b/mc/orm/orgcloudletpools.go
@@ -384,6 +384,7 @@ func ShowOrgCloudletInfo(c echo.Context) error {
 				CloudletInfo.MaintenanceState = output.MaintenanceState
 				CloudletInfo.TrustPolicyState = output.TrustPolicyState
 				CloudletInfo.ResourcesSnapshot = output.ResourcesSnapshot
+				CloudletInfo.CompatibilityVersion = output.CompatibilityVersion
 			}
 			show = append(show, CloudletInfo)
 		}


### PR DESCRIPTION
* This is required for UI to figure out the auto-cluster org to be set on AppInst creation