### PR TITLE
EDGECLOUD-5257: ClusterInst creation gets stuck intermittently while setting up GPU drivers

### DIFF
--- a/crm-platforms/vmpool/vmpool-provider.go
+++ b/crm-platforms/vmpool/vmpool-provider.go
@@ -304,7 +304,6 @@ func (o *VMPoolPlatform) createVMsInternal(ctx context.Context, markedVMs map[st
 		case <-wgDone:
 			break
 		case err := <-wgError:
-			close(wgError)
 			return err
 		case <-time.After(CreateVMTimeout):
 			return fmt.Errorf("Timed out setting up VMs")

--- a/vmlayer/gpu.go
+++ b/vmlayer/gpu.go
@@ -175,7 +175,6 @@ func (v *VMPlatform) setupGPUDrivers(ctx context.Context, rootLBClient ssh.Clien
 	case <-wgDone:
 		break
 	case err := <-wgError:
-		close(wgError)
 		return err
 	case <-time.After(DriverInstallationTimeout):
 		return fmt.Errorf("Timed out installing GPU driver on cluster VMs")


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5257: ClusterInst creation gets stuck intermittently while setting up GPU drivers

### Description

* On an error multiple goroutines write error to `wgError` channel. But currently, we were closing the `wgError` channel on receipt of the first error and hence subsequent write to the closed channel will fail. Hence avoid closing the channel. This should be okay as it will be cleaned up when function execution is finished.