### PR TITLE
Shepherd cache for platform metrics

### DIFF
--- a/infracommon/common-props.go
+++ b/infracommon/common-props.go
@@ -45,6 +45,12 @@ var InfraCommonProps = map[string]*edgeproto.PropertyInfo{
 		Name:        "CRM Gateway Address",
 		Description: "Required if infra API endpoint is completely isolated from external network",
 	},
+	"MEX_PLATFORM_STATS_MAX_CACHE_TIME": {
+		Name:        "Platform Stats Max Cache Time",
+		Description: "Maximum time to used cached platform stats if nothing changed, in seconds",
+		Internal:    true,
+		Value:       "3600",
+	},
 }
 
 func (ip *InfraProperties) GetCloudletCRMGatewayIPAndPort() (string, int) {
@@ -66,6 +72,18 @@ func (ip *InfraProperties) GetCloudletCRMGatewayIPAndPort() (string, int) {
 func GetVaultCloudletCommonPath(filePath string) string {
 	// TODO this path really should not be openstack
 	return fmt.Sprintf("/secret/data/cloudlet/openstack/%s", filePath)
+}
+
+func (ip *InfraProperties) GetPlatformStatsMaxCacheTime() (uint64, error) {
+	val, ok := ip.GetValue("MEX_PLATFORM_STATS_MAX_CACHE_TIME")
+	if !ok {
+		return 0, nil
+	}
+	v, err := strconv.ParseUint(val, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("ERROR: unable to parse MEX_PLATFORM_STATS_MAX_CACHE_TIME %s - %v", val, err)
+	}
+	return v, nil
 }
 
 type InfraProperties struct {


### PR DESCRIPTION
EDGECLOUD-4829

TEF is complaining that we are making too many API calls to their API GW even when there is no activity.   Shepherd platform stats which run every 15 seconds end up performing about 15 API calls resulting in a whopping 1 API call per second which is causing consternation.  If we have 2 cloudlets in their environment, their API GW will probably explode due to 2 HTTPS calls per second.

Fix here is to cache the platform stats for up to 1 hour by default, configurable via MEX_PLATFORM_STATS_MAX_CACHE_TIME or can be disabled by setting to 0.

If nothing changed from one run to the next of the worker thread, keep using the same platform metrics.   If there was some activity based on update callback, then get new metrics.