### PR TITLE
EDGECLOUD-5015:allow flavor maching for platforms with no native flav…

### DIFF
--- a/crm-platforms/vcd/vcd-common-utils.go
+++ b/crm-platforms/vcd/vcd-common-utils.go
@@ -12,7 +12,8 @@ import (
 )
 
 func (v *VcdPlatform) GetFlavor(ctx context.Context, flavorName string) (*edgeproto.FlavorInfo, error) {
-	flavs, err := v.GetFlavorListInternal(ctx)
+
+	flavs, err := v.vmProperties.GetFlavorListInternal(ctx, v.caches)
 	if err != nil {
 		return nil, err
 	}
@@ -28,66 +29,6 @@ func (v *VcdPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.FlavorInf
 	var flavors []*edgeproto.FlavorInfo
 	// by returning no flavors, we signal to the controller this platform supports no native flavors
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorList return empty", "len", len(flavors))
-	return flavors, nil
-}
-
-func (v *VcdPlatform) GetFlavorListInternal(ctx context.Context) ([]*edgeproto.FlavorInfo, error) {
-	log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorListInternal")
-
-	var flavors []*edgeproto.FlavorInfo
-	if v.caches == nil {
-		log.WarnLog("flavor cache is nil")
-		return nil, fmt.Errorf("Flavor cache is nil")
-	}
-	flavorkeys := make(map[edgeproto.FlavorKey]struct{})
-	v.caches.FlavorCache.GetAllKeys(ctx, func(k *edgeproto.FlavorKey, modRev int64) {
-
-		flavorkeys[*k] = struct{}{}
-	})
-
-	for k := range flavorkeys {
-		if v.Verbose {
-			//log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorList found flavor", "key", k)
-		}
-		var flav edgeproto.Flavor
-		if v.caches.FlavorCache.Get(&k, &flav) {
-			var flavInfo edgeproto.FlavorInfo
-			flavInfo.Name = flav.Key.Name
-			if flav.Ram >= vmlayer.MINIMUM_RAM_SIZE {
-				flavInfo.Ram = flav.Ram
-			} else {
-				flavInfo.Ram = vmlayer.MINIMUM_RAM_SIZE
-			}
-			if flav.Vcpus >= vmlayer.MINIMUM_VCPUS {
-				flavInfo.Vcpus = flav.Vcpus
-			} else {
-				flavInfo.Vcpus = vmlayer.MINIMUM_VCPUS
-			}
-			if flav.Disk >= vmlayer.MINIMUM_DISK_SIZE {
-				flavInfo.Disk = flav.Disk
-			} else {
-				flavInfo.Disk = vmlayer.MINIMUM_DISK_SIZE
-			}
-			flavors = append(flavors, &flavInfo)
-		} else {
-			return nil, fmt.Errorf("fail to fetch flavor %s", k)
-		}
-	}
-
-	// add the default platform flavor as well
-	var rlbFlav edgeproto.Flavor
-	err := v.vmProperties.GetCloudletSharedRootLBFlavor(&rlbFlav)
-	if err != nil {
-		return nil, err
-	}
-	rootlbFlavorInfo := edgeproto.FlavorInfo{
-		Name:  "mex-rootlb-flavor",
-		Vcpus: rlbFlav.Vcpus,
-		Ram:   rlbFlav.Ram,
-		Disk:  rlbFlav.Disk,
-	}
-	flavors = append(flavors, &rootlbFlavorInfo)
-	log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorListInternal added SharedRootLB", "flavor", rootlbFlavorInfo)
 	return flavors, nil
 }
 

--- a/crm-platforms/vsphere/vsphere-cloudlet.go
+++ b/crm-platforms/vsphere/vsphere-cloudlet.go
@@ -52,7 +52,6 @@ func (v *VSpherePlatform) CreateImageFromUrl(ctx context.Context, imageName, ima
 func (v *VSpherePlatform) AddCloudletImageIfNotPresent(ctx context.Context, imgPathPrefix, imgVersion string, updateCallback edgeproto.CacheUpdateCallback) (string, error) {
 	// we don't currently have the ability to download and setup the template, but we will verify it is there
 	log.SpanLog(ctx, log.DebugLevelInfra, "AddCloudletImageIfNotPresent", "imgPathPrefix", imgPathPrefix, "imgVersion", imgVersion)
-
 	imgPath := vmlayer.GetCloudletVMImagePath(imgPathPrefix, imgVersion, v.GetCloudletImageSuffix(ctx))
 	// Fetch platform base image name
 	pfImageName, err := cloudcommon.GetFileName(imgPath)
@@ -89,7 +88,8 @@ func (v *VSpherePlatform) AddCloudletImageIfNotPresent(ctx context.Context, imgP
 }
 
 func (v *VSpherePlatform) GetFlavor(ctx context.Context, flavorName string) (*edgeproto.FlavorInfo, error) {
-	flavs, err := v.GetFlavorList(ctx)
+
+	flavs, err := v.vmProperties.GetFlavorListInternal(ctx, v.caches)
 	if err != nil {
 		return nil, err
 	}
@@ -102,58 +102,9 @@ func (v *VSpherePlatform) GetFlavor(ctx context.Context, flavorName string) (*ed
 }
 
 func (v *VSpherePlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.FlavorInfo, error) {
-	log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorList")
-	// we just send the controller back the same list of flavors it gave us, because VSphere has no flavor concept.
-	// Make sure each flavor is at least a minimum size to run the platform
 	var flavors []*edgeproto.FlavorInfo
-	if v.caches == nil {
-		log.WarnLog("flavor cache is nil")
-		return nil, fmt.Errorf("Flavor cache is nil")
-	}
-	flavorkeys := make(map[edgeproto.FlavorKey]struct{})
-	v.caches.FlavorCache.GetAllKeys(ctx, func(k *edgeproto.FlavorKey, modRev int64) {
-		flavorkeys[*k] = struct{}{}
-	})
-	for k := range flavorkeys {
-		log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorList found flavor", "key", k)
-		var flav edgeproto.Flavor
-		if v.caches.FlavorCache.Get(&k, &flav) {
-			var flavInfo edgeproto.FlavorInfo
-			flavInfo.Name = flav.Key.Name
-			if flav.Ram >= vmlayer.MINIMUM_RAM_SIZE {
-				flavInfo.Ram = flav.Ram
-			} else {
-				flavInfo.Ram = vmlayer.MINIMUM_RAM_SIZE
-			}
-			if flav.Vcpus >= vmlayer.MINIMUM_VCPUS {
-				flavInfo.Vcpus = flav.Vcpus
-			} else {
-				flavInfo.Vcpus = vmlayer.MINIMUM_VCPUS
-			}
-			if flav.Disk >= vmlayer.MINIMUM_DISK_SIZE {
-				flavInfo.Disk = flav.Disk
-			} else {
-				flavInfo.Disk = vmlayer.MINIMUM_DISK_SIZE
-			}
-			flavors = append(flavors, &flavInfo)
-		} else {
-			return nil, fmt.Errorf("fail to fetch flavor %s", k)
-		}
-	}
-
-	// add the default platform flavor as well
-	var rlbFlav edgeproto.Flavor
-	err := v.vmProperties.GetCloudletSharedRootLBFlavor(&rlbFlav)
-	if err != nil {
-		return nil, err
-	}
-	rootlbFlavorInfo := edgeproto.FlavorInfo{
-		Name:  "mex-rootlb-flavor",
-		Vcpus: rlbFlav.Vcpus,
-		Ram:   rlbFlav.Ram,
-		Disk:  rlbFlav.Disk,
-	}
-	flavors = append(flavors, &rootlbFlavorInfo)
+	// by returning no flavors, we signal to the controller this platform supports no native flavors
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorList return empty", "len", len(flavors))
 	return flavors, nil
 }
 

--- a/crm-platforms/vsphere/vsphere-orch.go
+++ b/crm-platforms/vsphere/vsphere-orch.go
@@ -160,7 +160,7 @@ func (v *VSpherePlatform) populateOrchestrationParams(ctx context.Context, vmgp 
 	masterIP := ""
 	var flavors []*edgeproto.FlavorInfo
 	var err error
-	flavors, err = v.GetFlavorList(ctx)
+	flavors, err = v.vmProperties.GetFlavorListInternal(ctx, v.caches)
 	if err != nil {
 		return err
 	}

--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -542,14 +542,12 @@ func (v *VMPlatform) getCloudletVMsSpec(ctx context.Context, accessApi platform.
 			if len(flavorList) == 0 {
 				flavInfo, err := v.GetDefaultRootLBFlavor(ctx)
 				if err != nil {
-					log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletVMsSpec cld flavor list empty GetDefaultLBflavor failed:", "error", err)
 					return nil, fmt.Errorf("unable to find DefaultShared RootLB flavor: %v", err)
 				}
 				spec.FlavorName = flavInfo.Name
 			} else {
 				restbls := v.GetResTablesForCloudlet(ctx, &cli.Key)
 				spec, err = vmspec.GetVMSpec(ctx, *pfFlavor, cli, restbls)
-
 				if err != nil {
 					return nil, fmt.Errorf("unable to find VM spec for Shared RootLB: %v", err)
 				}

--- a/vmlayer/lb.go
+++ b/vmlayer/lb.go
@@ -273,7 +273,7 @@ var MaxRootLBWait = 5 * time.Minute
 
 // used by cloudlet.go currently
 func (v *VMPlatform) GetDefaultRootLBFlavor(ctx context.Context) (*edgeproto.FlavorInfo, error) {
-	log.SpanLog(ctx, log.DebugLevelInfra, "GetDefaultRootLBFlavor clouldet flavor list empty use default")
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetDefaultRootLBFlavor cloudlet flavor list empty use default")
 	var rlbFlav edgeproto.Flavor
 	// must be a platform with no native flavor support, use our default LB flavor from props
 	err := v.VMProperties.GetCloudletSharedRootLBFlavor(&rlbFlav)
@@ -283,7 +283,7 @@ func (v *VMPlatform) GetDefaultRootLBFlavor(ctx context.Context) (*edgeproto.Fla
 	}
 
 	rootlbFlavorInfo := edgeproto.FlavorInfo{
-		Name:  "mex-rootlb-flavor",
+		Name:  MEX_ROOTLB_FLAVOR_NAME,
 		Vcpus: rlbFlav.Vcpus,
 		Ram:   rlbFlav.Ram,
 		Disk:  rlbFlav.Disk,

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -9,8 +9,10 @@ import (
 	"github.com/go-chef/chef"
 	"github.com/mobiledgex/edge-cloud-infra/chefmgmt"
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
 )
 
 type VMProperties struct {
@@ -29,6 +31,11 @@ type VMProperties struct {
 	CloudletAccessToken        string
 }
 
+const MEX_ROOTLB_FLAVOR_NAME = "mex-rootlb-flavor"
+const MINIMUM_DISK_SIZE uint64 = 20
+const MINIMUM_RAM_SIZE uint64 = 2048
+const MINIMUM_VCPUS uint64 = 2
+
 // note that qcow2 must be understood by vsphere and vmdk must
 // be known by openstack so they can be converted back and forth
 var ImageFormatQcow2 = "qcow2"
@@ -37,10 +44,6 @@ var ImageFormatVmdk = "vmdk"
 var MEXInfraVersion = "4.3.5"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
-
-const MINIMUM_DISK_SIZE uint64 = 20
-const MINIMUM_RAM_SIZE uint64 = 2048
-const MINIMUM_VCPUS uint64 = 2
 
 // NoSubnetDNS means that DNS servers are not specified when creating the subnet
 var NoSubnetDNS = "NONE"
@@ -193,41 +196,6 @@ func GetCloudletVMImagePath(imgPath, imgVersion string, imgSuffix string) string
 	return vmRegistryPath + GetCloudletVMImageName(imgVersion) + imgSuffix
 }
 
-// GetCloudletSharedRootLBFlavor gets the flavor from defaults
-// or environment variables
-func (vp *VMProperties) GetCloudletSharedRootLBFlavor(flavor *edgeproto.Flavor) error {
-	ram, _ := vp.CommonPf.Properties.GetValue("MEX_SHARED_ROOTLB_RAM")
-	var err error
-	if ram != "" {
-		flavor.Ram, err = strconv.ParseUint(ram, 10, 64)
-		if err != nil {
-			return err
-		}
-	} else {
-		flavor.Ram = 4096
-	}
-	vcpus, _ := vp.CommonPf.Properties.GetValue("MEX_SHARED_ROOTLB_VCPUS")
-	if vcpus != "" {
-		flavor.Vcpus, err = strconv.ParseUint(vcpus, 10, 64)
-		if err != nil {
-			return err
-		}
-	} else {
-		flavor.Vcpus = 2
-	}
-	disk, _ := vp.CommonPf.Properties.GetValue("MEX_SHARED_ROOTLB_DISK")
-	if disk != "" {
-		flavor.Disk, err = strconv.ParseUint(disk, 10, 64)
-		if err != nil {
-			return err
-		}
-	} else {
-		flavor.Disk = 40
-	}
-	flavor.Key.Name = "mex-rootlb-flavor"
-	return nil
-}
-
 // GetCloudletSecurityGroupName overrides cloudlet wide security group if set in
 // envvars, but normally is derived from the cloudlet name.  It is not exported
 // as providers should use VMProperties.CloudletSecgrpName
@@ -367,4 +335,100 @@ func (vp *VMProperties) GetRegion() string {
 
 func (vp *VMProperties) GetDeploymentTag() string {
 	return vp.CommonPf.DeploymentTag
+}
+
+// For platforms without native flavor support, just use our meta flavors
+// Adjust flavor size if subpar.
+func (vp *VMProperties) GetFlavorListInternal(ctx context.Context, caches *platform.Caches) ([]*edgeproto.FlavorInfo, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorListInternal")
+
+	var flavors []*edgeproto.FlavorInfo
+	if caches == nil {
+		log.WarnLog("flavor cache is nil")
+		return nil, fmt.Errorf("Flavor cache is nil")
+	}
+	flavorkeys := make(map[edgeproto.FlavorKey]struct{})
+	caches.FlavorCache.GetAllKeys(ctx, func(k *edgeproto.FlavorKey, modRev int64) {
+
+		flavorkeys[*k] = struct{}{}
+	})
+
+	for k := range flavorkeys {
+		var flav edgeproto.Flavor
+		if caches.FlavorCache.Get(&k, &flav) {
+			var flavInfo edgeproto.FlavorInfo
+			flavInfo.Name = flav.Key.Name
+			if flav.Ram >= MINIMUM_RAM_SIZE {
+				flavInfo.Ram = flav.Ram
+			} else {
+				flavInfo.Ram = MINIMUM_RAM_SIZE
+			}
+			if flav.Vcpus >= MINIMUM_VCPUS {
+				flavInfo.Vcpus = flav.Vcpus
+			} else {
+				flavInfo.Vcpus = MINIMUM_VCPUS
+			}
+			if flav.Disk >= MINIMUM_DISK_SIZE {
+				flavInfo.Disk = flav.Disk
+			} else {
+				flavInfo.Disk = MINIMUM_DISK_SIZE
+			}
+			flavors = append(flavors, &flavInfo)
+		} else {
+			return nil, fmt.Errorf("fail to fetch flavor %s", k)
+		}
+	}
+
+	// add the default platform flavor as well
+	var rlbFlav edgeproto.Flavor
+	// in props today can't get there from here...
+	err := vp.GetCloudletSharedRootLBFlavor(&rlbFlav)
+	if err != nil {
+		return nil, err
+	}
+	rootlbFlavorInfo := edgeproto.FlavorInfo{
+		Name:  MEX_ROOTLB_FLAVOR_NAME,
+		Vcpus: rlbFlav.Vcpus,
+		Ram:   rlbFlav.Ram,
+		Disk:  rlbFlav.Disk,
+	}
+	flavors = append(flavors, &rootlbFlavorInfo)
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetFlavorListInternal added SharedRootLB", "flavor", rootlbFlavorInfo)
+	return flavors, nil
+}
+
+// GetCloudletSharedRootLBFlavor gets the flavor from defaults
+// or environment variables
+func (vp *VMProperties) GetCloudletSharedRootLBFlavor(flavor *edgeproto.Flavor) error {
+
+	ram, _ := vp.CommonPf.Properties.GetValue("MEX_SHARED_ROOTLB_RAM")
+	var err error
+	if ram != "" {
+		flavor.Ram, err = strconv.ParseUint(ram, 10, 64)
+		if err != nil {
+			return err
+		}
+	} else {
+		flavor.Ram = 4096
+	}
+	vcpus, _ := vp.CommonPf.Properties.GetValue("MEX_SHARED_ROOTLB_VCPUS")
+	if vcpus != "" {
+		flavor.Vcpus, err = strconv.ParseUint(vcpus, 10, 64)
+		if err != nil {
+			return err
+		}
+	} else {
+		flavor.Vcpus = 2
+	}
+	disk, _ := vp.CommonPf.Properties.GetValue("MEX_SHARED_ROOTLB_DISK")
+	if disk != "" {
+		flavor.Disk, err = strconv.ParseUint(disk, 10, 64)
+		if err != nil {
+			return err
+		}
+	} else {
+		flavor.Disk = 40
+	}
+	flavor.Key.Name = MEX_ROOTLB_FLAVOR_NAME
+	return nil
 }


### PR DESCRIPTION
…or support
Platforms with no native flavors must use the values found in our meta-flavors. These signal this by returning an empty list of what would be native (openstack) flavors in GetFlavorsList. restagtable.GetVMSpec() recognizes this signal by creating a VMCreationSpec with embedded FlavorInfo from the meta-flavor given without attempting to employ vmspec/vmspec_matcher.GetVMSpec() to find a matching platform flavor, as there are none for these platform types. A clusterInst using a gpu meta flavor on a vcd platform shows the flavor, and the optres: gpu as: key:
clusterkey:
name: clst1
cloudletkey:
organization: packet
name: cld1
organization: MobiledgeX
flavor:
name: mex.small-gpu
liveness: LivenessStatic
state: Ready
ipaccess: IpAccessShared
nodeflavor: mex.small-gpu
deployment: docker
optres: gpu
resources:
vms:
- name: mex-docker-vm-cld1-clst1-mobiledgex
type: cluster-docker-node
infraflavor: mex.small-gpu
ipaddresses:
- internalip: 10.101.1.101
createdat:
seconds: 1622237940
nanos: 632976285