### PR TITLE
Allow setting region-specific InfluxDB volume size overrides

### DIFF
--- a/ansible/mexdemo/group_vars/platform.yml
+++ b/ansible/mexdemo/group_vars/platform.yml
@@ -18,6 +18,7 @@ regions:
       - 262-01
       - 262-06
       - sdkdemo
+    influxdb_volume_size: 50Gi
 
   - name: mexdemo-us
     location: northcentralus

--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -115,6 +115,7 @@
         resource_group: "{{ item.resource_group }}"
         dme_aliases: "{{ item.global_dme_aliases }}"
         kubernetes_version: "{{ item.kubernetes_version }}"
+        cluster_influxdb_volume_size: "{{ item.influxdb_volume_size }}"
       with_items: "{{ platform_regions }}"
 
     - debug: var=dme_details

--- a/ansible/roles/azure-aks/tasks/platform-regions-load.yml
+++ b/ansible/roles/azure-aks/tasks/platform-regions-load.yml
@@ -10,13 +10,15 @@
           'dns_prefix': dns_pref,
           'resource_group': rg,
           'kubernetes_version': kver,
-          'global_dme_aliases': gdme
+          'global_dme_aliases': gdme,
+          'influxdb_volume_size': influxpvc
       } ] }}
   vars:
     rg: "{{ pr.azure_resource_group_name | default(pr.name + '-rg') }}"
     kver: "{{ pr.kubernetes_version | default(kubernetes_version) }}"
     dns_pref: "{{ pr.dns_prefix | default(pr.name) }}"
     gdme: "{{ pr.global_dme_aliases | default([]) | map('regex_replace', '$', global_dme_suffix) | list }}"
+    influxpvc: "{{ pr.influxdb_volume_size | default(influxdb_volume_size) }}"
   loop: "{{ regions }}"
   loop_control:
     loop_var: pr
@@ -31,6 +33,7 @@
       - pr.dns_prefix != ""
       - pr.resource_group != ""
       - pr.kubernetes_version != ""
+      - pr.influxdb_volume_size != ""
   loop: "{{ platform_regions }}"
   loop_control:
     loop_var: pr

--- a/ansible/roles/influxdb/tasks/main.yml
+++ b/ansible/roles/influxdb/tasks/main.yml
@@ -54,11 +54,19 @@
     namespace: default
     definition: "{{ lookup('file', 'influxdb-config.yaml') }}"
 
-- name: "Set up data volume ({{ influxdb_volume_size }})"
+- name: "Check data volume ({{ cluster_influxdb_volume_size }})"
   k8s:
     kubeconfig: "{{ kubeconfig_file.path }}"
     namespace: default
     definition: "{{ lookup('template', 'influxdb-volume.yml.j2') }}"
+  check_mode: yes
+  register: pvc
+
+- name: Ensure PVC does not need resizing
+  assert:
+    that:
+      - pvc.method == "create" or not pvc.changed
+    fail_msg: "PVC needs resizing: {{ influxdb_volume_name }}: {{ cluster_influxdb_volume_size }}"
 
 - name: "Deploy InfluxDB v{{ influxdb_version }}"
   k8s:

--- a/ansible/roles/influxdb/templates/influxdb-volume.yml.j2
+++ b/ansible/roles/influxdb/templates/influxdb-volume.yml.j2
@@ -8,4 +8,4 @@ spec:
   storageClassName: {{ azure_volume_storage_class }}
   resources:
     requests:
-      storage: {{ influxdb_volume_size }}
+      storage: {{ cluster_influxdb_volume_size }}


### PR DESCRIPTION
- Bump up EU InfluxDB volume to 50GB.
- Do not attempt to resize volumes automatically. Azure fails miserably at that.