### PR TITLE
EDGECLOUD-5196: CreateCloudlet fails on Openstack while setting up sharedrootlb

### DIFF
--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -367,7 +367,7 @@ func (v *VMPlatform) UpdateTrustPolicy(ctx context.Context, TrustPolicy *edgepro
 	if result == OperationNewlyInitialized {
 		defer v.VMProvider.InitOperationContext(ctx, OperationInitComplete)
 	}
-	rootlbClients, err := v.GetAllRootLBClients(ctx)
+	rootlbClients, err := v.GetAllRootLBClients(ctx, ClientTypeAllRootLB)
 	if err != nil {
 		return fmt.Errorf("Unable to get rootlb clients - %v", err)
 	}
@@ -442,7 +442,7 @@ func (v *VMPlatform) DeleteCloudlet(ctx context.Context, cloudlet *edgeproto.Clo
 			return fmt.Errorf("DeleteCloudlet error: %v", err)
 		}
 		updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Deleting Cloudlet Security Rules %s", rootLBName))
-		rootlbClients, err := v.GetAllRootLBClients(ctx)
+		rootlbClients, err := v.GetAllRootLBClients(ctx, ClientTypeAllRootLB)
 		if err != nil {
 			return fmt.Errorf("Unable to get rootlb clients - %v", err)
 		}

--- a/vmlayer/security.go
+++ b/vmlayer/security.go
@@ -8,7 +8,15 @@ import (
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
 
-func (v *VMPlatform) ConfigureCloudletSecurityRules(ctx context.Context, action ActionType) error {
+type ClientType int
+
+const (
+	ClientTypeAllRootLB ClientType = iota
+	ClientTypeAllExceptSharedRootLB
+	ClientTypeOnlySharedRootLB
+)
+
+func (v *VMPlatform) ConfigureCloudletSecurityRules(ctx context.Context, action ActionType, clientType ClientType) error {
 	// update security groups based on a configured privacy policy or none
 	privPolName := v.VMProperties.CommonPf.PlatformConfig.TrustPolicy
 	var privPol *edgeproto.TrustPolicy
@@ -24,7 +32,7 @@ func (v *VMPlatform) ConfigureCloudletSecurityRules(ctx context.Context, action 
 		// use an empty policy
 		privPol = &edgeproto.TrustPolicy{}
 	}
-	rootlbClients, err := v.GetAllRootLBClients(ctx)
+	rootlbClients, err := v.GetAllRootLBClients(ctx, clientType)
 	if err != nil {
 		return fmt.Errorf("Unable to get rootlb clients - %v", err)
 	}


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5196: CreateCloudlet fails on Openstack while setting up sharedrootlb

### Description
* It is now failing because CreateRootLB is looking for Cloudlet sec-group, but sec-group is not created until `ConfigureCloudletSecurityRules` is called. Updated the code to handle shared rootlb separately