### PR TITLE
EDGECLOUD-5233 create appinst fails fqdn prefix invalid DNS name

### DIFF
--- a/crm-platforms/k8s-baremetal/k8sbm-appinst.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-appinst.go
@@ -92,8 +92,6 @@ func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *e
 				action.PatchKube = true
 				action.PatchIP = lbinfo.InternalIpAddr
 				action.ExternalIP = lbinfo.ExternalIpAddr
-				// Should only add DNS for external ports
-				action.AddDNS = !app.InternalPorts
 				return &action, nil
 			}
 			// If this is all internal ports, all we need is patch of kube service

--- a/e2e-tests/data/autoprov_appinst_show.yml
+++ b/e2e-tests/data/autoprov_appinst_show.yml
@@ -17,13 +17,12 @@ regiondata:
       cloudletloc:
         latitude: 35
         longitude: -95
-      uri: tmus-cloud-2.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-2.tmus.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 81
         publicport: 81
-        fqdnprefix: autoprovapp10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -51,7 +50,7 @@ regiondata:
       cloudletloc:
         latitude: 31
         longitude: -91
-      uri: tmus-cloud-1.tmus.mobiledgex.net
+      uri: reservabled.tmus-cloud-1.tmus.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp

--- a/e2e-tests/data/autoprov_ha_appinst_failedover.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_failedover.yml
@@ -17,13 +17,12 @@ regiondata:
       cloudletloc:
         latitude: 31
         longitude: -91
-      uri: tmus-cloud-1.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-1.tmus.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -57,7 +56,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp-
+        fqdnprefix: autoprovha10-tcp.
       flavor:
         name: x1.small
       state: Ready
@@ -91,7 +90,7 @@ regiondata:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp-
+        fqdnprefix: autoprovha10-tcp.
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/autoprov_ha_appinst_maintenance.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_maintenance.yml
@@ -17,13 +17,12 @@ regiondata:
       cloudletloc:
         latitude: 31
         longitude: -91
-      uri: tmus-cloud-1.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-1.tmus.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -51,13 +50,12 @@ regiondata:
       cloudletloc:
         latitude: 35
         longitude: -95
-      uri: tmus-cloud-2.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-2.tmus.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -85,13 +83,13 @@ regiondata:
       cloudletloc:
         latitude: 32
         longitude: -91
-      uri: reservable3.azure-cloud-4.azure.mobiledgex.net
+      uri: acmeappcoautoprovha10.reservable3.azure-cloud-4.azure.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp-
+        fqdnprefix: autoprovha10-tcp.
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/autoprov_ha_appinst_show.yml
+++ b/e2e-tests/data/autoprov_ha_appinst_show.yml
@@ -17,13 +17,12 @@ regiondata:
       cloudletloc:
         latitude: 31
         longitude: -91
-      uri: tmus-cloud-1.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-1.tmus.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -51,13 +50,12 @@ regiondata:
       cloudletloc:
         latitude: 35
         longitude: -95
-      uri: tmus-cloud-2.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-2.tmus.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 82
         publicport: 82
-        fqdnprefix: autoprovha10-tcp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/edgeevent-newcloudlet-response.yml
+++ b/e2e-tests/data/edgeevent-newcloudlet-response.yml
@@ -1,20 +1,17 @@
 eventtype: EventCloudletUpdate
 newcloudlet:
   status: FindFound
-  fqdn: tmus-cloud-2.tmus.mobiledgex.net
+  fqdn: shared.tmus-cloud-2.tmus.mobiledgex.net
   ports:
   - proto: LProtoTcp
     internalport: 80
     publicport: 80
-    fqdnprefix: someapplication110-tcp-
   - proto: LProtoTcp
     internalport: 443
     publicport: 443
-    fqdnprefix: someapplication110-tcp-
   - proto: LProtoUdp
     internalport: 10002
     publicport: 10002
-    fqdnprefix: someapplication110-udp-
   cloudletlocation:
     latitude: 35
     longitude: -95

--- a/e2e-tests/data/find_cloudlet_response.yml
+++ b/e2e-tests/data/find_cloudlet_response.yml
@@ -4,15 +4,12 @@ ports:
 - proto: LProtoTcp
   internalport: 80
   publicport: 80
-  fqdnprefix: someapplication110-tcp-
 - proto: LProtoTcp
   internalport: 443
   publicport: 443
-  fqdnprefix: someapplication110-tcp-
 - proto: LProtoUdp
   internalport: 10002
   publicport: 10002
-  fqdnprefix: someapplication110-udp-
 cloudletlocation:
   latitude: 31
   longitude: -91

--- a/e2e-tests/data/kind_user2_data_show.yml
+++ b/e2e-tests/data/kind_user2_data_show.yml
@@ -141,13 +141,12 @@ regiondata:
       cloudletloc:
         latitude: 31
         longitude: -91
