### PR TITLE
EDGECLOUD-4939 Fix mcctl update of regional objects

### DIFF
--- a/mc/mcctl/mccli/cmd_test.go
+++ b/mc/mcctl/mccli/cmd_test.go
@@ -1,0 +1,32 @@
+package mccli
+
+import (
+	"testing"
+
+	"github.com/mobiledgex/edge-cloud-infra/mc/mcctl/ormctl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateFields(t *testing.T) {
+	rc := RootCommand{}
+	apiCmd := ormctl.MustGetCommand("UpdateClusterInst")
+	cliCmd := rc.ConvertCmd(apiCmd)
+	args := []string{
+		"region=local",
+		"cluster=clust1",
+		"cluster-org=devOrg",
+		"cloudlet=tmus-cloud-1",
+		"cloudlet-org=tmus",
+		"numnodes=2",
+	}
+	in, err := cliCmd.ParseInput(args)
+	require.Nil(t, err)
+	ormctl.SetUpdateClusterInstFields(in)
+	obj, ok := in["ClusterInst"]
+	require.True(t, ok)
+	objmap, ok := obj.(map[string]interface{})
+	require.True(t, ok)
+	fields, ok := objmap["fields"]
+	require.True(t, ok)
+	require.ElementsMatch(t, []string{"2.1.1", "2.3", "2.2.1", "2.2.2", "14"}, fields)
+}

--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -75,7 +75,7 @@ var UpdateAppCmd = &ApiCommand{
 
 func SetUpdateAppFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("App")]
+	obj := in["App"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/appinst.mc2.go
+++ b/mc/mcctl/ormctl/appinst.mc2.go
@@ -99,7 +99,7 @@ var UpdateAppInstCmd = &ApiCommand{
 
 func SetUpdateAppInstFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("AppInst")]
+	obj := in["AppInst"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/autoprovpolicy.mc2.go
+++ b/mc/mcctl/ormctl/autoprovpolicy.mc2.go
@@ -76,7 +76,7 @@ var UpdateAutoProvPolicyCmd = &ApiCommand{
 
 func SetUpdateAutoProvPolicyFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("AutoProvPolicy")]
+	obj := in["AutoProvPolicy"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/autoscalepolicy.mc2.go
+++ b/mc/mcctl/ormctl/autoscalepolicy.mc2.go
@@ -71,7 +71,7 @@ var UpdateAutoScalePolicyCmd = &ApiCommand{
 
 func SetUpdateAutoScalePolicyFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("AutoScalePolicy")]
+	obj := in["AutoScalePolicy"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -81,7 +81,7 @@ var UpdateCloudletCmd = &ApiCommand{
 
 func SetUpdateCloudletFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("Cloudlet")]
+	obj := in["Cloudlet"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/cloudletpool.mc2.go
+++ b/mc/mcctl/ormctl/cloudletpool.mc2.go
@@ -75,7 +75,7 @@ var UpdateCloudletPoolCmd = &ApiCommand{
 
 func SetUpdateCloudletPoolFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("CloudletPool")]
+	obj := in["CloudletPool"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/clusterinst.mc2.go
+++ b/mc/mcctl/ormctl/clusterinst.mc2.go
@@ -81,7 +81,7 @@ var UpdateClusterInstCmd = &ApiCommand{
 
 func SetUpdateClusterInstFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("ClusterInst")]
+	obj := in["ClusterInst"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/flavor.mc2.go
+++ b/mc/mcctl/ormctl/flavor.mc2.go
@@ -71,7 +71,7 @@ var UpdateFlavorCmd = &ApiCommand{
 
 func SetUpdateFlavorFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("Flavor")]
+	obj := in["Flavor"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/restagtable.mc2.go
+++ b/mc/mcctl/ormctl/restagtable.mc2.go
@@ -71,7 +71,7 @@ var UpdateResTagTableCmd = &ApiCommand{
 
 func SetUpdateResTagTableFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("ResTagTable")]
+	obj := in["ResTagTable"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/settings.mc2.go
+++ b/mc/mcctl/ormctl/settings.mc2.go
@@ -41,7 +41,7 @@ var UpdateSettingsCmd = &ApiCommand{
 
 func SetUpdateSettingsFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("Settings")]
+	obj := in["Settings"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/trustpolicy.mc2.go
+++ b/mc/mcctl/ormctl/trustpolicy.mc2.go
@@ -77,7 +77,7 @@ var UpdateTrustPolicyCmd = &ApiCommand{
 
 func SetUpdateTrustPolicyFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("TrustPolicy")]
+	obj := in["TrustPolicy"]
 	if obj == nil {
 		return
 	}

--- a/mc/mcctl/ormctl/vmpool.mc2.go
+++ b/mc/mcctl/ormctl/vmpool.mc2.go
@@ -76,7 +76,7 @@ var UpdateVMPoolCmd = &ApiCommand{
 
 func SetUpdateVMPoolFields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("VMPool")]
+	obj := in["VMPool"]
 	if obj == nil {
 		return
 	}

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -1027,7 +1027,6 @@ func getOrg(t *testing.T, mcClient *mctestclient.Client, uri, token, name string
 	orgs, status, err := mcClient.ShowOrg(uri, token)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
-	fmt.Printf("got orgs: %v\n", orgs)
 	for _, org := range orgs {
 		if org.Name == name {
 			return &org

--- a/mc/orm/server_test.go
+++ b/mc/orm/server_test.go
@@ -28,6 +28,8 @@ func TestServer(t *testing.T) {
 	uri := "http://" + addr + "/api/v1"
 	ctx := log.StartTestSpan(context.Background())
 
+	vault.DefaultJwkRefreshDelay = time.Hour
+
 	vaultServer, vaultConfig := vault.DummyServer()
 	defer vaultServer.Close()
 

--- a/protoc-gen-mc2/genmc2.go
+++ b/protoc-gen-mc2/genmc2.go
@@ -775,7 +775,7 @@ var {{.MethodName}}Cmd = &ApiCommand{
 {{if .SetFields}}
 func Set{{.MethodName}}Fields(in map[string]interface{}) {
 	// get map for edgeproto object in region struct
-	obj := in[strings.ToLower("{{.InName}}")]
+	obj := in["{{.InName}}"]
 	if obj == nil {
 		return
 	}


### PR DESCRIPTION
This fixes updates of regional objects via mcctl. I had changed one of the mapping functions to use proper json names, i.e. the struct field name if no json tag was present, rather than the lower-case version of the struct field name. (Note that golang json unmarshal prefers case-sensitive names, but allows lower-case names, thus while technically not correct, it wasn't an issue before). This caused the look up of the map in the "SetFields" func to fail, and thus the fields were never set. Fix is in genmc2.go.