### PR TITLE
Reducing the minumum memory requirements for controller

### DIFF
--- a/ansible/roles/controller/templates/deploy.yml.j2
+++ b/ansible/roles/controller/templates/deploy.yml.j2
@@ -21,7 +21,7 @@ spec:
         resources:
           requests:
             cpu: "200m"
-            memory: "1Gi"
+            memory: "500m"
           limits:
             cpu: "400m"
             memory: "2Gi"


### PR DESCRIPTION
Most times, the controller's memory usage is under 200MB. Reducing the
requests limit to make scheduling the controller easier.