-      uri: kind-cloud-1.tmus.mobiledgex.net
+      uri: shared.kind-cloud-1.tmus.mobiledgex.net
       liveness: LivenessStatic
       mappedports:
       - proto: LProtoTcp
         internalport: 7777
         publicport: 7777
-        fqdnprefix: someapplication110-tcp-
       flavor:
         name: x1.tiny
       state: Ready

--- a/e2e-tests/data/kind_user3_data_show.yml
+++ b/e2e-tests/data/kind_user3_data_show.yml
@@ -166,13 +166,12 @@ regiondata:
       cloudletloc:
         latitude: 31
         longitude: -91
-      uri: kind-cloud-1.tmus.mobiledgex.net
+      uri: shared.kind-cloud-1.tmus.mobiledgex.net
       liveness: LivenessAutoprov
       mappedports:
       - proto: LProtoTcp
         internalport: 7777
         publicport: 10000
-        fqdnprefix: someappuser310-tcp-
       flavor:
         name: x1.tiny
       state: Ready

--- a/e2e-tests/data/mc_admin_show.yml
+++ b/e2e-tests/data/mc_admin_show.yml
@@ -536,15 +536,12 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: ep1-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: ep1-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: ep1-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -567,7 +564,6 @@ regiondata:
       cloudletloc:
         latitude: 31
         longitude: -91
-      uri: smallcluster.tmus-cloud-1.tmus.mobiledgex.net
       liveness: LivenessStatic
       mappedports:
       - proto: LProtoTcp
@@ -635,7 +631,6 @@ regiondata:
       cloudletloc:
         latitude: 35
         longitude: -95
-      uri: smallcluster.tmus-cloud-2.tmus.mobiledgex.net
       liveness: LivenessStatic
       mappedports:
       - proto: LProtoTcp
@@ -669,15 +664,12 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication1-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication1-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication1-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -700,13 +692,12 @@ regiondata:
       cloudletloc:
         latitude: 35
         longitude: -95
-      uri: tmus-cloud-2.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-2.tmus.mobiledgex.net
       liveness: LivenessStatic
       mappedports:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication1-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
@@ -714,7 +705,6 @@ regiondata:
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication1-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -737,7 +727,6 @@ regiondata:
       cloudletloc:
         latitude: 31
         longitude: -91
-      uri: smallcluster.enterprise-1.enterprise.mobiledgex.net
       liveness: LivenessStatic
       mappedports:
       - proto: LProtoTcp

--- a/e2e-tests/data/mc_user2_chef_data_show.yml
+++ b/e2e-tests/data/mc_user2_chef_data_show.yml
@@ -208,7 +208,6 @@ regiondata:
       - proto: LProtoTcp
         internalport: 7777
         publicport: 7777
-        fqdnprefix: devorgsdkdemo-tcp-
       flavor:
         name: x1.small
       state: Ready
@@ -240,7 +239,6 @@ regiondata:
       - proto: LProtoTcp
         internalport: 8008
         publicport: 8008
-        fqdnprefix: facedetectiondemo-tcp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -378,15 +378,12 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -409,21 +406,18 @@ regiondata:
       cloudletloc:
         latitude: 35
         longitude: -95
-      uri: tmus-cloud-2.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-2.tmus.mobiledgex.net
       liveness: LivenessStatic
       mappedports:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -446,21 +440,18 @@ regiondata:
       cloudletloc:
         latitude: 35
         longitude: -95
-      uri: tmus-cloud-2.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-2.tmus.mobiledgex.net
       liveness: LivenessStatic
       mappedports:
       - proto: LProtoTcp
         internalport: 80
         publicport: 10000
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 10001
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10000
-        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -839,15 +830,12 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready
@@ -874,21 +862,18 @@ regiondata:
       cloudletloc:
         latitude: 36
         longitude: -96
-      uri: tmus-cloud-4.tmus.mobiledgex.net
+      uri: shared.tmus-cloud-4.tmus.mobiledgex.net
       liveness: LivenessStatic
       mappedports:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: someapplication110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: someapplication110-udp-
       flavor:
         name: x1.small
       state: Ready

--- a/e2e-tests/data/mc_user3_data_show.yml
+++ b/e2e-tests/data/mc_user3_data_show.yml
@@ -238,15 +238,12 @@ regiondata:
       - proto: LProtoTcp
         internalport: 80
         publicport: 80
-        fqdnprefix: ep110-tcp-
       - proto: LProtoTcp
         internalport: 443
         publicport: 443
-        fqdnprefix: ep110-tcp-
       - proto: LProtoUdp
         internalport: 10002
         publicport: 10002
-        fqdnprefix: ep110-udp-
       flavor:
         name: x1.small
       state: Ready

