### PR TITLE
fix e2e-tests deploymenttag

### DIFF
--- a/e2e-tests/data/appdata_automation.yml
+++ b/e2e-tests/data/appdata_automation.yml
@@ -29,7 +29,6 @@ cloudlets:
 - key:
     organization: tmus
     name: tmocloud-1
-  accessuri: cloud1.tmo
   location:
     latitude: 31
     longitude: -91
@@ -38,7 +37,6 @@ cloudlets:
 - key:
     organization: tmus
     name: tmocloud-2
-  accessuri: cloud2.tmo
   location:
     latitude: 35
     longitude: -95
@@ -47,7 +45,6 @@ cloudlets:
 - key:
     organization: TDG
     name: automationBonnCloudlet 
-  accessuri: cloud3.tmo
   location:
     latitude: 35
     longitude: -95
@@ -56,7 +53,6 @@ cloudlets:
 - key:
     organization: tmus
     name: automationBerlinCloudlet
-  accessuri: cloud4.tmo
   location:
     latitude: 35
     longitude: -95
@@ -65,7 +61,6 @@ cloudlets:
 - key:
     organization: tmus
     name: automationHamburgCloudlet
-  accessuri: cloud5.tmo
   location:
     latitude: 35
     longitude: -95
@@ -74,7 +69,6 @@ cloudlets:
 - key:
     organization: att
     name: attcloud-1
-  accessuri: cloud6.tmo
   location:
     latitude: 35
     longitude: -95
@@ -83,7 +77,6 @@ cloudlets:
 - key:
     organization: tmus
     name: automationProdHamburgCloudlet
-  accessuri: cloud7.tmo
   location:
     latitude: 35
     longitude: -95

--- a/e2e-tests/data/appdata_clustertest.yml
+++ b/e2e-tests/data/appdata_clustertest.yml
@@ -44,7 +44,6 @@ cloudlets:
 - key:
     organization: TDG
     name: jlmcloudlet
-  accessuri: jlm.cloudlet
   location:
     latitude: 31
     longitude: -91

--- a/e2e-tests/data/kind_user1_cloudlet_data.yml
+++ b/e2e-tests/data/kind_user1_cloudlet_data.yml
@@ -5,7 +5,6 @@ regiondata:
     - key:
         organization: tmus
         name: kind-cloud-1
-      accessuri: cloud1.kind
       location:
         latitude: 31
         longitude: -91

--- a/e2e-tests/data/kind_user1_data_show.yml
+++ b/e2e-tests/data/kind_user1_data_show.yml
@@ -12,22 +12,18 @@ orgs:
   type: operator
   address: tmus headquarters
   phone: 123-123-1234
-  adminusername: user1
 - name: azure
   type: operator
   address: amazon jungle
   phone: 123-123-1234
-  adminusername: user1
 - name: gcp
   type: operator
   address: mountain view
   phone: 123-123-1234
-  adminusername: user1
 - name: enterprise
   type: operator
   address: enterprise headquarters
   phone: 123-123-1234
-  adminusername: user1
 roles:
 - org: tmus
   username: user1

--- a/e2e-tests/data/kind_user2_data.yml
+++ b/e2e-tests/data/kind_user2_data.yml
@@ -3,7 +3,6 @@ orgs:
   type: developer
   address: 123 Maple Street, Gainesville, FL 32604
   phone: 123-123-1234
-  adminusername: user2
 
 billingorgs:
 - name: AcmeAppCo
@@ -17,7 +16,6 @@ billingorgs:
   state: FL
   postalcode: 32604
   phone: 123-123-1234
-  currency: USD
 
 regiondata:
 - region: local

--- a/e2e-tests/data/kind_user2_data_show.yml
+++ b/e2e-tests/data/kind_user2_data_show.yml
@@ -12,7 +12,6 @@ orgs:
   type: developer
   address: 123 Maple Street, Gainesville, FL 32604
   phone: 123-123-1234
-  adminusername: user2
   parent: AcmeAppCo
 billingorgs:
 - name: AcmeAppCo
@@ -26,7 +25,6 @@ billingorgs:
   state: FL
   postalcode: "32604"
   phone: 123-123-1234
