### PR TITLE
change GetAllRootlbClients to not return error on missing shared lb

### DIFF
--- a/vmlayer/vmprovider.go
+++ b/vmlayer/vmprovider.go
@@ -405,6 +405,15 @@ func (v *VMPlatform) Init(ctx context.Context, platformConfig *platform.Platform
 	if result == OperationNewlyInitialized {
 		defer v.VMProvider.InitOperationContext(ctx, OperationInitComplete)
 	}
+	if err := v.ConfigureCloudletSecurityRules(ctx, ActionCreate); err != nil {
+		if v.VMProperties.IptablesBasedFirewall {
+			// iptables based security rules can fail on one clusterInst LB, but we cannot treat
+			// this as a fatal error or it can cause the CRM to never initialize
+			log.SpanLog(ctx, log.DebugLevelInfra, "Warning: error in ConfigureCloudletSecurityRules", "err", err)
+		} else {
+			return err
+		}
+	}
 	// Set debug command to start crm upgrade
 	v.initDebug(v.VMProperties.CommonPf.PlatformConfig.NodeMgr)
 
@@ -467,16 +476,6 @@ func (v *VMPlatform) Init(ctx context.Context, platformConfig *platform.Platform
 		return err
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "ok, SetupRootLB")
-
-	if err := v.ConfigureCloudletSecurityRules(ctx, ActionCreate); err != nil {
-		if v.VMProperties.IptablesBasedFirewall {
-			// iptables based security rules can fail on one clusterInst LB, but we cannot treat
-			// this as a fatal error or it can cause the CRM to never initialize
-			log.SpanLog(ctx, log.DebugLevelInfra, "Warning: error in ConfigureCloudletSecurityRules", "err", err)
-		} else {
-			return err
-		}
-	}
 
 	// deletes exisitng l7 proxies for backwards compatibility, since we got rid of http. can be removed later
 	client, err := v.GetNodePlatformClient(ctx, &edgeproto.CloudletMgmtNode{Name: v.VMProperties.SharedRootLBName}, pc.WithCachedIp(true))


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5196 CreateCloudlet fails on Openstack while setting up sharedrootlb

### Description

My previous PR broke CreateCloudlet because of the new call to GetAllRootLBClients returns an error when the shared rootlb does not exist.  Ashish fixed this by moving the order of when  ConfigureCloudletSecurityRules to be before the sharedLb creation. This caused a different problem though because the cloudlet security group does not exist.

This fix reverts the order of ConfigureCloudletSecurityRules back to where it was, and also changes GetAllRootLBClients to not return an error if the shared LB is not there (ServerDoesNotExistError) as this is a valid scenario.  

Note in the VCD case, if the shared LB does not exist on startup, the security rules are still configured when the sharedLB is created.

Tested on OpenStack and VCD in both cases of SharedLB existing and not existing on startup.