### PR TITLE
EDGECLOUD-4824: Fix edgebox appinst bringup from private registry

### DIFF
--- a/crm-platforms/edgebox/edgebox-cloudlet.go
+++ b/crm-platforms/edgebox/edgebox-cloudlet.go
@@ -32,6 +32,8 @@ func (e *EdgeboxPlatform) CreateCloudlet(ctx context.Context, cloudlet *edgeprot
 
 func (e *EdgeboxPlatform) UpdateCloudlet(ctx context.Context, cloudlet *edgeproto.Cloudlet, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "update cloudlet for edgebox")
+	// Update envvars
+	e.commonPf.Properties.UpdatePropsFromVars(ctx, cloudlet.EnvVar)
 	return nil
 }
 

--- a/infracommon/kubectl.go
+++ b/infracommon/kubectl.go
@@ -88,7 +88,7 @@ func CreateDockerRegistrySecret(ctx context.Context, client ssh.Client, kconf st
 	// may put multiple apps in the same ClusterInst and they may come
 	// from different registries.
 	cmd := fmt.Sprintf("kubectl create secret docker-registry %s "+
-		"--docker-server=%s --docker-username=%s --docker-password=%s "+
+		"--docker-server=%s --docker-username='%s' --docker-password='%s' "+
 		"--docker-email=mobiledgex@mobiledgex.com --kubeconfig=%s",
 		secretName, dockerServer, auth.Username, auth.Password,
 		kconf)


### PR DESCRIPTION
* Add hostname & port for creds obj
* Add quotes for kubectl secret username & password as it was causing problems with special characters in the password
* Support updating envvars for Edgebox cloudlet