### PR TITLE
EDGECLOUD-5146: For k8s pods with multiple containers, need ability to choose container to open terminal in

### DIFF
--- a/e2e-tests/setups/local_edgebox.yml
+++ b/e2e-tests/setups/local_edgebox.yml
@@ -126,7 +126,6 @@ edgeturns:
   vaultaddr: "http://127.0.0.1:8200"
   listenaddr: "127.0.0.1:8080"
   proxyaddr: "127.0.0.1:8443"
-  deploymenttag: dev
 
 sqls:
 - name: sql1


### PR DESCRIPTION
* Refer PR: https://github.com/mobiledgex/edge-cloud/pull/1376
* `edgeturn` service was missing for edgebox, have added it.