### PR TITLE
fix build failure undefined billing comments

### DIFF
--- a/billing/billing.go
+++ b/billing/billing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/vault"
 )
@@ -13,14 +14,6 @@ const CUSTOMER_TYPE_CHILD = "child"
 const CUSTOMER_TYPE_SELF = "self"
 const PAYMENT_TYPE_CC = "credit_card"
 const BillingTypeFake = "fake"
-
-type AccountInfo struct {
-	OrgName        string `gorm:"primary_key;type:citext"`
-	AccountId      string `json:",omitempty"`
-	SubscriptionId string `json:",omitempty"`
-	ParentId       string `json:",omitempty"`
-	Type           string `json:",omitempty"`
-}
 
 type CustomerDetails struct {
 	OrgName   string
@@ -203,17 +196,17 @@ type BillingService interface {
 	// The Billing service's type ie. "chargify" or "zuora"
 	GetType() string
 	// Create Customer, and fills out the accountInfo for that customer
-	ValidateCustomer(ctx context.Context, account *AccountInfo) error
+	ValidateCustomer(ctx context.Context, account *ormapi.AccountInfo) error
 	// Delete Customer
-	DeleteCustomer(ctx context.Context, account *AccountInfo) error
+	DeleteCustomer(ctx context.Context, account *ormapi.AccountInfo) error
 	// Update Customer
-	UpdateCustomer(ctx context.Context, account *AccountInfo, customerDetails *CustomerDetails) error
+	UpdateCustomer(ctx context.Context, account *ormapi.AccountInfo, customerDetails *CustomerDetails) error
 	// Add a child to a parent
-	AddChild(ctx context.Context, parentAccount, childAccount *AccountInfo, childDetails *CustomerDetails) error
+	AddChild(ctx context.Context, parentAccount, childAccount *ormapi.AccountInfo, childDetails *CustomerDetails) error
 	// Remove a child from a parent
-	RemoveChild(ctx context.Context, parent, child *AccountInfo) error
+	RemoveChild(ctx context.Context, parent, child *ormapi.AccountInfo) error
 	// Records usage
-	RecordUsage(ctx context.Context, account *AccountInfo, usageRecords []UsageRecord) error
+	RecordUsage(ctx context.Context, account *ormapi.AccountInfo, usageRecords []UsageRecord) error
 	// Grab invoice data
-	GetInvoice(ctx context.Context, account *AccountInfo, startDate, endDate string) ([]InvoiceData, error)
+	GetInvoice(ctx context.Context, account *ormapi.AccountInfo, startDate, endDate string) ([]InvoiceData, error)
 }

--- a/billing/chargify/invoice.go
+++ b/billing/chargify/invoice.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mobiledgex/edge-cloud-infra/billing"
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 )
 
 type invoiceResp struct {
@@ -22,7 +23,7 @@ type invoiceResp struct {
 
 var invoiceEndpoint = "/invoices.json"
 
-func (bs *BillingService) GetInvoice(ctx context.Context, account *billing.AccountInfo, startDate, endDate string) ([]billing.InvoiceData, error) {
+func (bs *BillingService) GetInvoice(ctx context.Context, account *ormapi.AccountInfo, startDate, endDate string) ([]billing.InvoiceData, error) {
 	base, err := url.Parse(invoiceEndpoint)
 	if err != nil {
 		return nil, err

--- a/billing/chargify/usage.go
+++ b/billing/chargify/usage.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/mobiledgex/edge-cloud-infra/billing"
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
 
-func (bs *BillingService) RecordUsage(ctx context.Context, account *billing.AccountInfo, usageRecords []billing.UsageRecord) error {
+func (bs *BillingService) RecordUsage(ctx context.Context, account *ormapi.AccountInfo, usageRecords []billing.UsageRecord) error {
 	for _, record := range usageRecords {
 		var memo string
 		var cloudlet *edgeproto.CloudletKey

--- a/billing/fakebilling/fakebilling.go
+++ b/billing/fakebilling/fakebilling.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/mobiledgex/edge-cloud-infra/billing"
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/vault"
 )
 
@@ -25,11 +26,11 @@ func (bs *BillingService) GetType() string {
 	return "fakebilling"
 }
 
-func (bs *BillingService) ValidateCustomer(ctx context.Context, account *billing.AccountInfo) error {
+func (bs *BillingService) ValidateCustomer(ctx context.Context, account *ormapi.AccountInfo) error {
 	return nil
 }
 
-func (bs *BillingService) CreateCustomer(ctx context.Context, customer *billing.CustomerDetails, account *billing.AccountInfo) error {
+func (bs *BillingService) CreateCustomer(ctx context.Context, customer *billing.CustomerDetails, account *ormapi.AccountInfo) error {
 	accMux.Lock()
 	account.AccountId = strconv.Itoa(accountCounter)
 	accountCounter = accountCounter + 1
@@ -53,28 +54,28 @@ func (bs *BillingService) CreateCustomer(ctx context.Context, customer *billing.
 	return nil
 }
 
-func (bs *BillingService) DeleteCustomer(ctx context.Context, account *billing.AccountInfo) error {
+func (bs *BillingService) DeleteCustomer(ctx context.Context, account *ormapi.AccountInfo) error {
 	return nil
 }
 
-func (bs *BillingService) UpdateCustomer(ctx context.Context, account *billing.AccountInfo, customerDetails *billing.CustomerDetails) error {
+func (bs *BillingService) UpdateCustomer(ctx context.Context, account *ormapi.AccountInfo, customerDetails *billing.CustomerDetails) error {
 	return nil
 }
 
-func (bs *BillingService) AddChild(ctx context.Context, parentAccount, childAccount *billing.AccountInfo, childDetails *billing.CustomerDetails) error {
+func (bs *BillingService) AddChild(ctx context.Context, parentAccount, childAccount *ormapi.AccountInfo, childDetails *billing.CustomerDetails) error {
 	bs.CreateCustomer(ctx, childDetails, childAccount)
 	childAccount.ParentId = parentAccount.AccountId
 	return nil
 }
 
-func (bs *BillingService) RemoveChild(ctx context.Context, parent, child *billing.AccountInfo) error {
+func (bs *BillingService) RemoveChild(ctx context.Context, parent, child *ormapi.AccountInfo) error {
 	return nil
 }
 
-func (bs *BillingService) RecordUsage(ctx context.Context, account *billing.AccountInfo, usageRecords []billing.UsageRecord) error {
+func (bs *BillingService) RecordUsage(ctx context.Context, account *ormapi.AccountInfo, usageRecords []billing.UsageRecord) error {
 	return nil
 }
 
-func (bs *BillingService) GetInvoice(ctx context.Context, account *billing.AccountInfo, startDate, endDate string) ([]billing.InvoiceData, error) {
+func (bs *BillingService) GetInvoice(ctx context.Context, account *ormapi.AccountInfo, startDate, endDate string) ([]billing.InvoiceData, error) {
 	return nil, nil
 }

--- a/mc/mcctl/cliwrapper/billingorg.go
+++ b/mc/mcctl/cliwrapper/billingorg.go
@@ -1,15 +1,16 @@
 package cliwrapper
 
-import "github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
-
-import "github.com/mobiledgex/edge-cloud-infra/billing"
+import (
+	"github.com/mobiledgex/edge-cloud-infra/billing"
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+)
 
 func (s *Client) CreateBillingOrg(uri, token string, org *ormapi.BillingOrganization) (int, error) {
 	args := []string{"billingorg", "create"}
 	return s.runObjs(uri, token, args, org, nil)
 }
 
-func (s *Client) UpdateAccountInfo(uri, token string, acc *billing.AccountInfo) (int, error) {
+func (s *Client) UpdateAccountInfo(uri, token string, acc *ormapi.AccountInfo) (int, error) {
 	args := []string{"billingorg", "updateaccountinfo"}
 	return s.runObjs(uri, token, args, acc, nil)
 }

--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -299,7 +299,7 @@ var AppComments = map[string]string{
 	"requiredoutboundconnections:#.port":     "TCP or UDP port",
 	"requiredoutboundconnections:#.remoteip": "remote IP X.X.X.X",
 	"allowserverless":                        "App is allowed to deploy as serverless containers",
-	"serverlessconfig.vcpus":                 "virtual CPUs allocation per container when serverless, may be fractional in increments of 0.001",
+	"serverlessconfig.vcpus":                 "Virtual CPUs allocation per container when serverless, may be fractional in increments of 0.001",
 	"serverlessconfig.ram":                   "RAM allocation in megabytes per container when serverless",
 	"serverlessconfig.minreplicas":           "Minimum number of replicas when serverless",
 }
@@ -319,7 +319,7 @@ var ServerlessConfigAliasArgs = []string{
 	"minreplicas=serverlessconfig.minreplicas",
 }
 var ServerlessConfigComments = map[string]string{
-	"vcpus":       "virtual CPUs allocation per container when serverless, may be fractional in increments of 0.001",
+	"vcpus":       "Virtual CPUs allocation per container when serverless, may be fractional in increments of 0.001",
 	"ram":         "RAM allocation in megabytes per container when serverless",
 	"minreplicas": "Minimum number of replicas when serverless",
 }

--- a/mc/mcctl/ormctl/billingorg.go
+++ b/mc/mcctl/ormctl/billingorg.go
@@ -21,7 +21,7 @@ func GetBillingOrgCommand() *cobra.Command {
 		Short:        "Commit a BillingOrganization after validating it with our payment platform",
 		RequiredArgs: "orgname accountid",
 		OptionalArgs: "subscriptionid",
-		ReqData:      &billing.AccountInfo{},
+		ReqData:      &ormapi.AccountInfo{},
 		Comments:     ormapi.AccountInfoComments,
 		Run:          runRest("/auth/billingorg/updateaccount"),
 	}, &cli.Command{
@@ -66,7 +66,7 @@ func GetBillingOrgCommand() *cobra.Command {
 		RequiredArgs: "name",
 		OptionalArgs: "startdate enddate",
 		ReqData:      &ormapi.InvoiceRequest{},
-		Comments:     ormapi.InvoiceComments,
+		Comments:     ormapi.InvoiceRequestComments,
 		ReplyData:    &[]billing.InvoiceData{},
 		Run:          runRest("/auth/billingorg/invoice"),
 	}}

--- a/mc/orm/billing_organization.go
+++ b/mc/orm/billing_organization.go
@@ -131,7 +131,7 @@ func createBillingAccount(ctx context.Context, info *ormapi.BillingOrganization)
 	if !billingEnabled(ctx) {
 		return nil
 	}
-	accountInfo := billing.AccountInfo{
+	accountInfo := ormapi.AccountInfo{
 		OrgName: info.Name,
 		Type:    info.Type,
 	}
@@ -154,7 +154,7 @@ func UpdateAccountInfo(c echo.Context) error {
 		return err
 	}
 	ctx := GetContext(c)
-	acc := billing.AccountInfo{}
+	acc := ormapi.AccountInfo{}
 	if err := c.Bind(&acc); err != nil {
 		return bindErr(c, err)
 	}
@@ -164,7 +164,7 @@ func UpdateAccountInfo(c echo.Context) error {
 	return setReply(c, err, Msg("Account Info Updated"))
 }
 
-func UpdateAccountInfoObj(ctx context.Context, claims *UserClaims, account *billing.AccountInfo) (reterr error) {
+func UpdateAccountInfoObj(ctx context.Context, claims *UserClaims, account *ormapi.AccountInfo) (reterr error) {
 	// TODO: remove this later, for now only mexadmin has the permission to create billingOrgs
 	roles, err := ShowUserRoleObj(ctx, claims.Username)
 	if err != nil {
@@ -646,12 +646,12 @@ func billingOrgExists(ctx context.Context, orgName string) (*ormapi.BillingOrgan
 	return &org, nil
 }
 
-func accountInfoExists(ctx context.Context, orgName string) (*billing.AccountInfo, error) {
-	lookup := billing.AccountInfo{
+func accountInfoExists(ctx context.Context, orgName string) (*ormapi.AccountInfo, error) {
+	lookup := ormapi.AccountInfo{
 		OrgName: orgName,
 	}
 	db := loggedDB(ctx)
-	info := billing.AccountInfo{}
+	info := ormapi.AccountInfo{}
 	res := db.Where(&lookup).First(&info)
 	if res.RecordNotFound() {
 		return nil, nil
@@ -694,11 +694,11 @@ func deleteBillingAccount(ctx context.Context, orgName, deleteType string) error
 	return nil
 }
 
-func GetAccountObj(ctx context.Context, orgName string) (*billing.AccountInfo, error) {
+func GetAccountObj(ctx context.Context, orgName string) (*ormapi.AccountInfo, error) {
 	if orgName == "" {
 		return nil, fmt.Errorf("no orgName specified")
 	}
-	acc := billing.AccountInfo{
+	acc := ormapi.AccountInfo{
 		OrgName: orgName,
 	}
 	db := loggedDB(ctx)
@@ -804,7 +804,7 @@ func linkChildAccount(ctx context.Context, parent *ormapi.BillingOrganization, c
 
 	// chargify (and zuora) requires you to have billToContact info even if you are linked to a parent
 	// so for now just use parent first and last name
-	childAccountInfo := billing.AccountInfo{OrgName: child}
+	childAccountInfo := ormapi.AccountInfo{OrgName: child}
 	billTo := billing.CustomerDetails{
 		OrgName:   child,
 		FirstName: parent.FirstName,

--- a/mc/orm/billing_usage.go
+++ b/mc/orm/billing_usage.go
@@ -168,7 +168,7 @@ func recordAppUsages(ctx context.Context, usage *ormapi.MetricData, cloudletPool
 		orgTracker[newAppInst.AppKey.Organization] = append(records, newRecord)
 	}
 	for org, record := range orgTracker {
-		var accountInfo *billing.AccountInfo
+		var accountInfo *ormapi.AccountInfo
 		accountInfo, err := GetAccountObj(ctx, org)
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelInfo, "Unable to get account info", "org", org, "err", err)
@@ -229,7 +229,7 @@ func recordClusterUsages(ctx context.Context, usage *ormapi.MetricData, cloudlet
 		orgTracker[newClusterInst.Organization] = append(records, newRecord)
 	}
 	for org, record := range orgTracker {
-		var accountInfo *billing.AccountInfo
+		var accountInfo *ormapi.AccountInfo
 		accountInfo, err := GetAccountObj(ctx, org)
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelInfo, "Unable to get account info", "org", org, "err", err)

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -1776,7 +1776,7 @@ func testCreateBillingOrg(t *testing.T, mcClient *ormclient.Client, uri, token, 
 		Type: orgType,
 		Name: orgName,
 	}
-	acc := billing.AccountInfo{OrgName: org.Name}
+	acc := ormapi.AccountInfo{OrgName: org.Name}
 	status, err := mcClient.CreateBillingOrg(uri, token, &org)
 	require.Nil(t, err, "create billing org ", orgName)
 	require.Equal(t, http.StatusOK, status)

--- a/mc/orm/postgres.go
+++ b/mc/orm/postgres.go
@@ -11,7 +11,6 @@ import (
 	_ "github.com/labstack/echo"
 	"github.com/lib/pq"
 	_ "github.com/lib/pq"
-	"github.com/mobiledgex/edge-cloud-infra/billing"
 	"github.com/mobiledgex/edge-cloud-infra/mc/gormlog"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/log"
@@ -66,7 +65,7 @@ func InitData(ctx context.Context, superuser, superpass string, pingInterval tim
 
 		// create or update tables
 		err := db.AutoMigrate(&ormapi.User{}, &ormapi.Organization{},
-			&ormapi.Controller{}, &ormapi.Config{}, &ormapi.OrgCloudletPool{}, &billing.AccountInfo{}, &ormapi.BillingOrganization{}, &ormapi.UserApiKey{}).Error
+			&ormapi.Controller{}, &ormapi.Config{}, &ormapi.OrgCloudletPool{}, &ormapi.AccountInfo{}, &ormapi.BillingOrganization{}, &ormapi.UserApiKey{}).Error
 		if err != nil {
 			log.SpanLog(ctx, log.DebugLevelApi, "automigrate", "err", err)
 			if unitTest {

--- a/mc/ormapi/api.comments.go
+++ b/mc/ormapi/api.comments.go
@@ -1,5 +1,7 @@
 package ormapi
 
+// This is an auto-generated file. DO NOT EDIT directly.
+
 var UserComments = map[string]string{
 	"name":       `User name. Can only contain letters, digits, underscore, period, hyphen. It cannot have leading or trailing spaces or period. It cannot start with hyphen`,
 	"email":      `User email`,
@@ -33,6 +35,12 @@ var OrganizationComments = map[string]string{
 	"phone":   `Organization phone number`,
 }
 
+var InvoiceRequestComments = map[string]string{
+	"name":      `Billing Organization name to retrieve invoices for`,
+	"startdate": `Date filter for invoice selection, YYYY-MM-DD format`,
+	"enddate":   `Date filter for invoice selection, YYYY-MM-DD format`,
+}
+
 var BillingOrganizationComments = map[string]string{
 	"name":       `BillingOrganization name. Can only contain letters, digits, underscore, period, hyphen. It cannot have leading or trailing spaces or period. It cannot start with hyphen`,
 	"type":       `Organization type: "parent" or "self"`,
@@ -50,15 +58,9 @@ var BillingOrganizationComments = map[string]string{
 }
 
 var AccountInfoComments = map[string]string{
-	"orgname":        `BillingOrganization name to commit`,
-	"accountid":      `account id given by the billing platform`,
-	"subscriptionid": `subscription id given by the billing platform`,
-}
-
-var InvoiceComments = map[string]string{
-	"name":      `BillingOrganization name to retrieve invoices for`,
-	"startdate": `date filter for invoice selection YYYY-MM-DD format`,
-	"enddate":   `date filter for invoice selection YYYY-MM-DD format`,
+	"orgname":        `Billing Organization name to commit`,
+	"accountid":      `Account ID given by the billing platform`,
+	"subscriptionid": `Subscription ID given by the billing platform`,
 }
 
 var ControllerComments = map[string]string{

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -3,7 +3,6 @@ package ormapi
 import (
 	"time"
 
-	"github.com/mobiledgex/edge-cloud-infra/billing"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/util"
 )
@@ -111,9 +110,12 @@ type Organization struct {
 }
 
 type InvoiceRequest struct {
-	Name      string `json:",omitempty"`
+	// Billing Organization name to retrieve invoices for
+	Name string `json:",omitempty"`
+	// Date filter for invoice selection, YYYY-MM-DD format
 	StartDate string `json:",omitempty"`
-	EndDate   string `json:",omitempty"`
+	// Date filter for invoice selection, YYYY-MM-DD format
+	EndDate string `json:",omitempty"`
 }
 
 type BillingOrganization struct {
@@ -152,6 +154,17 @@ type BillingOrganization struct {
 	DeleteInProgress bool `json:",omitempty"`
 	// read only: true
 	CreateInProgress bool `json:",omitempty"`
+}
+
+type AccountInfo struct {
+	// Billing Organization name to commit
+	OrgName string `gorm:"primary_key;type:citext"`
+	// Account ID given by the billing platform
+	AccountId string `json:",omitempty"`
+	// Subscription ID given by the billing platform
+	SubscriptionId string `json:",omitempty"`
+	ParentId       string `json:",omitempty"`
+	Type           string `json:",omitempty"`
 }
 
 type Controller struct {
@@ -356,7 +369,7 @@ type WSStreamPayload struct {
 type AllData struct {
 	Controllers                   []Controller          `json:"controllers,omitempty"`
 	BillingOrgs                   []BillingOrganization `json:"billingorgs,omitempty"`
-	AccountInfos                  []billing.AccountInfo `json:"accountinfo,omitempty"`
+	AccountInfos                  []AccountInfo         `json:"accountinfo,omitempty"`
 	AlertReceivers                []AlertReceiver       `json:"alertreceivers,omitempty"`
 	Orgs                          []Organization        `json:"orgs,omitempty"`
 	Roles                         []Role                `json:"roles,omitempty"`

--- a/mc/ormapi/apidoc/apidoc.go
+++ b/mc/ormapi/apidoc/apidoc.go
@@ -39,6 +39,7 @@ func main() {
 	// generate comments
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "package %s", allStructs.pkgName)
+	fmt.Fprintf(buf, "\n// This is an auto-generated file. DO NOT EDIT directly.\n")
 	for _, apiSt := range allStructs.apiStructs {
 		comments := []Field{}
 		apiSt.genComments(&allStructs, []string{}, &comments)

--- a/mc/ormclient/clientapi.go
+++ b/mc/ormclient/clientapi.go
@@ -29,7 +29,7 @@ type Api interface {
 	RestrictedUpdateOrg(uri, token string, org map[string]interface{}) (int, error)
 
 	CreateBillingOrg(uri, token string, org *ormapi.BillingOrganization) (int, error)
-	UpdateAccountInfo(uri, token string, acc *billing.AccountInfo) (int, error)
+	UpdateAccountInfo(uri, token string, acc *ormapi.AccountInfo) (int, error)
 	DeleteBillingOrg(uri, token string, org *ormapi.BillingOrganization) (int, error)
 	UpdateBillingOrg(uri, token string, jsonData string) (int, error)
 	ShowBillingOrg(uri, token string) ([]ormapi.BillingOrganization, int, error)

--- a/mc/ormclient/rest_client.go
+++ b/mc/ormclient/rest_client.go
@@ -130,7 +130,7 @@ func (s *Client) CreateBillingOrg(uri, token string, bOrg *ormapi.BillingOrganiz
 	return s.PostJson(uri+"/auth/billingorg/create", token, bOrg, nil)
 }
 
-func (s *Client) UpdateAccountInfo(uri, token string, acc *billing.AccountInfo) (int, error) {
+func (s *Client) UpdateAccountInfo(uri, token string, acc *ormapi.AccountInfo) (int, error) {
 	return s.PostJson(uri+"/auth/billingorg/updateaccount", token, acc, nil)
 }
 


### PR DESCRIPTION
This fixes a build error:

go build ./...
# github.com/mobiledgex/edge-cloud-infra/mc/mcctl/ormctl
mc/mcctl/ormctl/billingorg.go:25:17: undefined: ormapi.AccountInfoComments
mc/mcctl/ormctl/billingorg.go:69:17: undefined: ormapi.InvoiceComments
make: *** [build-internal] Error 2

This happens because some manually created code got added to the auto-generated api.comments.go file, and if the file gets regenerated, that code gets wiped out.

To fix, I've moved that structs from billing.go into ormapi/api.go, because they are used for the MC's API. The comments now appear in api.comments.go, but are now auto-generated based on the comments in api.go.

Most of the changes here because of moving the structs from package billing to ormapi.