### PR TITLE
Limit orgName to 59 char as per artifactory repo name length limitati…

### DIFF
--- a/mc/orm/validate.go
+++ b/mc/orm/validate.go
@@ -12,8 +12,10 @@ func ValidName(name string) error {
 	err := util.ValidObjName(name)
 
 	// Gorm DB create works only for name <= 90
+	// Also, JFrog Artifactory repo name is created from OrgName and it must be <= 64
+	// In future, if we move away from artifactory, this limitation needs to be revisited.
 	const (
-		GormMaxName = 90
+		orgNameMax = 64
 	)
 
 	if err != nil {
@@ -43,7 +45,7 @@ func ValidName(name string) error {
 	if strings.HasSuffix(name, "-cache") {
 		return fmt.Errorf("Name cannot end with '-cache'")
 	}
-	if len(name) > GormMaxName {
+	if len(getArtifactoryRepoName(name)) > orgNameMax {
 		return fmt.Errorf("Name too long")
 	}
 	return nil

--- a/mc/orm/validate_test.go
+++ b/mc/orm/validate_test.go
@@ -9,7 +9,9 @@ import (
 func TestValidName(t *testing.T) {
 	var err error
 
-	var NameMax90Chars = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+	// Artifactory repo name uses orgName currently with a prefix "repo-"$orgName
+	// Total limit for artifactory name is 64 bytes. Work backwards to max orgName of 59 chars
+	var NameMax59Chars = "12345678901234567890123456789012345678901234567890123456789"
 
 	gname := GitlabGroupSanitize("niantic, inc.")
 	require.Equal(t, "niantic--inc", gname)
@@ -44,10 +46,10 @@ func TestValidName(t *testing.T) {
 	err = ValidName("username_123dev&test")
 	require.NotNil(t, err, "invalid user name")
 
-	err = ValidName(NameMax90Chars + "1")
+	err = ValidName(NameMax59Chars + "1")
 	require.NotNil(t, err, "invalid org name")
 
-	err = ValidName(NameMax90Chars)
+	err = ValidName(NameMax59Chars)
 	require.Nil(t, err)
 
 }


### PR DESCRIPTION
…on of 64 bytes - EDGECLOUD-4968