### PR TITLE
EDGECLOUD-4588  Pagerduty email notifcation needs format changes

### DIFF
--- a/ansible/roles/alertmanager/files/alertmanager.tmpl
+++ b/ansible/roles/alertmanager/files/alertmanager.tmpl
@@ -159,8 +159,9 @@ MobiledX Monitoring System: {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}
 {{ end }}
 {{ end }}
 
+# use description as the title of the alert, so no need to add "description" label, subsequently skip description annotation
 {{ define "pagerduty.instances" -}}
-{{ range . }}{{ range .Annotations.SortedPairs }}{{ .Name }} : {{ .Value }}
-{{ end }}Labels:
+{{ range . }}{{ .Annotations.title }} - {{ .Annotations.description }}
+Labels:
 {{ range .Labels.SortedPairs }} {{ .Name }} = {{ .Value }}
 {{ end }}{{ end }}{{ end }}

--- a/e2e-tests/data/alertmanager.tmpl
+++ b/e2e-tests/data/alertmanager.tmpl
@@ -161,8 +161,9 @@ MobiledX Monitoring System: {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}
 https://console.mobiledgex.net
 {{ end }}
 
+# use description as the title of the alert, so no need to add "description" label, subsequently skip description annotation
 {{ define "pagerduty.instances" -}}
-{{ range . }}{{ range .Annotations.SortedPairs }}{{ .Name }} : {{ .Value }}
-{{ end }}Labels:
+{{ range . }}{{ .Annotations.title }} - {{ .Annotations.description }}
+Labels:
 {{ range .Labels.SortedPairs }} {{ .Name }} = {{ .Value }}
 {{ end }}{{ end }}{{ end }}

--- a/e2e-tests/data/pagerdutydata_alert_firing.yml
+++ b/e2e-tests/data/pagerdutydata_alert_firing.yml
@@ -5,9 +5,8 @@
     source: MobiledgeX Monitoring
     severity: error
     customdetails:
-      alerts: |
-        description : Application server port is not responding
-        title : AppInstDown
+      firing: |
+        AppInstDown - Application server port is not responding
         Labels:
          alertname = AppInstDown
          app = someapplication1
@@ -20,6 +19,8 @@
          region = local
          scope = Application
          status = HealthCheckFailServerFail
+      numfiring: "1"
+      numresolved: "0"
   client: MobiledgeX Monitoring
   clienturl: |
     https://console.mobiledgex.net

--- a/e2e-tests/data/pagerdutydata_alert_resolved.yml
+++ b/e2e-tests/data/pagerdutydata_alert_resolved.yml
@@ -5,9 +5,8 @@
     source: MobiledgeX Monitoring
     severity: error
     customdetails:
-      alerts: |
-        description : Application server port is not responding
-        title : AppInstDown
+      firing: |
+        AppInstDown - Application server port is not responding
         Labels:
          alertname = AppInstDown
          app = someapplication1
@@ -20,6 +19,8 @@
          region = local
          scope = Application
          status = HealthCheckFailServerFail
+      numfiring: "1"
+      numresolved: "0"
   client: MobiledgeX Monitoring
   clienturl: |
     https://console.mobiledgex.net
@@ -30,9 +31,10 @@
     source: MobiledgeX Monitoring
     severity: error
     customdetails:
-      alerts: |
-        description : Application server port is not responding
-        title : AppInstDown
+      numfiring: "0"
+      numresolved: "1"
+      resolved: |
+        AppInstDown - Application server port is not responding
         Labels:
          alertname = AppInstDown
          app = someapplication1

--- a/mc/orm/alertmgr/alertmgr-vars.go
+++ b/mc/orm/alertmgr/alertmgr-vars.go
@@ -61,17 +61,11 @@ var (
 
 	alertmanagerConfigSlackIcon = "https://www.mobiledgex.com/img/logo.svg"
 
-	alertmanagerConfigPagerDutyAllAlertsDetails = `{{ template "pagerduty.instances" .Alerts.Firing }}{{ template "pagerduty.instances" .Alerts.Resolved }}`
-
 	alertmanagerConfigPagerDutyClient      = "MobiledgeX Monitoring"
 	alertmanagerConfigPagerDutyDescription = `{{ template "common.title" . }}`
 	alertmanagerConfigPagerDutyDetails     = map[string]string{
-		"alerts": alertmanagerConfigPagerDutyAllAlertsDetails,
-		// Need to reset default values, otherwise they get included in the notification
-		"firing":       "",
-		"resolved":     "",
-		"num_firing":   "",
-		"num_resolved": "",
+		"firing":   `{{ template "pagerduty.instances" .Alerts.Firing }}`,
+		"resolved": `{{ template "pagerduty.instances" .Alerts.Resolved }}`,
 	}
 
 	PagerDutyIntegrationKeyLen = 32


### PR DESCRIPTION
Reformatted pagerduty notification to use default details labels.
There is an issue being tracked on alertmanager  - https://github.com/prometheus/alertmanager/pull/2495, which we'll need in order to clean this up a bit more, but for now we will just reuse the existing default labels for pagerduty details.