-  currency: USD
   children: AcmeAppCo
   createinprogress: true
 roles:

--- a/e2e-tests/data/mc_admin_data.yml
+++ b/e2e-tests/data/mc_admin_data.yml
@@ -1,7 +1,3 @@
-config:
-  skipverifyemail: true
-  notifyemailaddress: support@mobiledgex.com
-
 controllers:
 - region: local
   address: "127.0.0.1:55001"
@@ -17,13 +13,11 @@ orgs:
   type: developer
   address: mobiledgex
   phone: 123-123-1234
-  adminusername: mexadmin
   publicimages: true
 - name: user3org
   type: developer
   address: enterprise headquarters
   phone: 123-123-1234
-  adminusername: mexadmin
   parent: user3org
 
 billingorgs:
@@ -38,7 +32,6 @@ billingorgs:
   state: FL
   postalcode: 32604
   phone: 123-123-1234
-  currency: USD
   children: user3org
 
 roles:

--- a/e2e-tests/data/mc_admin_data_chef.yml
+++ b/e2e-tests/data/mc_admin_data_chef.yml
@@ -3,7 +3,6 @@ orgs:
   type: developer
   address: mexdev headquarters
   phone: 123-123-1234
-  adminusername: mexadmin
   publicimages: true
 
 controllers:

--- a/e2e-tests/data/mc_admin_data_edgebox.yml
+++ b/e2e-tests/data/mc_admin_data_edgebox.yml
@@ -3,7 +3,6 @@ orgs:
   type: developer
   address: mexdev headquarters
   phone: 123-123-1234
-  adminusername: mexadmin
   publicimages: true
 
 controllers:

--- a/e2e-tests/data/mc_user1_chef.yml
+++ b/e2e-tests/data/mc_user1_chef.yml
@@ -3,7 +3,6 @@ orgs:
   type: operator
   address: mexdev headquarters
   phone: 123-123-1234
-  adminusername: user1
 
 regiondata:
 - region: local
@@ -12,7 +11,6 @@ regiondata:
     - key:
         organization: mexdev
         name: chef-test-1
-      accessuri: chef-test-1.tmo
       location:
         latitude: 31
         longitude: -91

--- a/e2e-tests/data/mc_user1_cloudlet_data.yml
+++ b/e2e-tests/data/mc_user1_cloudlet_data.yml
@@ -15,7 +15,6 @@ regiondata:
     - key:
         organization: tmus
         name: tmus-cloud-1
-      accessuri: cloud1.tmo
       location:
         latitude: 31
         longitude: -91
@@ -35,7 +34,6 @@ regiondata:
     - key:
         organization: tmus
         name: tmus-cloud-2
-      accessuri: cloud2.tmo
       location:
         latitude: 35
         longitude: -95
@@ -45,7 +43,6 @@ regiondata:
     - key:
         organization: azure
         name: azure-cloud-4
-      accessuri: cloud4.azure
       location:
         latitude: 32
         longitude: -91
@@ -55,7 +52,6 @@ regiondata:
     - key:
         organization: gcp
         name: gcp-cloud-5
-      accessuri: cloud5.gcp
       location:
         latitude: 36
         longitude: -95
@@ -109,7 +105,6 @@ regiondata:
     - key:
         organization: tmus
         name: tmus-cloud-3
-      accessuri: cloud1.tmo
       location:
         latitude: 32
         longitude: -92
@@ -119,7 +114,6 @@ regiondata:
     - key:
         organization: tmus
         name: tmus-cloud-4
-      accessuri: cloud2.tmo
       location:
         latitude: 36
         longitude: -96

--- a/e2e-tests/data/mc_user1_data_show.yml
+++ b/e2e-tests/data/mc_user1_data_show.yml
@@ -12,22 +12,18 @@ orgs:
   type: operator
   address: tmus headquarters
   phone: 123-123-1234
-  adminusername: user1
 - name: azure
   type: operator
   address: amazon jungle
   phone: 123-123-1234
-  adminusername: user1
 - name: gcp
   type: operator
   address: mountain view
   phone: 123-123-1234
-  adminusername: user1
 - name: enterprise
   type: operator
   address: enterprise headquarters
   phone: 123-123-1234
