### PR TITLE
EDGECLOUD-3634 fqdn prefix dot to dash

### DIFF
--- a/e2e-tests/data/autoprov_appinst_show.yml
+++ b/e2e-tests/data/autoprov_appinst_show.yml
@@ -23,7 +23,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 81
         publicport: 81
-        fqdnprefix: autoprovapp10-tcp.
+        fqdnprefix: autoprovapp10-tcp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/autoprov_ha_appinst_failedover.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_failedover.yml
@@ -23,7 +23,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp.
+        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -57,7 +57,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp.
+        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -91,7 +91,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp.
+        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/autoprov_ha_appinst_maintenance.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_maintenance.yml
@@ -23,7 +23,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp.
+        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -57,7 +57,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp.
+        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -91,7 +91,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp.
+        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/autoprov_ha_appinst_show.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_show.yml
@@ -23,7 +23,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp.
+        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -57,7 +57,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp.
+        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/edgeevent-newcloudlet-response.yml
+++ b/e2e-tests/data/edgeevent-newcloudlet-response.yml
@@ -6,15 +6,15 @@ newcloudlet:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp.
+    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp.
+    fqdnprefix: someapplication110-udp-
   cloudletlocation:
     latitude: 35
     longitude: -95

--- a/e2e-tests/data/find_cloudlet_response.yml
+++ b/e2e-tests/data/find_cloudlet_response.yml
@@ -4,15 +4,15 @@ ports:
 - proto: LProtoTcp
   internalport: 80
   publicport: 80
-  fqdnprefix: someapplication110-tcp.
+  fqdnprefix: someapplication110-tcp-
 - proto: LProtoTcp
   internalport: 443
   publicport: 443
-  fqdnprefix: someapplication110-tcp.
+  fqdnprefix: someapplication110-tcp-
 - proto: LProtoUdp
   internalport: 10002
   publicport: 10002
-  fqdnprefix: someapplication110-udp.
+  fqdnprefix: someapplication110-udp-
 cloudletlocation:
   latitude: 31
   longitude: -91

--- a/e2e-tests/data/kind_user2_data_show.yml
+++ b/e2e-tests/data/kind_user2_data_show.yml
@@ -147,7 +147,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 7777
         publicport: 7777
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       flavor:
         name: x1.tiny
       state: Ready

--- a/e2e-tests/data/kind_user3_data_show.yml
+++ b/e2e-tests/data/kind_user3_data_show.yml
@@ -172,7 +172,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 7777
         publicport: 10000
-        fqdnprefix: someappuser310-tcp.
+        fqdnprefix: someappuser310-tcp-
       flavor:
         name: x1.tiny
       state: Ready

--- a/e2e-tests/data/mc_admin_show.yml
+++ b/e2e-tests/data/mc_admin_show.yml
@@ -534,15 +534,15 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: ep1-tcp.
+        fqdnprefix: ep1-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: ep1-tcp.
+        fqdnprefix: ep1-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: ep1-udp.
+        fqdnprefix: ep1-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -667,15 +667,15 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication1-tcp.
+        fqdnprefix: someapplication1-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication1-tcp.
+        fqdnprefix: someapplication1-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication1-udp.
+        fqdnprefix: someapplication1-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -704,7 +704,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication1-tcp.
+        fqdnprefix: someapplication1-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
@@ -712,7 +712,7 @@ regiondata:
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication1-udp.
+        fqdnprefix: someapplication1-udp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/mc_user2_chef_data_show.yml
+++ b/e2e-tests/data/mc_user2_chef_data_show.yml
@@ -208,7 +208,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 7777
         publicport: 7777
-        fqdnprefix: devorgsdkdemo-tcp.
+        fqdnprefix: devorgsdkdemo-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -240,7 +240,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 8008
         publicport: 8008
-        fqdnprefix: facedetectiondemo-tcp.
+        fqdnprefix: facedetectiondemo-tcp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -377,15 +377,15 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication110-udp.
+        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -414,15 +414,15 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication110-udp.
+        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -451,15 +451,15 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 10000
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 10001
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10000
-        fqdnprefix: someapplication110-udp.
+        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -838,15 +838,15 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication110-udp.
+        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -879,15 +879,15 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication110-tcp.
+        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication110-udp.
+        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/mc_user3_data_show.yml
+++ b/e2e-tests/data/mc_user3_data_show.yml
@@ -238,15 +238,15 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: ep110-tcp.
+        fqdnprefix: ep110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: ep110-tcp.
+        fqdnprefix: ep110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: ep110-udp.
+        fqdnprefix: ep110-udp-
       flavor:
         name: x1.small
       state: Ready


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-3634 Change fqdn_prefix separator from dot to dash

### Description

Test code changes for https://github.com/mobiledgex/edge-cloud/pull/1393