### PR TITLE
EDGECLOUD-4947: EVENT_INIT_CONNECTION should not need location...latency, location, and FindCloudlet has already provided that info.

### DIFF
--- a/e2e-tests/data/edgeevent-req.yml
+++ b/e2e-tests/data/edgeevent-req.yml
@@ -12,9 +12,6 @@ findcloudletrequest:
   cellid: 1234
 clientedgeevent:
   eventtype: EVENT_INIT_CONNECTION
-  gpslocation:
-    latitude: 31.00
-    longitude: -91.00
   deviceinfostatic:
     deviceos: Android
     devicemodel: "SM-G920F"


### PR DESCRIPTION
remove gps location from edgeevents init in e2e test