### PR TITLE
Make sure platform VMs use old docker registry

### DIFF
--- a/ansible/roles/controller/defaults/main.yml
+++ b/ansible/roles/controller/defaults/main.yml
@@ -1,3 +1,4 @@
 artifactory_fqdn: https://artifactory.mobiledgex.net/artifactory/
+cloudlet_registry_path: registry.mobiledgex.net:5000/mobiledgex/edge-cloud
 cloudlet_vm_path: "https://artifactory.mobiledgex.net/artifactory/baseimages"
 controller_replicas: 1

--- a/ansible/roles/controller/templates/deploy.yml.j2
+++ b/ansible/roles/controller/templates/deploy.yml.j2
@@ -57,7 +57,7 @@ spec:
          - "--artifactoryFQDN"
          - "{{ artifactory_fqdn }}"
          - "--cloudletRegistryPath"
-         - "{{ edge_cloud_image }}"
+         - "{{ cloudlet_registry_path }}"
          - "-cloudletVMImagePath"
          - "{{ cloudlet_vm_path }}"
          - "--versionTag"


### PR DESCRIPTION
The new harbor registry slipped into the controller config and ended up
being used for cloudlet creation.