### PR TITLE
mcctl unit-tests

### DIFF
--- a/e2e-tests/data/mc_showaudit_admin.yml
+++ b/e2e-tests/data/mc_showaudit_admin.yml
@@ -22,7 +22,7 @@
   status: 200
   starttime: "2020-04-22T13:16:44.281831-07:00"
   duration: 2.39ms
-  request: '{"adminpasswordmincracktimesec":63072000,"maxmetricsdatapoints":10000,"notifyemailaddress":"support@mobiledgex.com","passwordmincracktimesec":2592000,"skipverifyemail":true,"userapikeycreatelimit":10}'
+  request: '{"AdminPasswordMinCrackTimeSec":63072000,"MaxMetricsDataPoints":10000,"NotifyEmailAddress":"support@mobiledgex.com","PasswordMinCrackTimeSec":2592000,"SkipVerifyEmail":true,"UserApiKeyCreateLimit":10}'
   traceid: 7add8f1b8f2a8aaa
 - operationname: /api/v1/login
   username: mexadmin

--- a/e2e-tests/data/mc_showaudit_all.yml
+++ b/e2e-tests/data/mc_showaudit_all.yml
@@ -40,7 +40,7 @@
   status: 200
   starttime: "2020-04-22T13:05:08.227371-07:00"
   duration: 2.377ms
-  request: '{"adminpasswordmincracktimesec":63072000,"maxmetricsdatapoints":10000,"notifyemailaddress":"support@mobiledgex.com","passwordmincracktimesec":2592000,"skipverifyemail":true,"userapikeycreatelimit":10}'
+  request: '{"AdminPasswordMinCrackTimeSec":63072000,"MaxMetricsDataPoints":10000,"NotifyEmailAddress":"support@mobiledgex.com","PasswordMinCrackTimeSec":2592000,"SkipVerifyEmail":true,"UserApiKeyCreateLimit":10}'
   traceid: 57c8051e9b691a7f
 - operationname: /api/v1/login
   username: mexadmin

--- a/mc/mcctl/cliwrapper/wrapcli_test.go
+++ b/mc/mcctl/cliwrapper/wrapcli_test.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/mobiledgex/edge-cloud-infra/mc/mcctl/ormctl"
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
 	"github.com/mobiledgex/edge-cloud/cli"
 	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
