### PR TITLE
Bump up controller memory limits

### DIFF
--- a/ansible/roles/controller/templates/deploy.yml.j2
+++ b/ansible/roles/controller/templates/deploy.yml.j2
@@ -21,10 +21,10 @@ spec:
         resources:
           requests:
             cpu: "200m"
-            memory: "512Mi"
+            memory: "1Gi"
           limits:
             cpu: "400m"
-            memory: "1Gi"
+            memory: "2Gi"
         command:
          - "controller"
          - "--commonName"


### PR DESCRIPTION
QA regressions are seeing controller crashes when it runs out of memory with a 1GB limit. Bumping it up to 2GB fixes this.

Need to have another look at this and see if we can scale the limits back again after we move transient data out of etcd into redis.
