### PR TITLE
fix firewall rules and default gw in netplan

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -308,7 +308,8 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 				return err
 			}
 			updateCallback(edgeproto.UpdateTask, "Configuring Firewall Rules")
-			ops := infracommon.ProxyDnsSecOpts{AddProxy: true, AddDnsAndPatchKubeSvc: false, AddSecurityRules: false}
+			addSecRules := v.VMProperties.IptablesBasedFirewall // need to do the rules here for iptables based providers
+			ops := infracommon.ProxyDnsSecOpts{AddProxy: true, AddDnsAndPatchKubeSvc: false, AddSecurityRules: addSecRules}
 			wlParams := infracommon.WhiteListParams{
 				SecGrpName:  infracommon.GetServerSecurityGroupName(orchVals.externalServerName),
 				ServerName:  orchVals.externalServerName,


### PR DESCRIPTION
EDGECLOUD-4983

Two VM App issues for VCD from TEF:
- Firewall rules are not opened for Iptables firewalls.  This is does not happen for Openstack it is done in the Heat template, but for iptables based firewalls, we need to open the ports separately
- TEF experienced a case in which the second default GW was not removed.   Normally we remove this via "route del" in the bootcmd, and it works most of the time but in one particular instance it did not, I believe due to timing.   To try to address this I am removing the second GW from the netplan file; I previously thought this was not needed