### PR TITLE
EDGECLOUD-5089  app metrics and clientappusage metrics not erroring when developer requests metrics without apporg

### DIFF
--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -774,8 +774,8 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 		poolCache.Update(ctx, &list[ii], 0)
 	}
 	// make sure there is at least one cloudletKey org is specified here
-	testFailCheckPermissionsAndGetCloudletList(t, ctx, oper.Name, ctrl.Region, []string{org1}, ResourceAppAnalytics,
-		[]edgeproto.CloudletKey{}, "No non-empty CloudletPools to show")
+	testFailCheckPermissionsAndGetCloudletList(t, ctx, oper.Name, ctrl.Region, []string{"invalidDeveloper"}, ResourceAppAnalytics,
+		[]edgeproto.CloudletKey{}, "Operators please specify the Cloudlet Organization")
 
 	// operator can see dev resources on cloudlet pool(returned list contains all cloudlets that operator is allowed to see)
 	// NOTE: there is a generated pool with three cloudlets - cloudlet1,cloudlet2,cloudlet3

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -838,10 +838,7 @@ func checkPermissionsAndGetCloudletList(ctx context.Context, username, region st
 	if _, found := authDevOrgs[""]; found {
 		// admin
 		devOrgPermOk = true
-	} else if len(devOrgs) == 0 {
-		// If no orgs are specified, no developer permissions
-		devOrgPermOk = false
-	} else {
+	} else if len(devOrgs) > 0 {
 		devOrgPermOk = true
 		for _, devOrg := range devOrgs {
 			_, devOrgPermOk = authDevOrgs[devOrg]
@@ -859,7 +856,7 @@ func checkPermissionsAndGetCloudletList(ctx context.Context, username, region st
 	if _, found := authOperOrgs[""]; found {
 		// admin
 		operOrgPermOk = true
-	} else {
+	} else if len(cloudletKeys) > 0 {
 		operOrgPermOk = true
 		for _, cloudletKey := range cloudletKeys {
 			_, operOrgPermOk = authOperOrgs[cloudletKey.Organization]


### PR DESCRIPTION
If no developer is specified for app-related metrics, we should error out. 
There was a bug where we default to permissions set to true. This was also a case for cloudletPool code path - fixed that too.

Also fixed random unit-test failures.