### PR TITLE
Fix edge cloud image build to store MobiledgeX logo

### DIFF
--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -76,6 +76,3 @@ RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/late
 	&& mv /tmp/eksctl /usr/local/bin
 
 COPY edge-cloud-base-image.root/_ssh /root/.ssh
-
-WORKDIR /go/src/github.com/mobiledgex
-COPY edge-cloud-infra/static/MobiledgeX_Logo.png /MobiledgeX_Logo.png


### PR DESCRIPTION
Moved this to edge-cloud Dockerfile: https://github.com/mobiledgex/edge-cloud/pull/1338