### PR TITLE
fix sporadic failures in e2e-tests

### DIFF
--- a/e2e-tests/testfiles/mc_add_delete.yml
+++ b/e2e-tests/testfiles/mc_add_delete.yml
@@ -75,7 +75,7 @@ tests:
 - includefile: find_cloudlet.yml
 
 - name: sleep, allow time for metrics to collect
-  actions: [sleep=2]
+  actions: [sleep=3]
 
 - name: Check client api metrics
   actions: [mcapi-showclientapimetrics]

--- a/vault/setup.sh
+++ b/vault/setup.sh
@@ -8,6 +8,7 @@ set -e
 
 vault secrets enable -path=jwtkeys kv
 vault kv enable-versioning jwtkeys
+sleep 1
 vault write jwtkeys/config max_versions=2
 
 # these are commented out but are used to set the mcorm secrets


### PR DESCRIPTION
Increase the sleep for app client collection interval. Wait for versioning being enabled for jwtkeys in setup.sh
 - setup.sh needs a short wait when enabling versioning - the service is put in the maintenance and subsequent command can sometimes fail
 - increased sleep to 3 seconds when waiting for client api metrics in mc_add_delete.yml