### PR TITLE
VCD api reduction

### DIFF
--- a/crm-platforms/vcd/vcd-network.go
+++ b/crm-platforms/vcd/vcd-network.go
@@ -271,7 +271,7 @@ func (v *VcdPlatform) AttachPortToServer(ctx context.Context, serverName, subnet
 		log.SpanLog(ctx, log.DebugLevelInfra, "unable to retrieve current vdc", "err", err)
 		return err
 	}
-	vapp, err := v.FindVApp(ctx, vappName, vcdClient)
+	vapp, err := v.FindVApp(ctx, vappName, vcdClient, vdc)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "AttachPortToServer server not found", "vapp", vappName, "for server", serverName)
 		return err
@@ -375,7 +375,7 @@ func (v *VcdPlatform) DetachPortFromServer(ctx context.Context, serverName, subn
 		return err
 	}
 	vappName := serverName + v.GetVappServerSuffix()
-	vapp, err := v.FindVApp(ctx, vappName, vcdClient)
+	vapp, err := v.FindVApp(ctx, vappName, vcdClient, vdc)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "DetachPortFromServer server not found", "vapp", vappName, "for server", serverName)
 		return err
@@ -1104,7 +1104,7 @@ func (v *VcdPlatform) RebuildIsoNamesAndFreeMaps(ctx context.Context) error {
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "Shared LB find fail", "err", err)
 	} else {
-		lbVm, err := v.FindVMByName(ctx, v.vmProperties.SharedRootLBName, vcdClient)
+		lbVm, err := v.FindVMByName(ctx, v.vmProperties.SharedRootLBName, vcdClient, vdc)
 		if err != nil {
 			return fmt.Errorf("Cannot find rootlb vm -- %v", err)
 		}

--- a/crm-platforms/vcd/vcd_custom_test.go
+++ b/crm-platforms/vcd/vcd_custom_test.go
@@ -39,6 +39,11 @@ func TestProdSec(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
 		fmt.Printf("TestProdSec:")
 
@@ -57,7 +62,7 @@ func TestProdSec(t *testing.T) {
 		// and then go to the vm's productSection to update the runtime info which  you want to pass int"
 		// Uh huh... sure buddy, we'll see
 		//
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("%s not found\n", *vappName)
 			return

--- a/crm-platforms/vcd/vcd_metadata_test.go
+++ b/crm-platforms/vcd/vcd_metadata_test.go
@@ -15,11 +15,16 @@ func TestMeta(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
 
 		fmt.Printf("TestMeta:")
 
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		require.Nil(t, err, "FindVApp")
 
 		vm, err := vapp.GetVMByName(*vmName, false)

--- a/crm-platforms/vcd/vcd_network_test.go
+++ b/crm-platforms/vcd/vcd_network_test.go
@@ -106,9 +106,13 @@ func TestGetVappAddr(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
-
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("Test error finding vapp %s\n", *vappName)
 			return
@@ -129,9 +133,14 @@ func TestGetVappNetworks(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
 		fmt.Printf("TestGetVappNetworks for %s\n", *vappName)
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("vapp %s not found err %s\n", *vappName, err.Error())
 			return
@@ -155,9 +164,14 @@ func TestGetVMNetworks(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
 		fmt.Printf("TestVMNetworks for %s\n", *vmName)
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("vapp %s not found err %s\n", *vappName, err.Error())
 			return
@@ -186,9 +200,13 @@ func TestGetVMAddr(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
-
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
-		vm, err := tv.FindVMByName(ctx, *vmName, testVcdClient)
+		vm, err := tv.FindVMByName(ctx, *vmName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("error finding vm %s\n", *vmName)
 			return
@@ -425,7 +443,7 @@ func TestIsoVdcNet(t *testing.T) {
 		fmt.Printf("Network %s created successfully now add it to %s\n", networkName, *vappName)
 		// ok, now that it's created, we'll add it to *vappNmae eh?
 
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("Failed to find vapp %s\n", *vappName)
 			return
@@ -548,14 +566,18 @@ func TestAttachPortToServer(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
-
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
 		fmt.Printf("TestAttachPortToServer testsubnets to %s\n", *vappName)
 
 		// create 3 vapp internal (isolated) networks for vapp
 		// then add connections to same for the first vm in target vapp
 
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("%s not found\n", *vappName)
 			return
@@ -682,8 +704,12 @@ func testEnableVAppFirewall(t *testing.T, ctx context.Context, vappName string) 
 }
 
 func testDeleteVAppNetwork(t *testing.T, ctx context.Context, vappName, networkName string) (*types.NetworkConfigSection, error) {
-
-	vapp, err := tv.FindVApp(ctx, vappName, testVcdClient)
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return nil, err
+	}
+	vapp, err := tv.FindVApp(ctx, vappName, testVcdClient, vdc)
 	if err != nil {
 		fmt.Printf("Error finding Vapp: %s : %s \n", vappName, err.Error())
 		return nil, err
@@ -710,7 +736,7 @@ func TestAddNextIsoSubnetToVapp(t *testing.T) {
 			fmt.Printf("GetVdc failed: %s\n", err.Error())
 			return
 		}
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("Error getvapp %s\n", err.Error())
 			return

--- a/crm-platforms/vcd/vcd_vapp_template_test.go
+++ b/crm-platforms/vcd/vcd_vapp_template_test.go
@@ -270,10 +270,15 @@ func dumpVAppTemplate(tv *VcdPlatform, ctx context.Context, vt *govcd.VAppTempla
 	fmt.Printf("%s %s\n", fill+"Name", vt.VAppTemplate.Name)
 	fmt.Printf("%s %s\n", fill+"HREF", vt.VAppTemplate.HREF)
 	fmt.Printf("%s %s\n", fill+"Type", vt.VAppTemplate.Type)
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if vt.VAppTemplate.Type == "application/vnd.vmware.vcloud.vm+xml" {
 
 		// we can fetch it from vCD or from our local cache if we've done things right
-		vm, err := tv.FindVMByName(ctx, vt.VAppTemplate.Name, testVcdClient)
+		vm, err := tv.FindVMByName(ctx, vt.VAppTemplate.Name, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("Failed to find vm %s locally\n", vt.VAppTemplate.Name)
 		} else {

--- a/crm-platforms/vcd/vcd_vapp_test.go
+++ b/crm-platforms/vcd/vcd_vapp_test.go
@@ -80,12 +80,16 @@ func TestDumpVappNetworks(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
-
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
 		fmt.Printf("TestDumpVAppNetworks...")
 		vappName := "mex-cldlet3.tdg.mobiledgex.net-vapp"
 		//vappName := "mex-vmware-vcd.tdg.mobiledgex.net-vapp"
-		vapp, err := tv.FindVApp(ctx, vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("%s not found\n", vappName)
 			return
@@ -688,9 +692,13 @@ func TestExtAddrVApp(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitVcdTestEnv")
 	defer testVcdClient.Disconnect()
-
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		require.Nil(t, err, "FindVapp")
 		fmt.Printf("TestVApp-Start create vapp named %s in vdc %s \n", *vappName, *vdcName)
 

--- a/crm-platforms/vcd/vcd_vm_test.go
+++ b/crm-platforms/vcd/vcd_vm_test.go
@@ -96,9 +96,13 @@ func TestShowVM(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitTestEnv")
 	defer testVcdClient.Disconnect()
-
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("vapp %s not found\n", *vappName)
 			return
@@ -262,8 +266,13 @@ func TestRMVM(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitTestEnv")
 	defer testVcdClient.Disconnect()
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
-		vm, err := tv.FindVMByName(ctx, *vmName, testVcdClient)
+		vm, err := tv.FindVMByName(ctx, *vmName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("VM %s not found\n", *vmName)
 			return
@@ -306,10 +315,14 @@ func TestVMDisk(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitTestEnv")
 	defer testVcdClient.Disconnect()
-
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
 		fmt.Printf("\nTestVMDisk Live: \n")
-		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient)
+		vapp, err := tv.FindVApp(ctx, *vappName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("Unable to find %s\n", *vappName)
 			return
@@ -374,9 +387,14 @@ func testAttachPortToServer(t *testing.T, ctx context.Context, serverName, subne
 		fmt.Printf("Error from GetServerDetail for %s : %s\n", serverName, err.Error())
 		return err
 	}
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return err
+	}
 	fmt.Printf("details of %s : %+v\n", serverName, detail)
 	// but this is not enough, we need the govcd.VM object for serverName, but we know it eixsts.
-	vm, err := tv.FindVMByName(ctx, serverName, vcdClient)
+	vm, err := tv.FindVMByName(ctx, serverName, vcdClient, vdc)
 	if err != nil {
 		fmt.Printf("FindVM failed err: %s\n", err.Error())
 		return err
@@ -406,7 +424,12 @@ func testVMMetrics(t *testing.T, ctx context.Context, vmname string, poweron boo
 	// if so, we should fetch the HREF and see what it has for us
 	// This will probably never work until govcd grows support for nsx-t.
 	// Ok, the ExecuteRequest on the "down"
-	vm, err := tv.FindVMByName(ctx, vmname, testVcdClient)
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return err
+	}
+	vm, err := tv.FindVMByName(ctx, vmname, testVcdClient, vdc)
 	if err != nil {
 		return fmt.Errorf("Error finding vm  %s  err: %s\n", *vmName, err.Error())
 	}
@@ -521,10 +544,14 @@ func TestGetExtAddrOfVM(t *testing.T) {
 	live, ctx, err := InitVcdTestEnv()
 	require.Nil(t, err, "InitTestEnv")
 	defer testVcdClient.Disconnect()
-
+	vdc, err := tv.GetVdc(ctx, testVcdClient)
+	if err != nil {
+		fmt.Printf("GetVdc failed: %s\n", err.Error())
+		return
+	}
 	if live {
 		fmt.Printf("TestGetExtAddrOfVM vmName %s netName %s\n", *vmName, *netName)
-		vm, err := tv.FindVMByName(ctx, *vmName, testVcdClient)
+		vm, err := tv.FindVMByName(ctx, *vmName, testVcdClient, vdc)
 		if err != nil {
 			fmt.Printf("Error finding vm named: %s err: %s \n", *vmName, err.Error())
 			return


### PR DESCRIPTION
EDGECLOUD-4924

Further reduce the number of API calls to TEF's API GW, the following tweaks result in a reduction in API calls of about 65% for clusterInst creation:

- Replace VMW's BlockWhileStatus function with our own version that is now set to check every 3 seconds rather than every 200ms, which was generating a lot of API calls 
- In various places, pass around a VDC object rather than looking it up within the called function.  