### PR TITLE
Trustpol crash

### DIFF
--- a/crm-platforms/vcd/vcd-security.go
+++ b/crm-platforms/vcd/vcd-security.go
@@ -486,7 +486,7 @@ func (v *VcdPlatform) ConfigureCloudletSecurityRules(ctx context.Context, egress
 				err = v.vmProperties.SetupIptablesRulesForRootLB(ctx, sshClient, sshCidrsAllowed, TrustPolicy)
 			}
 			if err != nil {
-				log.SpanLog(ctx, log.DebugLevelInfra, "ConfigureCloudletSecurityRules SetupIptablesRulesForRootLB  failed", "clientName", clientName, "sshClient", sshClient, "error", err)
+				log.SpanLog(ctx, log.DebugLevelInfra, "ConfigureCloudletSecurityRules failed", "clientName", clientName, "sshClient", sshClient, "error", err)
 				errMap[clientName] = err
 			}
 		}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5224 VCD crm crashed when adding a trust policy after completion of the policy

### Description

QA got into some error condition with leftover cluster instances.  This caused a CRM crash when trying to apply a trust policy.  The reason is that when getting the ssh clients via GetRootLbClients it is possible to get a nil ssh client, and the expectation is that the caller needs to check for this.
