### PR TITLE
fix concurrency problem with networks

### DIFF
--- a/crm-platforms/vcd/vcd-network.go
+++ b/crm-platforms/vcd/vcd-network.go
@@ -759,7 +759,7 @@ func (v *VcdPlatform) GetNextInternalSubnet(ctx context.Context, vappName string
 	// We'll incr the netSpec.DelimiterOctet of this start addr, if it's not in our
 	// All VApps map, it's available
 	curAddr := startAddr
-	vappMap, err := v.GetAllVAppsForVdcByIntAddr(ctx, vcdClient)
+	vappMap, err := v.GetVappToNetworkMap(ctx, vcdClient)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "GetNextInternalSubnet return", "curAddr", curAddr)
 		return curAddr, false, err

--- a/crm-platforms/vcd/vcd.go
+++ b/crm-platforms/vcd/vcd.go
@@ -285,63 +285,14 @@ func (v *VcdPlatform) GetServerDetail(ctx context.Context, serverName string) (*
 
 }
 
-func (v *VcdPlatform) GetAllVMsForVdcByIntAddr(ctx context.Context, vcdClient *govcd.VCDClient) (VMMap, error) {
-	vmMap := make(VMMap)
-
-	vdc, err := v.GetVdc(ctx, vcdClient)
-	if err != nil {
-		return vmMap, err
-	}
-	netName := v.vmProperties.GetCloudletExternalNetwork()
-
-	for _, r := range vdc.Vdc.ResourceEntities {
-		for _, res := range r.ResourceEntity {
-			if res.Type == "application/vnd.vmware.vcloud.vm+xml" {
-				vm, err := v.FindVMByName(ctx, res.Name, vcdClient)
-				if err != nil {
-					log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVMsForVdcByIntAddr FindVMByName error", "vm", res.Name, "error", err)
-					return vmMap, err
-				} else {
-					if v.Verbose {
-						log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVMsByIntAddr consider ", "vm", res.Name)
-					}
-					ncs, err := vm.GetNetworkConnectionSection()
-					if err != nil {
-						log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVMsByIntAddr GetNetworkConnectionSection failed", "error", err)
-						return vmMap, err
-					}
-					// looking for internal network name
-					for _, nc := range ncs.NetworkConnection {
-						if nc.Network != netName {
-							ip, err := v.GetAddrOfVM(ctx, vm, nc.Network)
-							if err != nil {
-								log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVapps GetAddrOfVapp ", "error", err)
-								return vmMap, err
-							}
-							// We only want gateway addrs in this map so reject any addrs
-							// that have other an .1 as the last octet
-							//
-							// Skip the vapp we're attempting to set
-							if ip != "" {
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-	return vmMap, nil
-}
-
-func (v *VcdPlatform) GetAllVAppsForVdcByIntAddr(ctx context.Context, vcdClient *govcd.VCDClient) (VAppMap, error) {
+func (v *VcdPlatform) GetVappToNetworkMap(ctx context.Context, vcdClient *govcd.VCDClient) (VAppMap, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetVappToNetworkMap")
 
 	vappMap := make(VAppMap)
 	vdc, err := v.GetVdc(ctx, vcdClient)
 	if err != nil {
 		return vappMap, err
 	}
-
-	extNetName := v.vmProperties.GetCloudletExternalNetwork()
 
 	for _, r := range vdc.Vdc.ResourceEntities {
 		for _, res := range r.ResourceEntity {
@@ -351,48 +302,15 @@ func (v *VcdPlatform) GetAllVAppsForVdcByIntAddr(ctx context.Context, vcdClient 
 					log.SpanLog(ctx, log.DebugLevelInfra, "GetVappByName", "Vapp", res.Name, "error", err)
 					return vappMap, err
 				} else {
-					if v.Verbose {
-						log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVappsByIntAddr consider ", "vapp", res.Name)
-					}
-					if vapp.VApp.Children == nil || len(vapp.VApp.Children.VM) == 0 {
-						continue
-					}
-					ncs, err := vapp.GetNetworkConnectionSection()
-					if err != nil {
-						log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVappsByIntAddr ", "error", err)
-						return vappMap, err
-					}
-					// looking for internal network name
-					for _, nc := range ncs.NetworkConnection {
-						if nc.Network != extNetName {
-							ip, err := v.GetAddrOfVapp(ctx, vapp, nc.Network)
-							if err != nil {
-								log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVapps GetAddrOfVapp ", "error", err)
-								return vappMap, err
-							}
-							// We only want gateway addrs in this map so reject any addrs
-							// that have other an .1 as the last octet
-							//
-							// Skip the vapp we're attempting to set
-							if ip != "" {
-								delimiter, err := Octet(ctx, ip, 2)
-								if err != nil {
-									log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVappsByIntAddr Octet failed", "err", err)
-									return vappMap, err
-								}
-								addr := fmt.Sprintf("10.101.%d.1", delimiter)
-								log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVappsByIntAddr add", "ip", ip, "vapp", res.Name)
-								vappMap[addr] = vapp
-							}
-						}
-						// else if it has no other nets, just skip it
+					log.SpanLog(ctx, log.DebugLevelInfra, "GetAllVappsByIntAddr found vapp", "vapp", res.Name)
+					for _, n := range vapp.VApp.NetworkConfigSection.NetworkNames() {
+						vappMap[n] = vapp
 					}
 				}
 			}
 		}
 	}
 	return vappMap, nil
-
 }
 
 func (v *VcdPlatform) GetApiEndpointAddr(ctx context.Context) (string, error) {


### PR DESCRIPTION
EDGECLOUD-4907

If 2 VCD shared access clusterInsts are created at the same time, one or both will fail.  The reason is that both end up trying to use the same isolated VCD network CIDR.   

While there is a lock around the code that allocates the subnet, it is not effective because the way the code currently looks for subnets in use is to iterate through all the VMs.  because the networks are not added to the VMs until afterwards, it does not work.

Fix is to change the way we find existing networks by looking at the vApp networks, not the VMs.  This is faster and more reliable because if a network is attached to a VM, it must be associated with the vApp, but the inverse is not true.

The diffs are a bit hard to read but:
- GetAllVMsForVdcByIntAddr is removed because it was unused.
-  GetAllVAppsForVdcByIntAddr is renamed to GetVappToNetworkMap and the code is changed to use the vapp network list instead of iterating thru the VMs