### PR TITLE
EDGECLOUD-5223: Indicate operator user that licenseconfig is associated with GPU driver

### DIFF
--- a/mc/orm/authz_show.go
+++ b/mc/orm/authz_show.go
@@ -210,6 +210,9 @@ func (s *AuthzGPUDriverShow) Filter(obj *edgeproto.GPUDriver) {
 	obj.Key = output.Key
 	obj.Properties = output.Properties
 	obj.Builds = output.Builds
+	if output.LicenseConfig != "" {
+		obj.LicenseConfig = "*****"
+	}
 	for ii := range obj.Builds {
 		obj.Builds[ii].DriverPath = ""
 		obj.Builds[ii].DriverPathCreds = ""


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5221: Indicate operator user that licenseconfig is associated with GPU driver

### Description

* Because we don't show licenseconfig, an operator might get confused if a licenseconfig is even associated with the driver. Hence show something to indicate the same