-  adminusername: user1
 roles:
 - org: tmus
   username: user1

--- a/e2e-tests/data/mc_user1_edgebox.yml
+++ b/e2e-tests/data/mc_user1_edgebox.yml
@@ -3,7 +3,6 @@ orgs:
   type: operator
   address: mexdev headquarters
   phone: 123-123-1234
-  adminusername: user1
 
 regiondata:
 - region: local
@@ -12,7 +11,6 @@ regiondata:
     - key:
         organization: mexdev
         name: localtest
-      accessuri: localtest.tmo
       location:
         latitude: 31
         longitude: -91

--- a/e2e-tests/data/mc_user1_org_data.yml
+++ b/e2e-tests/data/mc_user1_org_data.yml
@@ -3,19 +3,15 @@ orgs:
   type: operator
   address: tmus headquarters
   phone: 123-123-1234
-  adminusername: user1
 - name: azure
   type: operator
   address: amazon jungle
   phone: 123-123-1234
-  adminusername: user1
 - name: gcp
   type: operator
   address: mountain view
   phone: 123-123-1234
-  adminusername: user1
 - name: enterprise
   type: operator
   address: enterprise headquarters
   phone: 123-123-1234
-  adminusername: user1

--- a/e2e-tests/data/mc_user2_chef.yml
+++ b/e2e-tests/data/mc_user2_chef.yml
@@ -3,7 +3,6 @@ orgs:
   type: developer
   address: 123 Maple Street, Gainesville, FL 32604
   phone: 123-123-1234
-  adminusername: user2
 
 billingorgs:
 - name: DevOrg
@@ -17,7 +16,6 @@ billingorgs:
   state: FL
   postalcode: 32604
   phone: 123-123-1234
-  currency: USD
 
 regiondata:
 - region: local

--- a/e2e-tests/data/mc_user2_data.yml
+++ b/e2e-tests/data/mc_user2_data.yml
@@ -3,12 +3,10 @@ orgs:
   type: developer
   address: 123 Maple Street, Gainesville, FL 32604
   phone: 123-123-1234
-  adminusername: user2
 - name: Samsung
   type: developer
   address: 1 Samstreet, Samsung Town, South Korea
   phone: 123-123-1234
-  adminusername: user2
 
 billingorgs:
 - name: AcmeAppCo
@@ -22,7 +20,6 @@ billingorgs:
   state: FL
   postalcode: 32604
   phone: 123-123-1234
-  currency: USD
 
 regiondata:
 - region: local

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -12,13 +12,11 @@ orgs:
   type: developer
   address: 123 Maple Street, Gainesville, FL 32604
   phone: 123-123-1234
-  adminusername: user2
   parent: AcmeAppCo
 - name: Samsung
   type: developer
   address: 1 Samstreet, Samsung Town, South Korea
   phone: 123-123-1234
-  adminusername: user2
 billingorgs:
 - name: AcmeAppCo
   type: self
@@ -31,7 +29,6 @@ billingorgs:
   state: FL
   postalcode: "32604"
   phone: 123-123-1234
-  currency: USD
   children: AcmeAppCo
 roles:
 - org: AcmeAppCo

--- a/e2e-tests/data/mc_user2_edgebox.yml
+++ b/e2e-tests/data/mc_user2_edgebox.yml
@@ -3,7 +3,6 @@ orgs:
   type: developer
   address: 123 Maple Street, Gainesville, FL 32604
   phone: 123-123-1234
-  adminusername: user2
 
 billingorgs:
 - name: DevOrg
@@ -17,7 +16,6 @@ billingorgs:
   state: FL
   postalcode: 32604
   phone: 123-123-1234
-  currency: USD
 
 regiondata:
 - region: local

--- a/e2e-tests/data/mc_user2_edgebox_docker.yml
+++ b/e2e-tests/data/mc_user2_edgebox_docker.yml
@@ -3,7 +3,6 @@ orgs:
   type: developer
   address: 123 Maple Street, Gainesville, FL 32604
   phone: 123-123-1234
-  adminusername: user2
 
 billingorgs:
 - name: DevOrg
@@ -17,7 +16,6 @@ billingorgs:
   state: FL
   postalcode: 32604
   phone: 123-123-1234