@@ -64,4 +65,22 @@ func testObjToArgs(t *testing.T, obj interface{}, expected []string) {
 
 func TestCliPath(t *testing.T) {
 	NewClient()
+}
+
+func TestInjectRequiredArgs(t *testing.T) {
+	cmd := *ormctl.MustGetCommand("CreateUser")
+	// add some more required args to cover different types,
+	// so we cover string, int, float, bool.
+	cmd.RequiredArgs = "name email iter passcracktimesec enabletotp"
+	cmd.AliasArgs += " iter=user.iter passcracktimesec=user.passcracktimesec"
+
+	args := []string{}
+	expectedArgs := append(args, `name=""`, `email=""`, `iter=0`, `passcracktimesec=0`, `enabletotp=false`)
+	actualArgs := injectRequiredArgs(args, &cmd)
+	require.Equal(t, expectedArgs, actualArgs)
+
+	args = []string{"email=foobar", "passcracktimesec=1"}
+	expectedArgs = append(args, `name=""`, `iter=0`, `enabletotp=false`)
+	actualArgs = injectRequiredArgs(args, &cmd)
+	require.Equal(t, expectedArgs, actualArgs)
 }

--- a/mc/mcctl/mccli/execreq.go
+++ b/mc/mcctl/mccli/execreq.go
@@ -15,14 +15,14 @@ import (
 // We don't use the auto-generated Command because the client
 // must use websocket connection
 
-func getExecCmd(name string) *cobra.Command {
+func (s *RootCommand) getExecCmd(name string) *cobra.Command {
 	apiCmd := ormctl.MustGetCommand(name)
-	cliCmd := ConvertCmd(apiCmd)
-	cliCmd.Run = runExecRequest(apiCmd.Path)
+	cliCmd := s.ConvertCmd(apiCmd)
+	cliCmd.Run = s.runExecRequest(apiCmd.Path)
 	return cliCmd.GenCmd()
 }
 
-func runExecRequest(path string) func(c *cli.Command, args []string) error {
+func (s *RootCommand) runExecRequest(path string) func(c *cli.Command, args []string) error {
 	return func(c *cli.Command, args []string) error {
 		input := cli.Input{
 			RequiredArgs: strings.Split(c.RequiredArgs, " "),
@@ -33,11 +33,11 @@ func runExecRequest(path string) func(c *cli.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		client.Debug = cli.Debug
+		s.client.Debug = cli.Debug
 
 		exchangeFunc := func() (*edgeproto.ExecRequest, error) {
 			reply := edgeproto.ExecRequest{}
-			st, err := client.PostJson(getUri()+path, Token, &req, &reply)
+			st, err := s.client.PostJson(s.getUri()+path, s.token, &req, &reply)
 			err = check(c, st, err, nil)
 			if err != nil {
 				return nil, err

--- a/mc/mcctl/mccli/version.go
+++ b/mc/mcctl/mccli/version.go
@@ -14,12 +14,13 @@ func GetVersionCmd() *cobra.Command {
 		Short: "Version of mcctl cli utility",
 	}
 	cmd.Run = func(c *cli.Command, args []string) error {
-		fmt.Printf("buildmaster: %s\n", version.BuildMaster)
-		fmt.Printf("buildhead: %s\n", version.BuildHead)
+		wr := c.CobraCmd.OutOrStdout()
+		fmt.Fprintf(wr, "buildmaster: %s\n", version.BuildMaster)
+		fmt.Fprintf(wr, "buildhead: %s\n", version.BuildHead)
 		if version.BuildAuthor != "" {
-			fmt.Printf("buildauthor: %s\n", version.BuildAuthor)
+			fmt.Fprintf(wr, "buildauthor: %s\n", version.BuildAuthor)
 		}
-		fmt.Printf("builddate: %s\n", version.BuildDate)
+		fmt.Fprintf(wr, "builddate: %s\n", version.BuildDate)
 		return nil
 	}
 	return cmd.GenCmd()

--- a/mc/mcctl/mcctl.go
+++ b/mc/mcctl/mcctl.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	rootCmd := mccli.GetRootCommand()
-	err := rootCmd.Execute()
+	err := rootCmd.CobraCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/mc/mcctl/ormctl/allapis.go
+++ b/mc/mcctl/ormctl/allapis.go
@@ -33,6 +33,7 @@ type ApiCommand struct {
 	StreamOutIncremental bool
 	DataFlagOnly         bool
 	IsUpdate             bool
+	CliEmptyRequiredArgs string
 }
 
 type ApiGroup struct {

--- a/mc/mcctl/ormctl/user.go
+++ b/mc/mcctl/ormctl/user.go
@@ -48,7 +48,8 @@ func init() {
 		Short:        "Show users",
 		ReqData:      &ormapi.ShowUser{},
 		OptionalArgs: "name email emailverified familyname givenname nickname locked enabletotp orgname role",
-		Comments:     ormapi.UserComments,
+		AliasArgs:    strings.Join(EmbeddedUserAliasArgs, " "),
+		Comments:     aliasedComments(ormapi.ShowUserComments, EmbeddedUserAliasArgs),
 		ReplyData:    &[]ormapi.User{},
 		Path:         "/auth/user/show",
 	}, &ApiCommand{
@@ -144,17 +145,20 @@ func init() {
 	AllApis.AddCommand(cmd)
 }
 
-var CreateUserAliasArgs = []string{
+var EmbeddedUserAliasArgs = []string{
 	"name=user.name",
 	"email=user.email",
 	"nickname=user.nickname",
 	"familyname=user.familyname",
 	"givenname=user.givenname",
 	"password=user.passhash",
-	"callbackurl=verify.callbackurl",
 	"enabletotp=user.enabletotp",
 	"metadata=user.metadata",
 }
+
+var CreateUserAliasArgs = append(EmbeddedUserAliasArgs, []string{
+	"callbackurl=verify.callbackurl",
+}...)
 
 var CreateUserApiKeyAliasArgs = []string{
 	"org=userapikey.org",

--- a/mc/orm/alert_mc2_test.go
+++ b/mc/orm/alert_mc2_test.go
@@ -31,6 +31,7 @@ var _ = edgeproto.GetFields
 func badPermShowAlert(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Alert)) {
 	_, status, err := testutil.TestPermShowAlert(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/app_mc2_test.go
+++ b/mc/orm/app_mc2_test.go
@@ -31,6 +31,7 @@ var _ = edgeproto.GetFields
 func badPermCreateApp(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
 	_, status, err := testutil.TestPermCreateApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -51,6 +52,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteApp(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
 	_, status, err := testutil.TestPermDeleteApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -71,6 +73,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateApp(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
 	_, status, err := testutil.TestPermUpdateApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -91,6 +94,7 @@ var _ = edgeproto.GetFields
 func badPermShowApp(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.App)) {
 	_, status, err := testutil.TestPermShowApp(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -111,6 +115,7 @@ var _ = edgeproto.GetFields
 func badPermAddAppAutoProvPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
 	_, status, err := testutil.TestPermAddAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -131,6 +136,7 @@ var _ = edgeproto.GetFields
 func badPermRemoveAppAutoProvPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppAutoProvPolicy)) {
 	_, status, err := testutil.TestPermRemoveAppAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/appinst_mc2_test.go
+++ b/mc/orm/appinst_mc2_test.go
@@ -31,6 +31,7 @@ var _ = edgeproto.GetFields
 func badPermCreateAppInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
 	_, status, err := testutil.TestPermCreateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -51,6 +52,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteAppInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
 	_, status, err := testutil.TestPermDeleteAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -71,6 +73,7 @@ var _ = edgeproto.GetFields
 func badPermRefreshAppInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
 	_, status, err := testutil.TestPermRefreshAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -91,6 +94,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateAppInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.AppInst)) {
 	_, status, err := testutil.TestPermUpdateAppInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -111,6 +115,7 @@ var _ = edgeproto.GetFields
 func badPermShowAppInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInst)) {
 	_, status, err := testutil.TestPermShowAppInst(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -198,6 +203,7 @@ var _ = edgeproto.GetFields
 func badPermRequestAppInstLatency(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstLatency)) {
 	_, status, err := testutil.TestPermRequestAppInstLatency(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/appinstclient_mc2_test.go
+++ b/mc/orm/appinstclient_mc2_test.go
@@ -31,6 +31,7 @@ var _ = edgeproto.GetFields
 func badPermShowAppInstClient(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstClientKey)) {
 	_, status, err := testutil.TestPermShowAppInstClient(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/authz_app_test.go
+++ b/mc/orm/authz_app_test.go
@@ -76,15 +76,10 @@ func testImagePaths(t *testing.T, ctx context.Context, mcClient *mctestclient.Cl
 	// test publicimages enabled org
 	testImagePath(t, ctx, "DeveloperOrg", "docker.mobiledgex.net/mobiledgex/mobiledgex_public/mobiledgexsdkdemo", true)
 
-	status, err = mcClient.DeleteOrg(uri, tokenAd, &org1)
-	require.Nil(t, err)
-	require.Equal(t, http.StatusOK, status)
-	status, err = mcClient.DeleteOrg(uri, tokenAd, &org2)
-	require.Nil(t, err)
-	require.Equal(t, http.StatusOK, status)
-	status, err = mcClient.DeleteOrg(uri, tokenAd, &org3)
-	require.Nil(t, err)
-	require.Equal(t, http.StatusOK, status)
+	testDeleteOrg(t, mcClient, uri, tokenAd, org1.Name)
+	testDeleteOrg(t, mcClient, uri, tokenAd, org2.Name)
+	testDeleteOrg(t, mcClient, uri, tokenAd, org3.Name)
+	testDeleteOrg(t, mcClient, uri, tokenAd, mobiledgexOrg.Name)
 }
 
 func testImagePath(t *testing.T, ctx context.Context, org, imagepath string, ok bool) {

--- a/mc/orm/autoprovpolicy_mc2_test.go
+++ b/mc/orm/autoprovpolicy_mc2_test.go
@@ -32,6 +32,7 @@ var _ = edgeproto.GetFields
 func badPermCreateAutoProvPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
 	_, status, err := testutil.TestPermCreateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -52,6 +53,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteAutoProvPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
 	_, status, err := testutil.TestPermDeleteAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -72,6 +74,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateAutoProvPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
 	_, status, err := testutil.TestPermUpdateAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -92,6 +95,7 @@ var _ = edgeproto.GetFields
 func badPermShowAutoProvPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {
 	_, status, err := testutil.TestPermShowAutoProvPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -112,6 +116,7 @@ var _ = edgeproto.GetFields
 func badPermAddAutoProvPolicyCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
 	_, status, err := testutil.TestPermAddAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -132,6 +137,7 @@ var _ = edgeproto.GetFields
 func badPermRemoveAutoProvPolicyCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicyCloudlet)) {
 	_, status, err := testutil.TestPermRemoveAutoProvPolicyCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/autoscalepolicy_mc2_test.go
+++ b/mc/orm/autoscalepolicy_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermCreateAutoScalePolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
 	_, status, err := testutil.TestPermCreateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -50,6 +51,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteAutoScalePolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
 	_, status, err := testutil.TestPermDeleteAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -70,6 +72,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateAutoScalePolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
 	_, status, err := testutil.TestPermUpdateAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -90,6 +93,7 @@ var _ = edgeproto.GetFields
 func badPermShowAutoScalePolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoScalePolicy)) {
 	_, status, err := testutil.TestPermShowAutoScalePolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/cloudlet_mc2_test.go
+++ b/mc/orm/cloudlet_mc2_test.go
@@ -31,6 +31,7 @@ var _ = edgeproto.GetFields
 func badPermCreateCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
 	_, status, err := testutil.TestPermCreateCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -51,6 +52,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
 	_, status, err := testutil.TestPermDeleteCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -71,6 +73,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
 	_, status, err := testutil.TestPermUpdateCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -91,6 +94,7 @@ var _ = edgeproto.GetFields
 func badPermShowCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Cloudlet)) {
 	_, status, err := testutil.TestPermShowCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -111,6 +115,7 @@ var _ = edgeproto.GetFields
 func badPermGetCloudletManifest(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
 	_, status, err := testutil.TestPermGetCloudletManifest(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -131,6 +136,7 @@ var _ = edgeproto.GetFields
 func badPermGetCloudletProps(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletProps)) {
 	_, status, err := testutil.TestPermGetCloudletProps(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -151,6 +157,7 @@ var _ = edgeproto.GetFields
 func badPermGetCloudletResourceQuotaProps(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResourceQuotaProps)) {
 	_, status, err := testutil.TestPermGetCloudletResourceQuotaProps(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -171,6 +178,7 @@ var _ = edgeproto.GetFields
 func badPermGetCloudletResourceUsage(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResourceUsage)) {
 	_, status, err := testutil.TestPermGetCloudletResourceUsage(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -191,6 +199,7 @@ var _ = edgeproto.GetFields
 func badPermAddCloudletResMapping(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) {
 	_, status, err := testutil.TestPermAddCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -211,6 +220,7 @@ var _ = edgeproto.GetFields
 func badPermRemoveCloudletResMapping(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletResMap)) {
 	_, status, err := testutil.TestPermRemoveCloudletResMapping(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -231,6 +241,7 @@ var _ = edgeproto.GetFields
 func badPermFindFlavorMatch(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.FlavorMatch)) {
 	_, status, err := testutil.TestPermFindFlavorMatch(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -251,6 +262,7 @@ var _ = edgeproto.GetFields
 func badPermRevokeAccessKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
 	_, status, err := testutil.TestPermRevokeAccessKey(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -271,6 +283,7 @@ var _ = edgeproto.GetFields
 func badPermGenerateAccessKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
 	_, status, err := testutil.TestPermGenerateAccessKey(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -358,6 +371,7 @@ var _ = edgeproto.GetFields
 func badPermShowCloudletInfo(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
 	_, status, err := testutil.TestPermShowCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -378,6 +392,7 @@ var _ = edgeproto.GetFields
 func badPermInjectCloudletInfo(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
 	_, status, err := testutil.TestPermInjectCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -398,6 +413,7 @@ var _ = edgeproto.GetFields
 func badPermEvictCloudletInfo(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletInfo)) {
 	_, status, err := testutil.TestPermEvictCloudletInfo(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/cloudletpool_mc2_test.go
+++ b/mc/orm/cloudletpool_mc2_test.go
@@ -31,6 +31,7 @@ var _ = edgeproto.GetFields
 func badPermCreateCloudletPool(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
 	_, status, err := testutil.TestPermCreateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -51,6 +52,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteCloudletPool(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
 	_, status, err := testutil.TestPermDeleteCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -71,6 +73,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateCloudletPool(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
 	_, status, err := testutil.TestPermUpdateCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -91,6 +94,7 @@ var _ = edgeproto.GetFields
 func badPermShowCloudletPool(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPool)) {
 	_, status, err := testutil.TestPermShowCloudletPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -111,6 +115,7 @@ var _ = edgeproto.GetFields
 func badPermAddCloudletPoolMember(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
 	_, status, err := testutil.TestPermAddCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -131,6 +136,7 @@ var _ = edgeproto.GetFields
 func badPermRemoveCloudletPoolMember(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletPoolMember)) {
 	_, status, err := testutil.TestPermRemoveCloudletPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/clusterinst_mc2_test.go
+++ b/mc/orm/clusterinst_mc2_test.go
@@ -31,6 +31,7 @@ var _ = edgeproto.GetFields
 func badPermCreateClusterInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
 	_, status, err := testutil.TestPermCreateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -51,6 +52,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteClusterInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
 	_, status, err := testutil.TestPermDeleteClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -71,6 +73,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateClusterInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.ClusterInst)) {
 	_, status, err := testutil.TestPermUpdateClusterInst(mcClient, uri, token, region, org, targetCloudlet, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -91,6 +94,7 @@ var _ = edgeproto.GetFields
 func badPermShowClusterInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterInst)) {
 	_, status, err := testutil.TestPermShowClusterInst(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -111,6 +115,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteIdleReservableClusterInsts(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.IdleReservableClusterInsts)) {
 	_, status, err := testutil.TestPermDeleteIdleReservableClusterInsts(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/debug_mc2_test.go
+++ b/mc/orm/debug_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermEnableDebugLevels(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
 	_, status, err := testutil.TestPermEnableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -50,6 +51,7 @@ var _ = edgeproto.GetFields
 func badPermDisableDebugLevels(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
 	_, status, err := testutil.TestPermDisableDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -70,6 +72,7 @@ var _ = edgeproto.GetFields
 func badPermShowDebugLevels(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
 	_, status, err := testutil.TestPermShowDebugLevels(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -90,6 +93,7 @@ var _ = edgeproto.GetFields
 func badPermRunDebug(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DebugRequest)) {
 	_, status, err := testutil.TestPermRunDebug(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/device_mc2_test.go
+++ b/mc/orm/device_mc2_test.go
@@ -31,6 +31,7 @@ var _ = edgeproto.GetFields
 func badPermInjectDevice(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
 	_, status, err := testutil.TestPermInjectDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -51,6 +52,7 @@ var _ = edgeproto.GetFields
 func badPermShowDevice(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
 	_, status, err := testutil.TestPermShowDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -71,6 +73,7 @@ var _ = edgeproto.GetFields
 func badPermEvictDevice(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Device)) {
 	_, status, err := testutil.TestPermEvictDevice(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -91,6 +94,7 @@ var _ = edgeproto.GetFields
 func badPermShowDeviceReport(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.DeviceReport)) {
 	_, status, err := testutil.TestPermShowDeviceReport(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/exec_mc2_test.go
+++ b/mc/orm/exec_mc2_test.go
@@ -29,6 +29,7 @@ var _ = edgeproto.GetFields
 func badPermRunCommand(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
 	_, status, err := testutil.TestPermRunCommand(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -49,6 +50,7 @@ var _ = edgeproto.GetFields
 func badPermRunConsole(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
 	_, status, err := testutil.TestPermRunConsole(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -69,6 +71,7 @@ var _ = edgeproto.GetFields
 func badPermShowLogs(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
 	_, status, err := testutil.TestPermShowLogs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -89,6 +92,7 @@ var _ = edgeproto.GetFields
 func badPermAccessCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ExecRequest)) {
 	_, status, err := testutil.TestPermAccessCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/flavor_mc2_test.go
+++ b/mc/orm/flavor_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermCreateFlavor(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermCreateFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -50,6 +51,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteFlavor(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermDeleteFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -70,6 +72,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateFlavor(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermUpdateFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -90,6 +93,7 @@ var _ = edgeproto.GetFields
 func badPermShowFlavor(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermShowFlavor(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -110,6 +114,7 @@ var _ = edgeproto.GetFields
 func badPermAddFlavorRes(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermAddFlavorRes(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -130,6 +135,7 @@ var _ = edgeproto.GetFields
 func badPermRemoveFlavorRes(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Flavor)) {
 	_, status, err := testutil.TestPermRemoveFlavorRes(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/node_mc2_test.go
+++ b/mc/orm/node_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermShowNode(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Node)) {
 	_, status, err := testutil.TestPermShowNode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/operatorcode_mc2_test.go
+++ b/mc/orm/operatorcode_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermCreateOperatorCode(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
 	_, status, err := testutil.TestPermCreateOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -50,6 +51,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteOperatorCode(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
 	_, status, err := testutil.TestPermDeleteOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -70,6 +72,7 @@ var _ = edgeproto.GetFields
 func badPermShowOperatorCode(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.OperatorCode)) {
 	_, status, err := testutil.TestPermShowOperatorCode(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/refs_mc2_test.go
+++ b/mc/orm/refs_mc2_test.go
@@ -29,6 +29,7 @@ var _ = edgeproto.GetFields
 func badPermShowCloudletRefs(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletRefs)) {
 	_, status, err := testutil.TestPermShowCloudletRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -49,6 +50,7 @@ var _ = edgeproto.GetFields
 func badPermShowClusterRefs(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterRefs)) {
 	_, status, err := testutil.TestPermShowClusterRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -69,6 +71,7 @@ var _ = edgeproto.GetFields
 func badPermShowAppInstRefs(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstRefs)) {
 	_, status, err := testutil.TestPermShowAppInstRefs(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/restagtable_mc2_test.go
+++ b/mc/orm/restagtable_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermCreateResTagTable(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermCreateResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -50,6 +51,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteResTagTable(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermDeleteResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -70,6 +72,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateResTagTable(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermUpdateResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -90,6 +93,7 @@ var _ = edgeproto.GetFields
 func badPermShowResTagTable(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermShowResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -110,6 +114,7 @@ var _ = edgeproto.GetFields
 func badPermAddResTag(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermAddResTag(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -130,6 +135,7 @@ var _ = edgeproto.GetFields
 func badPermRemoveResTag(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTable)) {
 	_, status, err := testutil.TestPermRemoveResTag(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -150,6 +156,7 @@ var _ = edgeproto.GetFields
 func badPermGetResTagTable(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ResTagTableKey)) {
 	_, status, err := testutil.TestPermGetResTagTable(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/settings_mc2_test.go
+++ b/mc/orm/settings_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateSettings(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
 	_, status, err := testutil.TestPermUpdateSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -50,6 +51,7 @@ var _ = edgeproto.GetFields
 func badPermResetSettings(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
 	_, status, err := testutil.TestPermResetSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -70,6 +72,7 @@ var _ = edgeproto.GetFields
 func badPermShowSettings(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.Settings)) {
 	_, status, err := testutil.TestPermShowSettings(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/stream_mc2_test.go
+++ b/mc/orm/stream_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermStreamAppInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AppInstKey)) {
 	_, status, err := testutil.TestPermStreamAppInst(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -50,6 +51,7 @@ var _ = edgeproto.GetFields
 func badPermStreamClusterInst(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.ClusterInstKey)) {
 	_, status, err := testutil.TestPermStreamClusterInst(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -70,6 +72,7 @@ var _ = edgeproto.GetFields
 func badPermStreamCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
 	_, status, err := testutil.TestPermStreamCloudlet(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/trustpolicy_mc2_test.go
+++ b/mc/orm/trustpolicy_mc2_test.go
@@ -30,6 +30,7 @@ var _ = edgeproto.GetFields
 func badPermCreateTrustPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.TrustPolicy)) {
 	_, status, err := testutil.TestPermCreateTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -50,6 +51,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteTrustPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.TrustPolicy)) {
 	_, status, err := testutil.TestPermDeleteTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -70,6 +72,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateTrustPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.TrustPolicy)) {
 	_, status, err := testutil.TestPermUpdateTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -90,6 +93,7 @@ var _ = edgeproto.GetFields
 func badPermShowTrustPolicy(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.TrustPolicy)) {
 	_, status, err := testutil.TestPermShowTrustPolicy(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/mc/orm/vmpool_mc2_test.go
+++ b/mc/orm/vmpool_mc2_test.go
@@ -32,6 +32,7 @@ var _ = edgeproto.GetFields
 func badPermCreateVMPool(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
 	_, status, err := testutil.TestPermCreateVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -52,6 +53,7 @@ var _ = edgeproto.GetFields
 func badPermDeleteVMPool(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
 	_, status, err := testutil.TestPermDeleteVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -72,6 +74,7 @@ var _ = edgeproto.GetFields
 func badPermUpdateVMPool(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
 	_, status, err := testutil.TestPermUpdateVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -92,6 +95,7 @@ var _ = edgeproto.GetFields
 func badPermShowVMPool(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPool)) {
 	_, status, err := testutil.TestPermShowVMPool(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -112,6 +116,7 @@ var _ = edgeproto.GetFields
 func badPermAddVMPoolMember(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) {
 	_, status, err := testutil.TestPermAddVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 
@@ -132,6 +137,7 @@ var _ = edgeproto.GetFields
 func badPermRemoveVMPoolMember(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.VMPoolMember)) {
 	_, status, err := testutil.TestPermRemoveVMPoolMember(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 

--- a/protoc-gen-mc2/genmc2.go
+++ b/protoc-gen-mc2/genmc2.go
@@ -717,6 +717,7 @@ var _ = edgeproto.GetFields
 func badPerm{{.MethodName}}(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string{{.TargetCloudletParam}}, modFuncs ...func(*edgeproto.{{.InName}})) {
 	_, status, err := testutil.TestPerm{{.MethodName}}(mcClient, uri, token, region, org{{.TargetCloudletArg}}, modFuncs...)
 	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
 	require.Equal(t, http.StatusForbidden, status)
 }
 


### PR DESCRIPTION
This changes the two main MC unit-tests (TestServer and TestController), to run twice, once using the REST API client (which it was using before), and again using the mcctl wrapper client. This exercises a lot of the mcctl code. To support that change, I've also made the following changes
- when unit-tests run the mcctl wrapper, instead of spawning a separate mcctl process each call, it runs the code inline. This will allow code coverage tools to count the exercised mcctl code
- changes to allow the mcctl code to be run multiple times (normally every time mcctl is run, it's a new process, so it doesn't need to clean up/reset state)
- inject required args for fake regional controller API calls (REST API just ignores them, but mcctl checks for required args)
- bunch of changes to clean up unit-test data so it can be run a second time without having to restart the db/dummy servers