### PR TITLE
Resource limits; Influxdb disk-backed index

### DIFF
--- a/ansible/roles/autoprov/templates/deploy.yml.j2
+++ b/ansible/roles/autoprov/templates/deploy.yml.j2
@@ -18,6 +18,13 @@ spec:
       - name: autoprov
         image: "{{ edge_cloud_image }}:{{ edge_cloud_version }}"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "100Mi"
+          limits:
+            cpu: "100m"
+            memory: "200Mi"
         command:
          - "autoprov"
          - "--ctrlAddrs"

--- a/ansible/roles/cluster-svc/templates/deploy.yml.j2
+++ b/ansible/roles/cluster-svc/templates/deploy.yml.j2
@@ -18,6 +18,13 @@ spec:
       - name: cluster-svc
         image: "{{ edge_cloud_image }}:{{ edge_cloud_version }}"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "100Mi"
+          limits:
+            cpu: "100m"
+            memory: "200Mi"
         command:
          - "cluster-svc"
          - "--notifyAddrs"

--- a/ansible/roles/controller/templates/deploy.yml.j2
+++ b/ansible/roles/controller/templates/deploy.yml.j2
@@ -18,6 +18,13 @@ spec:
       - name: controller
         image: "{{ edge_cloud_image }}:{{ edge_cloud_version }}"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "512Mi"
+          limits:
+            cpu: "400m"
+            memory: "1Gi"
         command:
          - "controller"
          - "--commonName"

--- a/ansible/roles/dme/templates/deploy.yml.j2
+++ b/ansible/roles/dme/templates/deploy.yml.j2
@@ -18,6 +18,13 @@ spec:
       - name: dme
         image: "{{ edge_cloud_image }}:{{ edge_cloud_version }}"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "150m"
+            memory: "100Mi"
+          limits:
+            cpu: "300m"
+            memory: "200Mi"
         command:
          - "/bin/bash"
          - "-ecx"

--- a/ansible/roles/edgeturn/templates/deploy.yml.j2
+++ b/ansible/roles/edgeturn/templates/deploy.yml.j2
@@ -18,6 +18,13 @@ spec:
       - name: edgeturn
         image: "{{ edge_cloud_image }}:{{ edge_cloud_version }}"
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "100Mi"
+          limits:
+            cpu: "100m"
+            memory: "200Mi"
         command:
          - "edgeturn"
          - "--commonName"

--- a/ansible/roles/etcd/templates/mex-etcd.yml
+++ b/ansible/roles/etcd/templates/mex-etcd.yml
@@ -23,6 +23,13 @@ spec:
       containers:
       - name: "{{ etcd_cluster_name }}"
         image: "quay.io/coreos/etcd:{{ etcd_version }}"
+        resources:
+          requests:
+            cpu: "75m"
+            memory: "750Mi"
+          limits:
+            cpu: "150m"
+            memory: "1500Mi"
         ports:
         - containerPort: 2379
           name: client

--- a/ansible/roles/influxdb/tasks/main.yml
+++ b/ansible/roles/influxdb/tasks/main.yml
@@ -47,12 +47,35 @@
 - set_fact:
     influxdb_user: "{{ vault_lookup.influxdb.data.user }}"
     influxdb_password: "{{ vault_lookup.influxdb.data.pass }}"
+    influxdb_config: "{{ lookup('template', 'influxdb-config.yaml.j2') }}"
 
-- name: Set up configmap
+- name: Check configmap
   k8s:
     kubeconfig: "{{ kubeconfig_file.path }}"
     namespace: default
-    definition: "{{ lookup('file', 'influxdb-config.yaml') }}"
+    definition: "{{ influxdb_config }}"
+  register: influxdb_configmap
+  check_mode: yes
+
+- block:
+  # Config map has been modified; check if the change is the index-version, in
+  # which case, abort as this needs a manual migration
+  - set_fact:
+      index_version_param: 'index-version = "{{ index_version }}"'
+
+  - name: 'Make sure the index-version is already "{{ index_version }}"'
+    assert:
+      that:
+        - "index_version_param in influxdb_configmap.diff.before.data['influxdb.conf']"
+      fail_msg: 'Needs manual migration to change index version to "{{ index_version }}"'
+
+  - name: Set up configmap
+    k8s:
+      kubeconfig: "{{ kubeconfig_file.path }}"
+      namespace: default
+      definition: "{{ influxdb_config }}"
+
+  when: influxdb_configmap.changed
 
 - name: "Check data volume ({{ cluster_influxdb_volume_size }})"
   k8s:

--- a/ansible/roles/influxdb/templates/influxdb-config.yaml.j2
+++ b/ansible/roles/influxdb/templates/influxdb-config.yaml.j2
@@ -14,7 +14,7 @@ data:
 
     [data]
       dir = "/var/lib/influxdb/data"
-      index-version = "inmem"
+      index-version = "{{ index_version }}"
       wal-dir = "/var/lib/influxdb/wal"
       wal-fsync-delay = "0s"
       validate-keys = false

--- a/ansible/roles/influxdb/templates/influxdb.yml.j2
+++ b/ansible/roles/influxdb/templates/influxdb.yml.j2
@@ -21,6 +21,13 @@ spec:
       containers:
       - name: influxdb
         image: influxdb:{{ influxdb_version }}
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "1Gi"
+          limits:
+            cpu: "200m"
+            memory: "2Gi"
         volumeMounts:
         - mountPath: /var/lib/influxdb
           name: influxdb-storage

--- a/ansible/roles/influxdb/vars/main.yml
+++ b/ansible/roles/influxdb/vars/main.yml
@@ -5,3 +5,4 @@ influxdb_volume_name: influxdb-data-managed-disk
 influxdb_configmap: influxdb-conf
 tls_cert_manifest: "/tmp/influxdb-{{ deploy_environ }}-{{ region }}-cert.yaml"
 influxdb_backup_version: v1.2.4-87-gd0e1d20b
+index_version: tsi1

--- a/ansible/roles/k8s-telegraf/templates/telegraf-deploy.yaml.j2
+++ b/ansible/roles/k8s-telegraf/templates/telegraf-deploy.yaml.j2
@@ -15,6 +15,13 @@ spec:
       containers:
         - image: telegraf:{{ telegraf_image_tag }}
           name: telegraf
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "100Mi"
+            limits:
+              cpu: "100m"
+              memory: "200Mi"
           volumeMounts:
             - mountPath: /etc/telegraf/telegraf.conf
               name: telegraf-conf


### PR DESCRIPTION
- Switch InfluxDB from a purely in-memory index to a disk-backed one.
- Set resource limits for all deployment.