### PR TITLE
Cloudlet pool invitation fixes

### DIFF
--- a/mc/orm/authz_orgcloudletpool.go
+++ b/mc/orm/authz_orgcloudletpool.go
@@ -13,13 +13,13 @@ type AuthzOrgCloudletPool struct {
 	allowAll        bool
 }
 
-func newAuthzOrgCloudletPool(ctx context.Context, region, username string) (*AuthzOrgCloudletPool, error) {
+func newAuthzOrgCloudletPool(ctx context.Context, region, username, action string) (*AuthzOrgCloudletPool, error) {
 	// This may be called by either a developer or an operator.
-	authOperOrgs, err := enforcer.GetAuthorizedOrgs(ctx, username, ResourceCloudletPools, ActionManage)
+	authOperOrgs, err := enforcer.GetAuthorizedOrgs(ctx, username, ResourceCloudletPools, action)
 	if err != nil {
 		return nil, err
 	}
-	authDevOrgs, err := enforcer.GetAuthorizedOrgs(ctx, username, ResourceUsers, ActionManage)
+	authDevOrgs, err := enforcer.GetAuthorizedOrgs(ctx, username, ResourceUsers, action)
 	if err != nil {
 		return nil, err
 	}

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -185,7 +185,7 @@ func DeleteOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.Organizat
 			log.SpanLog(ctx, log.DebugLevelApi, "undo mark org for delete", "undoerr", undoerr)
 		}
 		if strings.Contains(err.Error(), "violates foreign key constraint \"org_cloudlet_pools_org_fkey\"") {
-			return fmt.Errorf("Cannot delete organization because it is referenced by some cloudletpool invitation or confirmation")
+			return fmt.Errorf("Cannot delete organization because it is referenced by some cloudletpool invitation or response")
 		}
 		return dbErr(err)
 	}


### PR DESCRIPTION
Fixes a bunch of minor issues:
EDGECLOUD-4757: Capitalization of error message
EDGECLOUD-4758: Change "confirmation" in message to "response"
EDGECLOUD-4780: Also delete response when invitation is deleted
EDGECLOUD-4802: Change RBAC for invitation show commands to use ActionView instead of ActionManage
EDGECLOUD-4833: Do not allow a non-developer Org to specified as the developer Org in the invitation