### PR TITLE
EDGECLOUD-5194/5195: Controller restarted while adding build to gpudriver + other fixes

### DIFF
--- a/crm-platforms/openstack/openstack-cmd.go
+++ b/crm-platforms/openstack/openstack-cmd.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -683,7 +684,7 @@ func (s *OpenstackPlatform) CreateImageFromUrl(ctx context.Context, imageName, i
 	}
 	defer func() {
 		// Stale file might be present if download fails/succeeds, deleting it
-		if delerr := infracommon.DeleteFile(filePath); delerr != nil {
+		if delerr := cloudcommon.DeleteFile(filePath); delerr != nil {
 			log.SpanLog(ctx, log.DebugLevelInfra, "delete file failed", "filePath", filePath)
 		}
 	}()

--- a/crm-platforms/vcd/vcd-common-utils.go
+++ b/crm-platforms/vcd/vcd-common-utils.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/crmutil"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -38,7 +38,7 @@ func (v *VcdPlatform) CreateImageFromUrl(ctx context.Context, imageName, imageUr
 	filePath := ""
 	defer func() {
 		// Stale file might be present if download fails/succeeds, deleting it
-		if delerr := infracommon.DeleteFile(filePath); delerr != nil {
+		if delerr := cloudcommon.DeleteFile(filePath); delerr != nil {
 			log.SpanLog(ctx, log.DebugLevelInfra, "delete file failed", "filePath", filePath)
 		}
 	}()

--- a/crm-platforms/vcd/vcd-vapptemplate.go
+++ b/crm-platforms/vcd/vcd-vapptemplate.go
@@ -246,7 +246,7 @@ func (v *VcdPlatform) AddImageIfNotPresent(ctx context.Context, imageInfo *infra
 	defer func() {
 		for _, file := range filesToCleanup {
 			log.SpanLog(ctx, log.DebugLevelInfra, "delete file", "file", file)
-			if delerr := infracommon.DeleteFile(file); delerr != nil {
+			if delerr := cloudcommon.DeleteFile(file); delerr != nil {
 				if !os.IsNotExist(delerr) {
 					log.SpanLog(ctx, log.DebugLevelInfra, "delete file failed", "file", file, "error", delerr)
 				}

--- a/crm-platforms/vsphere/vsphere-cloudlet.go
+++ b/crm-platforms/vsphere/vsphere-cloudlet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 	"github.com/mobiledgex/edge-cloud/vault"
@@ -48,7 +49,7 @@ func (v *VSpherePlatform) CreateImageFromUrl(ctx context.Context, imageName, ima
 	}
 	defer func() {
 		// Stale file might be present if download fails/succeeds, deleting it
-		if delerr := infracommon.DeleteFile(filePath); delerr != nil {
+		if delerr := cloudcommon.DeleteFile(filePath); delerr != nil {
 			log.SpanLog(ctx, log.DebugLevelInfra, "delete file failed", "filePath", filePath)
 		}
 	}()

--- a/crm-platforms/vsphere/vsphere-image.go
+++ b/crm-platforms/vsphere/vsphere-image.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud-infra/vmlayer"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
 )
@@ -47,7 +48,7 @@ func (v *VSpherePlatform) AddImageIfNotPresent(ctx context.Context, imageInfo *i
 	defer func() {
 		for _, file := range filesToCleanup {
 			log.SpanLog(ctx, log.DebugLevelInfra, "delete file", "file", file)
-			if delerr := infracommon.DeleteFile(file); delerr != nil {
+			if delerr := cloudcommon.DeleteFile(file); delerr != nil {
 				if !os.IsNotExist(delerr) {
 					log.SpanLog(ctx, log.DebugLevelInfra, "delete file failed", "file", file, "error", delerr)
 				}

--- a/infracommon/uri.go
+++ b/infracommon/uri.go
@@ -2,18 +2,13 @@ package infracommon
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
-	sh "github.com/codeskyblue/go-sh"
 	"github.com/miekg/dns"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
@@ -93,29 +88,6 @@ func GetUrlInfo(ctx context.Context, accessApi platform.AccessApi, fileUrlPath s
 		md5Sum = resp.Header.Get("X-Checksum-Md5")
 	}
 	return lastMod, md5Sum, err
-}
-
-func Md5SumFile(filePath string) (string, error) {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to open file %s, %v", filePath, err)
-	}
-	defer f.Close()
-
-	h := md5.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", fmt.Errorf("failed to calculate md5sum of file %s, %v", filePath, err)
-	}
-
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-func DeleteFile(filePath string) error {
-	var err error
-	if _, err = os.Stat(filePath); !os.IsNotExist(err) {
-		_, err = sh.Command("rm", filePath).Output()
-	}
-	return err
 }
 
 // Get the externally visible public IP address

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -815,7 +815,7 @@ func DownloadVMImage(ctx context.Context, accessApi platform.AccessApi, imageNam
 	defer func() {
 		if reterr != nil {
 			// Stale file might be present if download fails/succeeds, deleting it
-			infracommon.DeleteFile(filePath)
+			cloudcommon.DeleteFile(filePath)
 		}
 	}()
 
@@ -825,7 +825,7 @@ func DownloadVMImage(ctx context.Context, accessApi platform.AccessApi, imageNam
 	}
 	// Verify checksum
 	if md5Sum != "" {
-		fileMd5Sum, err := infracommon.Md5SumFile(filePath)
+		fileMd5Sum, err := cloudcommon.Md5SumFile(filePath)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
### Issues Fixed

- EDGECLOUD-5194: Controller restarted while adding build to gpudriver
- EDGECLOUD-5195: driverpath contains artifactory path instead of google storage path

### Description
* Refer PR: https://github.com/mobiledgex/edge-cloud/pull/1387