### PR TITLE
response header timeout change

### DIFF
--- a/crm-platforms/vcd/vcd-appinst.go
+++ b/crm-platforms/vcd/vcd-appinst.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
@@ -25,8 +24,6 @@ type VmAppOvfParams struct {
 }
 
 var vcdDirectUser string = "vcdDirect"
-
-var uploadResponseHeaderTimeout time.Duration = time.Second * 15
 
 var vmAppOvfTemplate = `<?xml version='1.0' encoding='UTF-8'?>
 <Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
@@ -239,9 +236,9 @@ func (v *VcdPlatform) AddAppImageIfNotPresent(ctx context.Context, imageInfo *in
 			timeout := cloudcommon.GetTimeout(int(size))
 			if timeout > 0 {
 				reqConfig.Timeout = timeout
+				reqConfig.ResponseHeaderTimeout = timeout
 				log.SpanLog(ctx, log.DebugLevelApi, "increased upload timeout", "file", f, "timeout", timeout.String())
 			}
-			reqConfig.ResponseHeaderTimeout = uploadResponseHeaderTimeout
 			body := bufio.NewReader(file)
 			reqConfig.Headers = make(map[string]string)
 			reqConfig.Headers["Content-Type"] = "application/octet-stream"


### PR DESCRIPTION
My previous fix for the upload response header timeout worked in the dev lab but not in Tom's QA setup, as the upload still timed out.  To get a better understanding, I built a test load with an adjustable timeout via envvar and Tom ran a bunch of tests against it.  The conclusion is that the response header timeout needs to be about as long as the total timeout, This was a little surprising as in the GET case it works fine with just 5 seconds but apparently PUT is different.

Based on Tom's test results, this fix sets the ResponseHeaderTimeout the same as the overall timeout.