### PR TITLE
Remove disk property from CRM

### DIFF
--- a/crm-platforms/openstack/openstack-cloudlet.go
+++ b/crm-platforms/openstack/openstack-cloudlet.go
@@ -179,8 +179,6 @@ func (o *OpenstackPlatform) GetCloudletInfraResourcesInfo(ctx context.Context) (
 	ramMax := uint64(0)
 	vcpusUsed := uint64(0)
 	vcpusMax := uint64(0)
-	diskUsed := uint64(0)
-	diskMax := uint64(0)
 	instancesUsed := uint64(0)
 	instancesMax := uint64(0)
 	fipsUsed := uint64(0)
@@ -195,10 +193,6 @@ func (o *OpenstackPlatform) GetCloudletInfraResourcesInfo(ctx context.Context) (
 			vcpusUsed = uint64(l.Value)
 		case "maxTotalCores":
 			vcpusMax = uint64(l.Value)
-		case "totalGigabytesUsed":
-			diskUsed = uint64(l.Value)
-		case "maxTotalVolumeGigabytes":
-			diskMax = uint64(l.Value)
 		case "totalInstancesUsed":
 			instancesUsed = uint64(l.Value)
 		case "maxTotalInstances":
@@ -220,12 +214,6 @@ func (o *OpenstackPlatform) GetCloudletInfraResourcesInfo(ctx context.Context) (
 			Name:          cloudcommon.ResourceVcpus,
 			Value:         vcpusUsed,
 			InfraMaxValue: vcpusMax,
-		},
-		edgeproto.InfraResource{
-			Name:          cloudcommon.ResourceDiskGb,
-			Value:         diskUsed,
-			InfraMaxValue: diskMax,
-			Units:         cloudcommon.ResourceDiskUnits,
 		},
 		edgeproto.InfraResource{
 			Name:          ResourceInstances,

--- a/e2e-tests/data/mc_user1_data_show.yml
+++ b/e2e-tests/data/mc_user1_data_show.yml
@@ -196,10 +196,6 @@ regiondata:
         - name: vCPUs
           value: 4
           inframaxvalue: 50
-        - name: Disk
-          value: 80
-          inframaxvalue: 5000
-          units: GB
         - name: External IPs
           value: 1
           inframaxvalue: 30
@@ -248,10 +244,6 @@ regiondata:
         - name: vCPUs
           value: 4
           inframaxvalue: 50
-        - name: Disk
-          value: 80
-          inframaxvalue: 5000
-          units: GB
         - name: External IPs
           value: 1
           inframaxvalue: 30
@@ -300,10 +292,6 @@ regiondata:
         - name: vCPUs
           value: 4
           inframaxvalue: 50
-        - name: Disk
-          value: 80
-          inframaxvalue: 5000
-          units: GB
         - name: External IPs
           value: 1
           inframaxvalue: 30
@@ -352,10 +340,6 @@ regiondata:
         - name: vCPUs
           value: 4
           inframaxvalue: 50
-        - name: Disk
-          value: 80
-          inframaxvalue: 5000
-          units: GB
         - name: External IPs
           value: 1
           inframaxvalue: 30
@@ -404,10 +388,6 @@ regiondata:
         - name: vCPUs
           value: 4
           inframaxvalue: 50
-        - name: Disk
-          value: 80
-          inframaxvalue: 5000
-          units: GB
         - name: External IPs
           value: 1
           inframaxvalue: 30
@@ -532,10 +512,6 @@ regiondata:
         - name: vCPUs
           value: 4
           inframaxvalue: 50
-        - name: Disk
-          value: 80
-          inframaxvalue: 5000
-          units: GB
         - name: External IPs
           value: 1
           inframaxvalue: 30
@@ -584,10 +560,6 @@ regiondata:
         - name: vCPUs
           value: 4
           inframaxvalue: 50
-        - name: Disk
-          value: 80
-          inframaxvalue: 5000
-          units: GB
         - name: External IPs
           value: 1
           inframaxvalue: 30
@@ -636,10 +608,6 @@ regiondata:
         - name: vCPUs
           value: 4
           inframaxvalue: 50
-        - name: Disk
-          value: 80
-          inframaxvalue: 5000
-          units: GB
         - name: External IPs
           value: 1
           inframaxvalue: 30

--- a/go.sum
+++ b/go.sum
@@ -608,6 +608,8 @@ github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241 h1:RSm6957vFVXbyaqiKC3V1
 github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241.1 h1:nd623YPZD0Td/bMO5RG6cwb+TRiRi4YYQzmHVZcyyF0=
 github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241.1/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
+github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241.2 h1:mmpYVq9BA9Ii7wD/Nzs1xiUkPYJlRDdc0i050bfzxZw=
+github.com/mobiledgex/go-vcloud-director/v2 v2.11.0-241.2/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/mobiledgex/golang-ssh v0.0.10 h1:GwcGZGAsKkC4XgIDQ15+XbDWkpGZM8tHbT/6YOYrCDo=
 github.com/mobiledgex/golang-ssh v0.0.10/go.mod h1:lOpuGpjEhPMO4gxtlLkeC04vN+pB1xmZsYeQZWg0mMI=
 github.com/mobiledgex/jaeger v1.13.1 h1:ccldpM70eSW7JLCKhv+cht4OVIdp/wjdioegeWOk4Zc=

--- a/mc/mcctl/ormctl/flavor.mc2.go
+++ b/mc/mcctl/ormctl/flavor.mc2.go
@@ -178,7 +178,7 @@ var FlavorComments = map[string]string{
 	"ram":       "RAM in megabytes",
 	"vcpus":     "Number of virtual CPUs",
 	"disk":      "Amount of disk space in gigabytes",
-	"optresmap": "Optional Resources request, key = [gpu, nas, nic] gpu kinds: [gpu, vgpu, pci] form: $resource=$kind:[$alias]$count ex: optresmap=gpu=vgpu:nvidia-63:1",
+	"optresmap": "Optional Resources request, key = gpu form: $resource=$kind:[$alias]$count ex: optresmap=gpu=vgpu:nvidia-63:1",
 }
 var FlavorSpecialArgs = map[string]string{
 	"flavor.fields":    "StringArray",

--- a/mc/mcctl/ormctl/vmpool.mc2.go
+++ b/mc/mcctl/ormctl/vmpool.mc2.go
@@ -388,7 +388,7 @@ var VMSpecComments = map[string]string{
 	"flavor.ram":       "RAM in megabytes",
 	"flavor.vcpus":     "Number of virtual CPUs",
 	"flavor.disk":      "Amount of disk space in gigabytes",
-	"flavor.optresmap": "Optional Resources request, key = [gpu, nas, nic] gpu kinds: [gpu, vgpu, pci] form: $resource=$kind:[$alias]$count ex: optresmap=gpu=vgpu:nvidia-63:1",
+	"flavor.optresmap": "Optional Resources request, key = gpu form: $resource=$kind:[$alias]$count ex: optresmap=gpu=vgpu:nvidia-63:1",
 }
 var VMSpecSpecialArgs = map[string]string{
 	"vmspec.flavor.fields":    "StringArray",


### PR DESCRIPTION
Fixes following issues:
* EDGECLOUD-4821: Controller should throw error while creating cloudlet with Disk as resource quota
* EDGECLOUD-4822: Remove Disk from getresourcequotaprops for PlatformTypeOpenstack/PlatformTypeFake
* EDGECLOUD-4823: Remove Disk from Resource Quota Properties for PlatformTypeOpenstack

My previous changes removed disk tracking from controller. This change removes the disk property from CRM as well
Corresponding edge-cloud changes: https://github.com/mobiledgex/edge-cloud/pull/1322