### PR TITLE
edgecloud-4713: billing messages

### DIFF
--- a/mc/mcctl/ormctl/billingorg.go
+++ b/mc/mcctl/ormctl/billingorg.go
@@ -9,7 +9,7 @@ import (
 
 func GetBillingOrgCommand() *cobra.Command {
 	cmds := []*cli.Command{&cli.Command{
-		Use:          "validate",
+		Use:          "create",
 		Short:        "Set up a BillingOrganization and validate inputs",
 		RequiredArgs: "name type firstname lastname email",
 		OptionalArgs: "address address2 city country state postalcode phone paymenttype ccfirstname cclastname ccnumber ccexpmonth ccexpyear children",

--- a/mc/orm/billing_organization.go
+++ b/mc/orm/billing_organization.go
@@ -34,7 +34,7 @@ func CreateBillingOrg(c echo.Context) error {
 	span.SetTag("billing org", org.Name)
 
 	err = CreateBillingOrgObj(ctx, claims, &org)
-	return setReply(c, err, Msg("Billing Organization primed"))
+	return setReply(c, err, Msg("Billing Organization created"))
 }
 
 // Parent billing orgs will have a billing Group, self billing orgs will just use the existing developer group from the org
@@ -203,7 +203,7 @@ func UpdateAccountInfoObj(ctx context.Context, claims *UserClaims, account *bill
 		}
 	}
 	defer func() {
-		// if we reach here this is a big problem, that means the account was OK'ed by us earlier in primer and we validated it was successfully
+		// if we reach here this is a big problem, that means the account was OK'ed by us earlier in create and we validated it was successfully
 		// created in chargify, we need some sort of alert to have an admin go and manually delete the customer and sub from chargify
 		if reterr != nil {
 			bOrg.CreateInProgress = true

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -1778,9 +1778,9 @@ func testCreateBillingOrg(t *testing.T, mcClient *ormclient.Client, uri, token, 
 	}
 	acc := billing.AccountInfo{OrgName: org.Name}
 	status, err := mcClient.CreateBillingOrg(uri, token, &org)
-	require.Nil(t, err, "create billing org primer ", orgName)
+	require.Nil(t, err, "create billing org ", orgName)
 	require.Equal(t, http.StatusOK, status)
 	status, err = mcClient.UpdateAccountInfo(uri, token, &acc)
-	require.Nil(t, err, "create billing org primer ", orgName)
+	require.Nil(t, err, "update account info ", orgName)
 	require.Equal(t, http.StatusOK, status)
 }


### PR DESCRIPTION
overlooked a few changes when renaming things from `validate` to create, and also fixed up some messages to make more sense