### PR TITLE
Added nodecount to billingevents api

### DIFF
--- a/mc/orm/influx_events.go
+++ b/mc/orm/influx_events.go
@@ -16,6 +16,7 @@ var clusterEventFields = []string{
 	"vcpu",
 	"ram",
 	"disk",
+	"nodecount",
 	"other",
 }
 


### PR DESCRIPTION
nodecount is already stored in influx, just was never exposed in the events api.

Example:
```
mcctl --skipverify --addr https://localhost:9900 billingevents cluster region=local cluster-org=DevOrg
data:
- series:
  - columns:
    - time
    - cluster
    - clusterorg
    - cloudlet
    - cloudletorg
    - reservedBy
    - flavor
    - vcpu
    - ram
    - disk
    - nodecount
    - other
    - event
    - status
    name: clusterinst-checkpoints
    values:
    - - "2021-06-16T18:12:00Z"
      - AppCluster
      - DevOrg
      - localtest
      - mexdev
      - null
      - x1.medium
      - null
      - null
      - null
      - 4
      - null
      - null
      - UP
    - - "2021-06-16T18:09:00Z"
      - AppCluster
      - DevOrg
      - localtest
      - mexdev
      - null
      - x1.medium
      - null
      - null
      - null
      - 4
      - null
      - null
      - UP
  - columns:
    - time
    - cluster
    - clusterorg
    - cloudlet
    - cloudletorg
    - reservedBy
    - flavor
    - vcpu
    - ram
    - disk
    - nodecount
    - other
    - event
    - status
    name: clusterinst
    values:
    - - "2021-06-16T18:06:57.599204Z"
      - AppCluster
      - DevOrg
      - localtest
      - mexdev
      - null
      - x1.medium
      - 4
      - 4096
      - 40
      - 4
      - map[]
      - CREATED
      - UP
```