### PR TITLE
use VCD's dhcp server

### DIFF
--- a/crm-platforms/vcd/vcd-prop.go
+++ b/crm-platforms/vcd/vcd-prop.go
@@ -47,7 +47,6 @@ var VcdProps = map[string]*edgeproto.PropertyInfo{
 		Description: "Set value for vCPU Speed if unable to read from admin VCD",
 		Internal:    true,
 	},
-
 	"VCD_NSX_TYPE": {
 		Description: "NSX-T or NSX-V",
 		Mandatory:   true,
@@ -61,6 +60,11 @@ var VcdProps = map[string]*edgeproto.PropertyInfo{
 		Description: "How long to cache VDC objects for VM App stat collection, in seconds",
 		Internal:    true,
 		Value:       "3600",
+	},
+	"VCD_VM_APP_INTERNAL_DHCP_SERVER": {
+		Description: "If true sets up an internal DHCP server for VM Apps, otherwise uses VCD server",
+		Value:       "false",
+		Internal:    true,
 	},
 }
 
@@ -202,6 +206,11 @@ func (v *VcdPlatform) GetVmAppStatsVdcMaxCacheTime() (uint64, error) {
 		return 0, fmt.Errorf("ERROR: unable to parse VCD_VM_APP_STATS_MAX_VDC_CACHE_TIME %s - %v", val, err)
 	}
 	return vi, nil
+}
+
+func (v *VcdPlatform) GetVmAppInternalDhcpServer() bool {
+	val, _ := v.vmProperties.CommonPf.Properties.GetValue("VCD_VM_APP_INTERNAL_DHCP_SERVER")
+	return strings.ToLower(val) == "true"
 }
 
 // start fetching access  bits from vault

--- a/crm-platforms/vcd/vcd-vm.go
+++ b/crm-platforms/vcd/vcd-vm.go
@@ -944,7 +944,7 @@ func (v *VcdPlatform) GetVMAddresses(ctx context.Context, vm *govcd.VM, vcdClien
 func (v *VcdPlatform) SetVMProperties(vmProperties *vmlayer.VMProperties) {
 	v.vmProperties = vmProperties
 	vmProperties.IptablesBasedFirewall = true
-	vmProperties.RunLbDhcpServerForVmApps = true
+	vmProperties.RunLbDhcpServerForVmApps = v.GetVmAppInternalDhcpServer()
 	vmProperties.AppendFlavorToVmAppImage = true
 	vmProperties.ValidateExternalIPMapping = true
 }


### PR DESCRIPTION
EDGECLOUD-4612

VM Apps do not work in the WWT NSX-T environment because the internal DHCP server we set up does not work.  It appears to be some port security issue blocking the DHCP offer message from getting back to the VM.    

The solution is to use the VCD's own DHCP server.   This will be the default behavior for VCD now, but in case this causes some issue, there will be a setting to revert to using our internal server (since this is working fine in TEF currently)

Internal DHCP server will still be used for vSphere.