--- a/managedk8s/mk8s-appinst.go
+++ b/managedk8s/mk8s-appinst.go
@@ -29,6 +29,7 @@ func (m *ManagedK8sPlatform) CreateAppInst(ctx context.Context, clusterInst *edg
 	if err != nil {
 		return err
 	}
+	features := m.GetFeatures()
 
 	updateCallback(edgeproto.UpdateTask, "Creating Registry Secret")
 	for _, imagePath := range names.ImagePaths {
@@ -68,7 +69,7 @@ func (m *ManagedK8sPlatform) CreateAppInst(ctx context.Context, clusterInst *edg
 		} else {
 			return nil, fmt.Errorf("Did not get either an IP or a hostname from GetSvcExternalIpOrHost")
 		}
-		action.AddDNS = !app.InternalPorts
+		action.AddDNS = !app.InternalPorts && features.IPAllocatedPerService
 		return &action, nil
 	}
 	err = m.CommonPf.CreateAppDNSAndPatchKubeSvc(ctx, client, names, infracommon.NoDnsOverride, getDnsAction)

--- a/mc/mcctl/ormctl/app.mc2.go
+++ b/mc/mcctl/ormctl/app.mc2.go
@@ -358,7 +358,6 @@ var DeploymentCloudletRequestOptionalArgs = []string{
 	"app.serverlessconfig.minreplicas",
 	"app.vmappostype",
 	"dryrundeploy",
-	"vmapptest",
 }
 var DeploymentCloudletRequestAliasArgs = []string{
 	"app.fields=deploymentcloudletrequest.app.fields",
@@ -404,7 +403,6 @@ var DeploymentCloudletRequestAliasArgs = []string{
 	"app.serverlessconfig.minreplicas=deploymentcloudletrequest.app.serverlessconfig.minreplicas",
 	"app.vmappostype=deploymentcloudletrequest.app.vmappostype",
 	"dryrundeploy=deploymentcloudletrequest.dryrundeploy",
-	"vmapptest=deploymentcloudletrequest.vmapptest",
 }
 var DeploymentCloudletRequestComments = map[string]string{
 	"app.fields":              "Fields are used for the Update API to specify which fields to apply",
@@ -431,7 +429,7 @@ var DeploymentCloudletRequestComments = map[string]string{
 	"app.officialfqdn":        "Official FQDN is the FQDN that the app uses to connect by default",
 	"app.md5sum":              "MD5Sum of the VM-based app image",
 	"app.autoprovpolicy":      "(_deprecated_) Auto provisioning policy name",
-	"app.accesstype":          "Access type, one of AccessTypeDefaultForDeployment, AccessTypeDirect, AccessTypeLoadBalancer",
+	"app.accesstype":          "(Deprecated) Access type, one of AccessTypeDefaultForDeployment, AccessTypeDirect, AccessTypeLoadBalancer",
 	"app.deleteprepare":       "Preparing to be deleted",
 	"app.autoprovpolicies":    "Auto provisioning policy names, may be specified multiple times",
 	"app.templatedelimiter":   "Delimiter to be used for template parsing, defaults to [[ ]]",
@@ -446,7 +444,6 @@ var DeploymentCloudletRequestComments = map[string]string{
 	"app.serverlessconfig.minreplicas":           "Minimum number of replicas when serverless",
 	"app.vmappostype":                            "OS Type for VM Apps, one of VmAppOsUnknown, VmAppOsLinux, VmAppOsWindows10, VmAppOsWindows2012, VmAppOsWindows2016, VmAppOsWindows2019",
 	"dryrundeploy":                               "Attempt to qualify cloudlet resources for deployment",
-	"vmapptest":                                  "True if requesting vmAppInset deployment check",
 }
 var DeploymentCloudletRequestSpecialArgs = map[string]string{
 	"deploymentcloudletrequest.app.autoprovpolicies": "StringArray",

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -247,6 +247,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 			}
 		}()
 
+		features := v.VMProvider.GetFeatures()
 		// set up DNS
 		var rootLBIPaddr *ServerIP
 		rootLBIPaddr, err = v.GetIPFromServerName(ctx, v.VMProperties.GetCloudletExternalNetwork(), "", rootLBName, pc.WithCachedIp(true))
@@ -257,7 +258,8 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 				action.PatchIP = masterIP.ExternalAddr
 				action.ExternalIP = rootLBIPaddr.ExternalAddr
 				// Should only add DNS for external ports
-				action.AddDNS = !app.InternalPorts
+				// and if ips are per service.
+				action.AddDNS = !app.InternalPorts && features.IPAllocatedPerService
 				return &action, nil
 			}
 			// If this is an internal ports, all we need is patch of kube service


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5233 Creation of AppInst with user specified deployment manifest fails

### Description

Changes corresponding to edge-cloud PR: https://github.com/mobiledgex/edge-cloud/pull/1403

The changes here make it so CreateAppDNSAndPatchKubeSvc does not issue DNS records for kubernetes services that don't have their own IP. To remove the double negative: only kubernetes services that are issued their own IP for platforms like GCP/Azure/etc, will issue a DNS record for the service name (fqdn prefix + uri).