### PR TITLE
Switch to harbor docker registry for public cloud deployments

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -3,7 +3,7 @@ vm_ssh_user: ubuntu
 vm_ssh_pub_key_file: "{{ lookup('env','HOME') }}/.mobiledgex/id_rsa_mex.pub"
 platform_k8s_pool_size: 3
 platform_k8s_vm_size: Standard_DS1_v2
-mex_docker_registry: registry.mobiledgex.net:5000
+mex_docker_registry: harbor.mobiledgex.net
 edge_cloud_image: "{{ mex_docker_registry }}/mobiledgex/edge-cloud"
 monitor_image: "{{ mex_docker_registry }}/mobiledgex/monitor"
 mex_ops_email: mobiledgex.ops@mobiledgex.com

--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -509,7 +509,7 @@
 
 - hosts: slack
   vars:
-    slack_org_mgmt_image: "registry.mobiledgex.net:5000/mobiledgex/slack-org-mgmt:1.2.4"
+    slack_org_mgmt_image: "{{ mex_docker_registry }}/mobiledgex/slack-org-mgmt:1.2.4"
     slack_org_mgmt_log: slack-org-mgmt.log
     skipped_channel_file: "{{ ansible_env.HOME }}/skipped-channels.txt"
     support_users:

--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -81,7 +81,10 @@
 
     - name: Check if edge-cloud Image is Available
       uri:
-        url: "https://{{ mex_docker_username }}:{{ mex_docker_password }}@{{ mex_docker_registry }}/v2/mobiledgex/edge-cloud/tags/list"
+        url: "https://{{ mex_docker_registry }}/v2/mobiledgex/edge-cloud/tags/list"
+        url_username: "{{ mex_docker_username }}"
+        url_password: "{{ mex_docker_password }}"
+        force_basic_auth: yes
         return_content: yes
         status_code: 200
         body_format: json

--- a/ansible/roles/console/vars/main.yml
+++ b/ansible/roles/console/vars/main.yml
@@ -1,3 +1,3 @@
-console_image: registry.mobiledgex.net:5000/mobiledgex/console
+console_image: "{{ mex_docker_registry }}/mobiledgex/console"
 console_prod_image: "{{ console_image }}-prod"
 slack_channel: "#web-ui"

--- a/ansible/roles/influxdb/templates/influxdb-backup.yml.j2
+++ b/ansible/roles/influxdb/templates/influxdb-backup.yml.j2
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: backup
-            image: registry.mobiledgex.net:5000/mobiledgex/influxdb-backup:{{ influxdb_backup_version }}
+            image: {{ mex_docker_registry }}/mobiledgex/influxdb-backup:{{ influxdb_backup_version }}
             args:
             - /bin/sh
             - -c

--- a/ansible/roles/influxdb/vars/main.yml
+++ b/ansible/roles/influxdb/vars/main.yml
@@ -1,6 +1,5 @@
 # See https://github.com/mobiledgex/edge-cloud-infra/pull/50
 influxdb_version: 1.7.6
-influxdb_image: registry.mobiledgex.net:5000/mobiledgex/influxdb:v1.0.0
 influxdb_volume_name: influxdb-data-managed-disk
 influxdb_configmap: influxdb-conf
 tls_cert_manifest: "/tmp/influxdb-{{ deploy_environ }}-{{ region }}-cert.yaml"

--- a/ansible/roles/k8s/tasks/main.yml
+++ b/ansible/roles/k8s/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Compute Docker Config
+  set_fact:
+    docker_config: '{"auths":{"{{ mex_docker_registry }}":{"username":"{{ mex_docker_username }}","password":"{{ mex_docker_password }}"}}}'
+
 - name: Deploy Mex Secrets
   k8s:
     kubeconfig: "{{ kubeconfig_file.path }}"

--- a/ansible/roles/load-vault-creds/defaults/main.yml
+++ b/ansible/roles/load-vault-creds/defaults/main.yml
@@ -8,7 +8,6 @@ gcp_account_path: secret/ansible/common/accounts/gcp
 harbot_account_path: secret/ansible/common/accounts/harbor
 locapi_account_path: secret/ansible/common/accounts/locapi
 mc_ldap_vault_path: "secret/ansible/{{ deploy_environ }}/accounts/mc_ldap"
-mex_docker_account_path: secret/ansible/common/accounts/mex_docker
 ns1_account_path: secret/ansible/common/accounts/ns1
 sendgrid_account_path: secret/ansible/common/accounts/sendgrid
 slack_org_mgmt_path: secret/ansible/internal/accounts/slack_org_mgmt

--- a/ansible/roles/load-vault-creds/tasks/mex_docker.yml
+++ b/ansible/roles/load-vault-creds/tasks/mex_docker.yml
@@ -1,7 +1,9 @@
 - name: Look up mex_docker creds in vault
   set_fact:
     vault_lookup: "{{ lookup('vault', mex_docker_account_path) }}"
