### PR TITLE
allow forwarding only to external interface

### DIFF
--- a/infracommon/common-iptables.go
+++ b/infracommon/common-iptables.go
@@ -212,7 +212,11 @@ func getCurrentIptableRulesForLabel(ctx context.Context, client ssh.Client, labe
 	}
 	lines := strings.Split(out, "\n")
 	for _, line := range lines {
-		if strings.Contains(line, "\"label "+label+"\"") && strings.HasPrefix(line, "-A") {
+		if label == "" {
+			if strings.HasPrefix(line, "-A") {
+				rules[line] = line
+			}
+		} else if strings.Contains(line, "\"label "+label+"\"") && strings.HasPrefix(line, "-A") {
 			rules[line] = line
 		}
 	}
@@ -251,6 +255,49 @@ func removeIptablesRule(ctx context.Context, client ssh.Client, direction string
 		if err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// FixForwardingRules fixes rules which had allowed inter-cluster forwarding and replaces
+// then with rules that allow only forwarding to the external interface
+func FixForwardingRules(ctx context.Context, client ssh.Client, externalIf string) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "FixForwardingRules", "externalIf", externalIf)
+	currentRules, err := getCurrentIptableRulesForLabel(ctx, client, "")
+	if err != nil {
+		return err
+	}
+	changeMade := false
+	forwardingPatternNoExtIf := "FORWARD -i (\\w+) -j ACCEPT"
+	reg := regexp.MustCompile(forwardingPatternNoExtIf)
+	for _, r := range currentRules {
+		if reg.MatchString(r) {
+			matches := reg.FindStringSubmatch(r)
+			if len(matches) != 2 { // one match for the whole string, one for the interface grouping
+				return fmt.Errorf("Unexpected regex match count %d for forwarding rule: %s", len(matches), r)
+			}
+			internalIf := matches[1]
+			// delete the rule with no external IF
+			delCmd := strings.Replace(r, "-A ", "-D ", 1)
+			action := InterfaceActionsOp{DeleteIptables: true}
+			log.SpanLog(ctx, log.DebugLevelInfra, "Removing forwarding rule with no external interface", "delCmd", delCmd)
+			err := DoIptablesCommand(ctx, client, delCmd, true, &action)
+			if err != nil {
+				return err
+			}
+			// add the rule back with the external IF
+			addCmd := strings.Replace(r, "FORWARD -i "+internalIf+" -j ACCEPT", "FORWARD -i "+internalIf+" -o "+externalIf+" -j ACCEPT", 1)
+			log.SpanLog(ctx, log.DebugLevelInfra, "Adding back forwarding rule with external interface", "addCmd", addCmd)
+
+			err = DoIptablesCommand(ctx, client, addCmd, true, &action)
+			if err != nil {
+				return err
+			}
+			changeMade = true
+		}
+	}
+	if changeMade {
+		return PersistIptablesRules(ctx, client)
 	}
 	return nil
 }

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -279,7 +279,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		if app.AccessType == edgeproto.AccessType_ACCESS_TYPE_LOAD_BALANCER {
 			updateCallback(edgeproto.UpdateTask, "Setting Up Load Balancer")
 			pp := edgeproto.TrustPolicy{}
-			err = v.SetupRootLB(ctx, orchVals.lbName, &clusterInst.Key.CloudletKey, &pp, updateCallback)
+			err = v.SetupRootLB(ctx, orchVals.lbName, &clusterInst.Key.CloudletKey, &pp, false, updateCallback)
 			if err != nil {
 				return err
 			}

--- a/vmlayer/cluster.go
+++ b/vmlayer/cluster.go
@@ -373,7 +373,7 @@ func (v *VMPlatform) setupClusterRootLBAndNodes(ctx context.Context, rootLBName 
 		log.SpanLog(ctx, log.DebugLevelInfra, "new dedicated rootLB", "IpAccess", clusterInst.IpAccess)
 		updateCallback(edgeproto.UpdateTask, "Setting Up Root LB")
 		TrustPolicy := edgeproto.TrustPolicy{}
-		err := v.SetupRootLB(ctx, rootLBName, &clusterInst.Key.CloudletKey, &TrustPolicy, updateCallback)
+		err := v.SetupRootLB(ctx, rootLBName, &clusterInst.Key.CloudletKey, &TrustPolicy, false, updateCallback)
 		if err != nil {
 			return err
 		}

--- a/vmlayer/iptables.go
+++ b/vmlayer/iptables.go
@@ -31,7 +31,7 @@ func (v *VMPlatform) setupForwardingIptables(ctx context.Context, client ssh.Cli
 	masqueradeRule := fmt.Sprintf("-t nat %s %s", option, masqueradeRuleMatch)
 	forwardExternalRuleMatch := fmt.Sprintf("FORWARD -i %s -o %s -m state --state RELATED,ESTABLISHED -j ACCEPT", externalIfname, internalIfname)
 	forwardExternalRule := fmt.Sprintf("%s %s", option, forwardExternalRuleMatch)
-	forwardInternalRuleMatch := fmt.Sprintf("FORWARD -i %s -j ACCEPT", internalIfname)
+	forwardInternalRuleMatch := fmt.Sprintf("FORWARD -i %s -o %s -j ACCEPT", internalIfname, externalIfname)
 	forwardInternalRule := fmt.Sprintf("%s %s", option, forwardInternalRuleMatch)
 
 	masqueradeRuleExists := false

--- a/vmlayer/vmprovider.go
+++ b/vmlayer/vmprovider.go
@@ -448,7 +448,7 @@ func (v *VMPlatform) Init(ctx context.Context, platformConfig *platform.Platform
 
 	log.SpanLog(ctx, log.DebugLevelInfra, "calling SetupRootLB")
 	updateCallback(edgeproto.UpdateTask, "Setting up RootLB")
-	err = v.SetupRootLB(ctx, v.VMProperties.SharedRootLBName, v.VMProperties.CommonPf.PlatformConfig.CloudletKey, nil, updateCallback)
+	err = v.SetupRootLB(ctx, v.VMProperties.SharedRootLBName, v.VMProperties.CommonPf.PlatformConfig.CloudletKey, nil, true, updateCallback)
 	if err != nil {
 		return err
 	}
@@ -459,7 +459,6 @@ func (v *VMPlatform) Init(ctx context.Context, platformConfig *platform.Platform
 	if err != nil {
 		return err
 	}
-
 	updateCallback(edgeproto.UpdateTask, "Setting up Proxy")
 	err = proxy.InitL7Proxy(ctx, client, proxy.WithDockerNetwork("host"))
 	if err != nil {


### PR DESCRIPTION
EDGECLOUD-5036

Currently the shared RootLB allows iptables forwarding between internal interfaces.  This allows one cluster to be able to ping another which is a security violation.  

- Add the external interface when creating forwarding rules to prevent inter-cluster communication
- Create a function FixForwardingRules which will find and correct previously created rules and add the external interface.  This is only needed for a short period of time and will correct the existing rules on CRM startup