-  currency: USD
 
 regiondata:
 - region: local

--- a/e2e-tests/data/mc_user3_data_show.yml
+++ b/e2e-tests/data/mc_user3_data_show.yml
@@ -12,7 +12,6 @@ orgs:
   type: developer
   address: enterprise headquarters
   phone: 123-123-1234
-  adminusername: mexadmin
   parent: user3org
 billingorgs:
 - name: user3org
@@ -26,7 +25,6 @@ billingorgs:
   state: FL
   postalcode: 32604
   phone: 123-123-1234
-  currency: USD
   children: user3org
 roles:
 - org: user3org

--- a/e2e-tests/data/mc_user3_empty_show.yml
+++ b/e2e-tests/data/mc_user3_empty_show.yml
@@ -12,7 +12,6 @@ orgs:
   type: developer
   address: enterprise headquarters
   phone: 123-123-1234
-  adminusername: mexadmin
   parent: user3org
 billingorgs:
 - name: user3org
@@ -26,7 +25,6 @@ billingorgs:
   state: FL
   postalcode: "32604"
   phone: 123-123-1234
-  currency: USD
   children: user3org
 roles:
 - org: user3org

--- a/e2e-tests/int-process/process_defs.go
+++ b/e2e-tests/int-process/process_defs.go
@@ -8,14 +8,13 @@ import (
 
 type MC struct {
 	process.Common          `yaml:",inline"`
+	process.NodeCommon      `yaml:",inline"`
 	Addr                    string
 	SqlAddr                 string
-	VaultAddr               string
 	RolesFile               string
 	LdapAddr                string
 	NotifySrvAddr           string
 	ConsoleProxyAddr        string
-	UseVaultPki             bool
 	AlertResolveTimeout     string
 	BillingPlatform         string
 	UsageCollectionInterval string
@@ -23,8 +22,7 @@ type MC struct {
 	AlertMgrApiAddr         string
 	ApiTlsCert              string
 	ApiTlsKey               string
-	DeploymentTag           string
-	TLS                     process.TLSCerts
+	StaticDir               string
 	cmd                     *exec.Cmd
 }
 type Sql struct {
@@ -37,34 +35,27 @@ type Sql struct {
 	cmd            *exec.Cmd
 }
 type Shepherd struct {
-	process.Common `yaml:",inline"`
-	NotifyAddrs    string
-	Platform       string
-	VaultAddr      string
-	MetricsAddr    string
-	PhysicalName   string
-	CloudletKey    string
-	UseVaultPki    bool
-	TLS            process.TLSCerts
-	cmd            *exec.Cmd
-	Span           string
-	Region         string
-	AppDNSRoot     string
-	DeploymentTag  string
-	ChefServerPath string
-	AccessKeyFile  string
-	AccessApiAddr  string
+	process.Common     `yaml:",inline"`
+	process.NodeCommon `yaml:",inline"`
+	NotifyAddrs        string
+	Platform           string
+	MetricsAddr        string
+	PhysicalName       string
+	CloudletKey        string
+	cmd                *exec.Cmd
+	Span               string
+	Region             string
+	AppDNSRoot         string
+	ChefServerPath     string
 }
 type AutoProv struct {
-	process.Common `yaml:",inline"`
-	NotifyAddrs    string
-	CtrlAddrs      string
-	VaultAddr      string
-	InfluxAddr     string
-	Region         string
-	UseVaultPki    bool
-	TLS            process.TLSCerts
-	cmd            *exec.Cmd
+	process.Common     `yaml:",inline"`
+	process.NodeCommon `yaml:",inline"`
+	NotifyAddrs        string
+	CtrlAddrs          string
+	InfluxAddr         string
+	Region             string
+	cmd                *exec.Cmd
 }
 
 type PromE2e struct {

--- a/e2e-tests/int-process/process_local.go
+++ b/e2e-tests/int-process/process_local.go
@@ -22,7 +22,7 @@ import (
 // Master Controller
 
 func (p *MC) StartLocal(logfile string, opts ...process.StartOp) error {
-	args := []string{}
+	args := p.GetNodeMgrArgs()
 	if p.Addr != "" {
 		args = append(args, "--addr")
 		args = append(args, p.Addr)
@@ -31,11 +31,6 @@ func (p *MC) StartLocal(logfile string, opts ...process.StartOp) error {
 		args = append(args, "--sqlAddr")
 		args = append(args, p.SqlAddr)
 	}
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
-	}
-	args = p.TLS.AddInternalPkiArgs(args)
 	if p.TLS.ClientCert != "" {
 		args = append(args, "--clientCert")
 		args = append(args, p.TLS.ClientCert)
@@ -62,9 +57,6 @@ func (p *MC) StartLocal(logfile string, opts ...process.StartOp) error {
 		args = append(args, "--alertResolveTimeout")
 		args = append(args, p.AlertResolveTimeout)
 	}
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
-	}
 	if p.BillingPlatform != "" {
 		args = append(args, "--billingPlatform")
 		args = append(args, p.BillingPlatform)
@@ -81,9 +73,8 @@ func (p *MC) StartLocal(logfile string, opts ...process.StartOp) error {
 		args = append(args, "--alertMgrApiAddr")
 		args = append(args, p.AlertMgrApiAddr)
 	}
-	if p.DeploymentTag != "" {
-		args = append(args, "--deploymentTag")
-		args = append(args, p.DeploymentTag)
+	if p.StaticDir != "" {
+		args = append(args, "--staticDir", p.StaticDir)
 	}
 	args = append(args, "--hostname", p.Name)
 	options := process.StartOptions{}
@@ -266,7 +257,7 @@ func (p *Sql) runPsql(args []string) ([]byte, error) {
 }
 
 func (p *Shepherd) GetArgs(opts ...process.StartOp) []string {
-	args := []string{}
+	args := p.GetNodeMgrArgs()
 	if p.Name != "" {
 		args = append(args, "--name")
 		args = append(args, p.Name)
@@ -279,10 +270,6 @@ func (p *Shepherd) GetArgs(opts ...process.StartOp) []string {
 		args = append(args, "--platform")
 		args = append(args, p.Platform)
 	}
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
-	}
 	if p.PhysicalName != "" {
 		args = append(args, "--physicalName")
 		args = append(args, p.PhysicalName)
@@ -291,7 +278,6 @@ func (p *Shepherd) GetArgs(opts ...process.StartOp) []string {
 		args = append(args, "--cloudletKey")
 		args = append(args, p.CloudletKey)
 	}
-	args = p.TLS.AddInternalPkiArgs(args)
 	if p.Span != "" {
 		args = append(args, "--span")
 		args = append(args, p.Span)
@@ -299,9 +285,6 @@ func (p *Shepherd) GetArgs(opts ...process.StartOp) []string {
 	if p.Region != "" {
 		args = append(args, "--region")
 		args = append(args, p.Region)
-	}
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
 	}
 	if p.MetricsAddr != "" {
 		args = append(args, "--metricsAddr")
@@ -311,19 +294,9 @@ func (p *Shepherd) GetArgs(opts ...process.StartOp) []string {
 		args = append(args, "--appDNSRoot")
 		args = append(args, p.AppDNSRoot)
 	}
-	if p.DeploymentTag != "" {
-		args = append(args, "--deploymentTag")
-		args = append(args, p.DeploymentTag)
-	}
 	if p.ChefServerPath != "" {
 		args = append(args, "--chefServerPath")
 		args = append(args, p.ChefServerPath)
-	}
-	if p.AccessKeyFile != "" {
-		args = append(args, "--accessKeyFile", p.AccessKeyFile)
-	}
-	if p.AccessApiAddr != "" {
-		args = append(args, "--accessApiAddr", p.AccessApiAddr)
 	}
 
 	options := process.StartOptions{}
@@ -371,25 +344,18 @@ func (p *Shepherd) Wait() {
 
 func (p *AutoProv) StartLocal(logfile string, opts ...process.StartOp) error {
 	args := []string{"--notifyAddrs", p.NotifyAddrs}
+	args = append(args, p.GetNodeMgrArgs()...)
 	if p.CtrlAddrs != "" {
 		args = append(args, "--ctrlAddrs")
 		args = append(args, p.CtrlAddrs)
-	}
-	if p.VaultAddr != "" {
-		args = append(args, "--vaultAddr")
-		args = append(args, p.VaultAddr)
 	}
 	if p.InfluxAddr != "" {
 		args = append(args, "--influxAddr")
 		args = append(args, p.InfluxAddr)
 	}
-	args = p.TLS.AddInternalPkiArgs(args)
 	if p.Region != "" {
 		args = append(args, "--region")
 		args = append(args, p.Region)
-	}
-	if p.UseVaultPki {
-		args = append(args, "--useVaultPki")
 	}
 	options := process.StartOptions{}
 	options.ApplyStartOptions(opts...)

--- a/e2e-tests/int-process/services.go
+++ b/e2e-tests/int-process/services.go
@@ -112,20 +112,22 @@ func getShepherdProc(cloudlet *edgeproto.Cloudlet, pfConfig *edgeproto.PlatformC
 			Hostname: cloudlet.Key.Name,
 			EnvVars:  envVars,
 		},
-		TLS: process.TLSCerts{
-			ServerCert: tlsCertFile,
-			ServerKey:  tlsKeyFile,
-			CACert:     tlsCAFile,
+		NodeCommon: process.NodeCommon{
+			TLS: process.TLSCerts{
+				ServerCert: tlsCertFile,
+				ServerKey:  tlsKeyFile,
+				CACert:     tlsCAFile,
+			},
+			VaultAddr:     vaultAddr,
+			UseVaultPki:   useVaultPki,
+			DeploymentTag: deploymentTag,
+			AccessApiAddr: accessApiAddr,
 		},
-		VaultAddr:      vaultAddr,
 		PhysicalName:   cloudlet.PhysicalName,
 		Span:           span,
 		Region:         region,
-		UseVaultPki:    useVaultPki,
 		AppDNSRoot:     appDNSRoot,
-		DeploymentTag:  deploymentTag,
 		ChefServerPath: chefServerPath,
-		AccessApiAddr:  accessApiAddr,
 	}, opts, nil
 }
 

--- a/e2e-tests/setups/local_multi.yml
+++ b/e2e-tests/setups/local_multi.yml
@@ -100,7 +100,6 @@ controllers:
   appdnsroot: mobiledgex.net
   deploymenttag: dev
   accessapiaddr: "127.0.0.1:41001"
-  requirenotifyaccesskey: true
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
@@ -121,7 +120,6 @@ controllers:
   appdnsroot: mobiledgex.net
   deploymenttag: dev
   accessapiaddr: "127.0.0.1:41002"
-  requirenotifyaccesskey: true
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
@@ -144,7 +142,6 @@ controllers:
   deploymenttag: dev
   influxaddr: "http://127.0.0.1:8087"
   accessapiaddr: "127.0.0.1:41011"
-  requirenotifyaccesskey: true
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
@@ -167,7 +164,6 @@ controllers:
   deploymenttag: dev
   influxaddr: "http://127.0.0.1:8087"
   accessapiaddr: "127.0.0.1:41012"
-  requirenotifyaccesskey: true
   envvars:
     ES_SERVER_URLS: https://localhost:9201
     E2ETEST_TLS: true
@@ -308,7 +304,6 @@ mcs:
   consoleproxyaddr: "127.0.0.1:6080"
   alertresolvetimeout: "{{alertmgrresolvetimeout}}"
   alertmgrapiaddr: "https://127.0.0.1:9094"
-  billingpath: "fake"
   apitlscert: "{{tlsoutdir}}/mex-server.crt"
   apitlskey: "{{tlsoutdir}}/mex-server.key"
   deploymenttag: dev


### PR DESCRIPTION
E2e-tests were failing because the autoprov service had a deploymentTag set in the setup file, but the process definition didn't support that field, so it was silently ignored - this cause the events to go to the wrong elastic search database, which caused the tests to fail because all the autoprov events were missing.

I initially changed the yaml unmarshal to strict for everything, and started fixing all the extra junk that's been leftover in the data files, but it turned out to be too much, so for now I've just made the unmarshal of the setup file strict, which the data files still ignore invalid data. See the edge-cloud PR for that strict change (https://github.com/mobiledgex/edge-cloud/pull/1336).