### PR TITLE
Edgecloud-4949: flavor charging and other bugfixes

### DIFF
--- a/billing/chargify/flavor_map.go
+++ b/billing/chargify/flavor_map.go
@@ -1,10 +1,10 @@
 package chargify
 
 import (
-	"strings"
 	"time"
 
 	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/util"
 )
 
 var dmeApiCode = "dmeapi"
@@ -14,5 +14,5 @@ func getComponentCode(flavor string, cloudlet *edgeproto.CloudletKey, start, end
 	// for now just return flavor, later on we can get more complex with different prices based on cloudlet and peak usage times
 	// Handle must start with a letter or number and may only contain lowercase letters, numbers, or the characters ':', '-', or '_'
 	// replace .&,!
-	return "handle:" + strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(flavor, ".", ":"), "&", ":"), ",", ":"), "!", ":")
+	return "handle:" + util.DNSSanitize(flavor)
 }

--- a/billing/chargify/usage.go
+++ b/billing/chargify/usage.go
@@ -13,7 +13,6 @@ import (
 )
 
 func (bs *BillingService) RecordUsage(ctx context.Context, account *ormapi.AccountInfo, usageRecords []billing.UsageRecord) error {
-	fmt.Printf("usagerecord: %+v\n", usageRecords)
 	for _, record := range usageRecords {
 		var memo string
 		var cloudlet *edgeproto.CloudletKey
@@ -39,7 +38,6 @@ func (bs *BillingService) RecordUsage(ctx context.Context, account *ormapi.Accou
 			Quantity: duration,
 			Memo:     memo,
 		}
-		fmt.Printf("new usage: %+v\n", newUsage)
 		resp, err := newChargifyReq("POST", endpoint, UsageWrapper{Usage: &newUsage})
 		if err != nil {
 			return fmt.Errorf("Error sending request: %v\n", err)

--- a/mc/orm/billing_organization.go
+++ b/mc/orm/billing_organization.go
@@ -40,23 +40,13 @@ func CreateBillingOrg(c echo.Context) error {
 // Parent billing orgs will have a billing Group, self billing orgs will just use the existing developer group from the org
 func CreateBillingOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.BillingOrganization) error {
 	// TODO: remove this later, for now only mexadmin the permission to create billingOrgs
-	roles, err := ShowUserRoleObj(ctx, claims.Username)
-	if err != nil {
-		return fmt.Errorf("Unable to discover user roles: %v", err)
-	}
-	isAdmin := false
-	for _, role := range roles {
-		if isAdminRole(role.Role) {
-			isAdmin = true
-		}
-	}
-	if !isAdmin && billingEnabled(ctx) {
+	if !isAdmin(ctx, claims.Username) && billingEnabled(ctx) {
 		return fmt.Errorf("Currently only admins may create and commit billingOrgs")
 	}
 	if org.Name == "" {
 		return fmt.Errorf("Name not specified")
 	}
-	err = ValidName(org.Name)
+	err := ValidName(org.Name)
 	if err != nil {
 		return err
 	}
@@ -415,23 +405,14 @@ func DeleteBillingOrg(c echo.Context) error {
 }
 
 func DeleteBillingOrgObj(ctx context.Context, claims *UserClaims, org *ormapi.BillingOrganization) error {
-	roles, err := ShowUserRoleObj(ctx, claims.Username)
-	if err != nil {
-		return fmt.Errorf("Unable to discover user roles: %v", err)
-	}
-	isAdmin := false
-	for _, role := range roles {
-		if isAdminRole(role.Role) {
-			isAdmin = true
-		}
-	}
-	if !isAdmin && billingEnabled(ctx) {
+	// TODO: remove this check later, for now to keep consistent with create, only allow admins to delete billingOrgs
+	if !isAdmin(ctx, claims.Username) && billingEnabled(ctx) {
 		return fmt.Errorf("Currently only admins may create and commit billingOrgs")
 	}
 	if org.Name == "" {
 		return fmt.Errorf("Organization name not specified")
 	}
-	if err = authorized(ctx, claims.Username, org.Name, ResourceBilling, ActionManage); err != nil {
+	if err := authorized(ctx, claims.Username, org.Name, ResourceBilling, ActionManage); err != nil {
 		return err
 	}
 	orgDetails, err := billingOrgExists(ctx, org.Name)

--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -606,3 +606,16 @@ func isApiKeyRole(role string) bool {
 	}
 	return false
 }
+
+func isAdmin(ctx context.Context, username string) bool {
+	roles, err := ShowUserRoleObj(ctx, username)
+	if err != nil {
+		return false
+	}
+	for _, role := range roles {
+		if isAdminRole(role.Role) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Have mc actually start recording usage to real flavors in chargify. 

There character restrictions for an api handle for a component in chargify is currently stricter than our naming convention for flavors. This could result in some collisions if flavor naming gets tricky, for example `x1.medium` and `x1?medium` would currently map to the same components. We could just also restrict the naming of flavors to match chargify. I believe currently the only character we are using in our flavor names that isnt allowed in a chargify api handle is the `.`, so we don't necessarily need to decide on this right away. 

Also made billing org deletion mexadmin only as well, just to keep things consistent with create