### PR TITLE
EDGECLOUD-5138/5064/5137: Remove Every30Days enum + Fix report graph + Improve titles

### DIFF
--- a/mc/orm/reporter.go
+++ b/mc/orm/reporter.go
@@ -49,8 +49,6 @@ func getScheduleDayMonthCount(schedule edgeproto.ReportSchedule) (int, int, erro
 		dayCount = 7
 	case edgeproto.ReportSchedule_Every15Days:
 		dayCount = 15
-	case edgeproto.ReportSchedule_Every30Days:
-		dayCount = 30
 	case edgeproto.ReportSchedule_EveryMonth:
 		monthCount = 1
 	default:
@@ -1515,7 +1513,7 @@ func GenerateCloudletReport(ctx context.Context, username string, regions []stri
 		if len(cloudletpools) > 0 {
 			header = []string{"Name", "Associated Cloudlets", "Accepted Developers", "Pending Developers"}
 			columnsWidth = []float64{30, 60, 50, 50}
-			pdfReport.AddTable("CloudletPools", header, cloudletpools, columnsWidth)
+			pdfReport.AddTable("CloudletPools - Last Known Details", header, cloudletpools, columnsWidth)
 		}
 
 		// Sort cloudlet by name
@@ -1543,7 +1541,7 @@ func GenerateCloudletReport(ctx context.Context, username string, regions []stri
 
 			// Get top flavors used per Cloudlet
 			if data, ok := flavorData[cloudletName]; ok {
-				err = pdfReport.AddPieChart(cloudletName, "Flavor Usage Count", data)
+				err = pdfReport.AddPieChart(cloudletName, "Flavor Usage - Count of maximum flavors used", data)
 				if err != nil {
 					return nil, err
 				}
@@ -1564,7 +1562,7 @@ func GenerateCloudletReport(ctx context.Context, username string, regions []stri
 
 			// Get app count by developer on cloudlet
 			if data, ok := appCountData[cloudletName]; ok {
-				err = pdfReport.AddPieChart(cloudletName, "App Count By Developer", data)
+				err = pdfReport.AddPieChart(cloudletName, "Developer App Deployments - Count of maximum apps deployed by developers", data)
 				if err != nil {
 					return nil, err
 				}

--- a/mc/ormapi/api.comments.go
+++ b/mc/ormapi/api.comments.go
@@ -173,7 +173,7 @@ var ReporterComments = map[string]string{
 	"name":              `Reporter name. Can only contain letters, digits, period, hyphen. It cannot have leading or trailing spaces or period. It cannot start with hyphen`,
 	"org":               `Organization name`,
 	"email":             `Email to send generated reports`,
-	"schedule":          `Indicates how often a report should be generated, one of EveryWeek, Every15Days, Every30Days, EveryMonth`,
+	"schedule":          `Indicates how often a report should be generated, one of EveryWeek, Every15Days, EveryMonth`,
 	"startscheduledate": `Start date (in RFC3339 format with intended timezone) when the report is scheduled to be generated (Default: today)`,
 	"nextscheduledate":  `Date when the next report is scheduled to be generated (for internal use only)`,
 	"username":          `User name (for internal use only)`,

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -576,7 +576,7 @@ type Reporter struct {
 	Org string `gorm:"primary_key;type:citext REFERENCES organizations(name)"`
 	// Email to send generated reports
 	Email string `json:",omitempty"`
-	// Indicates how often a report should be generated, one of EveryWeek, Every15Days, Every30Days, EveryMonth
+	// Indicates how often a report should be generated, one of EveryWeek, Every15Days, EveryMonth
 	Schedule edgeproto.ReportSchedule `json:",omitempty"`
 	// Start date (in RFC3339 format with intended timezone) when the report is scheduled to be generated (Default: today)
 	StartScheduleDate string `json:",omitempty"`


### PR DESCRIPTION
* Fix an issue seen with graphs generated in operator reports. All the values are handled as type `float64` and converting this to `int` was causing a problem. Hence, added custom ticks to get proper int based values from float64 values
* Also, removes Every30Days enum, as it is of no use. A user would always use EveryMonth rather than this
* Add some more details to few titles part of operator reports