### PR TITLE
Vault policy for login credentials

### DIFF
--- a/ansible/development/group_vars/all
+++ b/ansible/development/group_vars/all
@@ -19,6 +19,7 @@ vault_github_teams:
       - cloudlets.read.v1
       - chef.read.v1
       - influxdb.read.v1
+      - logins.read.v1
       - mexenv.read.v1
       - registry.read.v1
       - ssh-ansible-user.sign.v1

--- a/ansible/mexdemo/group_vars/all
+++ b/ansible/mexdemo/group_vars/all
@@ -9,6 +9,7 @@ notifyroot_hostname: notifyroot.mobiledgex.net
 vault_github_teams:
   - name: edge-cloud-development-team
     policies:
+      - logins.read.v1
       - ssh-ansible-user.sign.v1
       - ssh-machine.sign.v1
       - ssh-user.sign.v1

--- a/ansible/qa/group_vars/all
+++ b/ansible/qa/group_vars/all
@@ -11,6 +11,7 @@ vault_ha_zones:
 vault_github_teams:
   - name: edge-cloud-development-team
     policies:
+      - logins.read.v1
       - ssh-ansible-user.sign.v1
       - ssh-machine.sign.v1
       - ssh-user.sign.v1

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -8,6 +8,7 @@ certgen_image_version: 2019-11-01
 vault_github_teams:
   - name: edge-cloud-development-team
     policies:
+      - logins.read.v1
       - ssh-user.sign.v1
 
 vault_ldap_groups: []

--- a/ansible/roles/vault/tasks/policies.yml
+++ b/ansible/roles/vault/tasks/policies.yml
@@ -26,6 +26,7 @@
     - policies/cloudlets.write.v1.hcl.j2
     - policies/influxdb.read.v1.hcl.j2
     - policies/influxdb-internal.read.v1.hcl.j2
+    - policies/logins.read.v1.hcl.j2
     - policies/noreplyemail.read.v1.hcl.j2
     - policies/gcp-auth.read.v1.hcl.j2
     - policies/mcorm-jwtkeys.read.v1.hcl.j2

--- a/ansible/roles/vault/templates/policies/logins.read.v1.hcl.j2
+++ b/ansible/roles/vault/templates/policies/logins.read.v1.hcl.j2
@@ -1,0 +1,3 @@
+path "secret/data/logins/*" {
+  capabilities = [ "read" ]
+}

--- a/ansible/staging/group_vars/all
+++ b/ansible/staging/group_vars/all
@@ -15,6 +15,7 @@ vault_ldap_groups:
 vault_github_teams:
   - name: edge-cloud-development-team
     policies:
+      - logins.read.v1
       - ssh-ansible-user.sign.v1
       - ssh-machine.sign.v1
       - ssh-user.sign.v1


### PR DESCRIPTION
Policy allowing access to login credentials stored in vault under the
path "secrets/logins". These are primarily credentials for shared web
applications and are accessible by everyone in the Github "Edge-Cloud
Development Team".