### PR TITLE
VCD VM image upload timeout

### DIFF
--- a/crm-platforms/vcd/vcd-appinst.go
+++ b/crm-platforms/vcd/vcd-appinst.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
@@ -24,6 +25,8 @@ type VmAppOvfParams struct {
 }
 
 var vcdDirectUser string = "vcdDirect"
+
+var uploadResponseHeaderTimeout time.Duration = time.Second * 15
 
 var vmAppOvfTemplate = `<?xml version='1.0' encoding='UTF-8'?>
 <Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
@@ -155,6 +158,8 @@ func (v *VcdPlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo *in
 	}
 
 	filesToCleanup := []string{}
+	filesToUpload := []string{}
+
 	defer func() {
 		for _, file := range filesToCleanup {
 			log.SpanLog(ctx, log.DebugLevelInfra, "delete file", "file", file)
@@ -193,6 +198,7 @@ func (v *VcdPlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo *in
 			if err != nil {
 				return err
 			}
+			filesToUpload = append(filesToUpload, vmdkFile)
 		}
 
 		filenameNoExtension := strings.TrimSuffix(vmdkFile, filepath.Ext(vmdkFile))
@@ -213,9 +219,10 @@ func (v *VcdPlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo *in
 		if err != nil {
 			return fmt.Errorf("unable to write OVF file %s: %s", ovfFile, err.Error())
 		}
+		filesToUpload = append(filesToUpload, ovfFile)
 
 		updateCallback(edgeproto.UpdateTask, "Uploading OVF to Artifactory")
-		for _, f := range filesToCleanup {
+		for _, f := range filesToUpload {
 			artifactoryPathMinusFile = u.Scheme + "://" + u.Host + strings.Join(ps[:len(ps)-1], "/") + "/"
 			uploadPath := artifactoryPathMinusFile + filepath.Base(f)
 			log.SpanLog(ctx, log.DebugLevelInfra, "Uploading OVF to Artifactory", "uploadPath", uploadPath)
@@ -223,8 +230,19 @@ func (v *VcdPlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo *in
 			if err != nil {
 				return fmt.Errorf("unable to open file: %s for upload - %v", f, err)
 			}
-			body := bufio.NewReader(file)
+			fi, err := file.Stat()
+			if err != nil {
+				return fmt.Errorf("Could not stat file: %s - %v", f, err)
+			}
 			reqConfig := cloudcommon.RequestConfig{}
+			size := fi.Size()
+			timeout := cloudcommon.GetTimeout(int(size))
+			if timeout > 0 {
+				reqConfig.Timeout = timeout
+				log.SpanLog(ctx, log.DebugLevelApi, "increased upload timeout", "file", f, "timeout", timeout.String())
+			}
+			reqConfig.ResponseHeaderTimeout = uploadResponseHeaderTimeout
+			body := bufio.NewReader(file)
 			reqConfig.Headers = make(map[string]string)
 			reqConfig.Headers["Content-Type"] = "application/octet-stream"
 			resp, err := cloudcommon.SendHTTPReq(ctx, "PUT", uploadPath, v.vmProperties.CommonPf.PlatformConfig.AccessApi, &reqConfig, body)


### PR DESCRIPTION
EDGECLOUD-4887

- use configurable timeouts when uploading images
- avoid re-uploading the original qcow2 file