+  vars:
+    mex_docker_account_path: "secret/registry/{{ mex_docker_registry }}"
 
 - set_fact:
-    mex_docker_username: "{{ vault_lookup.mex_docker.data.user }}"
-    mex_docker_password: "{{ vault_lookup.mex_docker.data.pass }}"
+    mex_docker_username: "{{ vault_lookup[mex_docker_registry].data.username }}"
+    mex_docker_password: "{{ vault_lookup[mex_docker_registry].data.password }}"

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -54,6 +54,7 @@ vault_user_roles:
   deployer: &vault_user_role_deployer
     - *vault_user_role_viewer
     - ansible.read.v1
+    - edge-cloud-registry.read.v1
     - gcp-bucket-create-key.read.v1
     - gcp-firewall-manage-key.read.v1
     - gcp-role-create-key.read.v1

--- a/ansible/roles/vault/tasks/policies.yml
+++ b/ansible/roles/vault/tasks/policies.yml
@@ -24,6 +24,7 @@
     - policies/chef.read.v1.hcl.j2
     - policies/cloudlets.read.v1.hcl.j2
     - policies/cloudlets.write.v1.hcl.j2
+    - policies/edge-cloud-registry.read.v1.hcl.j2
     - policies/gcs.read.v1.hcl.j2
     - policies/gcp-auth.read.v1.hcl.j2
     - policies/gcp-bucket-create-key.read.v1.hcl.j2

--- a/ansible/roles/vault/tasks/roles.yml
+++ b/ansible/roles/vault/tasks/roles.yml
@@ -14,6 +14,7 @@
       - auth-ldap-config.read.v1
       - certs.read.v1
       - chef.read.v1
+      - edge-cloud-registry.read.v1
       - gcp-bucket-create-key.read.v1
       - gcp-config.read.v1
       - gcp-firewall-manage-key.read.v1

--- a/ansible/roles/vault/templates/policies/edge-cloud-registry.read.v1.hcl.j2
+++ b/ansible/roles/vault/templates/policies/edge-cloud-registry.read.v1.hcl.j2
@@ -1,0 +1,3 @@
+path "secret/data/registry/harbor.mobiledgex.net" {
+  capabilities = [ "read" ]
+}

--- a/ansible/templates/apidocs/akraino-swagger.cron.j2
+++ b/ansible/templates/apidocs/akraino-swagger.cron.j2
@@ -6,7 +6,7 @@ TAG="{{ edge_cloud_version }}"
 TAG=$( date +'%Y-%m-%d' )
 {% endif %}
 
-EDGECLOUD="registry.mobiledgex.net:5000/mobiledgex/edge-cloud:$TAG"
+EDGECLOUD="{{ mex_docker_registry }}/mobiledgex/edge-cloud:$TAG"
 APIDOCS_MASSAGE="{{ apidocs_script_dir }}/apidocs-massage.py"
 AKRAINO_POSTPROCESS="{{ apidocs_script_dir }}/akraino-postprocess.py"
 

--- a/ansible/templates/apidocs/swagger-gen.j2
+++ b/ansible/templates/apidocs/swagger-gen.j2
@@ -6,7 +6,7 @@ TAG="{{ edge_cloud_version }}"
 TAG=$( date +'%Y-%m-%d' )
 {% endif %}
 
-EDGECLOUD="registry.mobiledgex.net:5000/mobiledgex/edge-cloud:$TAG"
+EDGECLOUD="{{ mex_docker_registry }}/mobiledgex/edge-cloud:$TAG"
 APIDOCS_MASSAGE="{{ apidocs_script_dir }}/apidocs-massage.py"
 ARTF_TOKEN="{{ artifactory_apidocs_token }}"
 

--- a/ansible/templates/mexplat/mex-secret.yml
+++ b/ansible/templates/mexplat/mex-secret.yml
@@ -1,9 +1,8 @@
 apiVersion: v1
-data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5tb2JpbGVkZ2V4Lm5ldDo1MDAwL3YyLyI6eyJ1c2VybmFtZSI6Im1vYmlsZWRnZXgiLCJwYXNzd29yZCI6InNhbmRoaWxsIiwiZW1haWwiOiJqaW0ubW9ycmlzQG1vYmlsZWRnZXguY29tIiwiYXV0aCI6ImJXOWlhV3hsWkdkbGVEcHpZVzVrYUdsc2JBPT0ifX19
 kind: Secret
 metadata:
   name: mexreg-secret
   namespace: default
-  selfLink: /api/v1/namespaces/default/secrets/mexreg-secret
+data:
+  .dockerconfigjson: "{{ docker_config | tojson | b64encode }}"
 type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Platform VM deployments will continue using the old
registry.mobiledgex.net:5000 registry. Switching to harbour there might
need coordination with some operators to get them to update firewall
rules.
