### PR TITLE
adaptation for 4.4.x image

### DIFF
--- a/crm-platforms/vsphere/vsphere-cloudlet.go
+++ b/crm-platforms/vsphere/vsphere-cloudlet.go
@@ -25,6 +25,19 @@ func (v *VSpherePlatform) SaveCloudletAccessVars(ctx context.Context, cloudlet *
 }
 
 func (v *VSpherePlatform) GetCloudletImageSuffix(ctx context.Context) string {
+	// we use a common image as of 4.4.0 and beyond
+	vers := v.vmProperties.CommonPf.PlatformConfig.VMImageVersion
+	if vers == "" {
+		vers = vmlayer.MEXInfraVersion
+	}
+	// note this string compare would fail for something like 4.10.x, but is only intended for short term purposes
+	// and should be removed after 4.4.0 has time to soak
+	if vers >= "4.4.0" {
+		log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletImageSuffix returning generic suffix post 4.4.0", "vers", vers)
+		return ".qcow2"
+	}
+	// older loads are specific per platform
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletImageSuffix returning vsphere specific suffix pre 4.4.0", "vers", vers)
 	return "-vsphere.qcow2"
 }
 


### PR DESCRIPTION
The baseimage is being reworked to be common across all platforms.  Currently vsphere assumes the image will end in -vsphere.qcow.  This will no longer be true after 4.4.0 and beyond.  

This is a backwards compatible but short term fix to allow testing with the 4.4.0 image soon to come out.  At a time in the near future this code can be simplified to just return ".qcow2" or GetCloudletImageSuffix can be removed totally