### PR TITLE
EDGECLOUD-5267 two shared rootlbs after upgrade

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -301,7 +301,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		}
 		updateCallback(edgeproto.UpdateTask, "Setting Up Load Balancer")
 		pp := edgeproto.TrustPolicy{}
-		err = v.SetupRootLB(ctx, orchVals.lbName, &clusterInst.Key.CloudletKey, &pp, false, updateCallback)
+		err = v.SetupRootLB(ctx, orchVals.lbName, orchVals.lbName, &clusterInst.Key.CloudletKey, &pp, false, updateCallback)
 		if err != nil {
 			return err
 		}

--- a/vmlayer/cluster.go
+++ b/vmlayer/cluster.go
@@ -396,7 +396,7 @@ func (v *VMPlatform) setupClusterRootLBAndNodes(ctx context.Context, rootLBName 
 		log.SpanLog(ctx, log.DebugLevelInfra, "new dedicated rootLB", "IpAccess", clusterInst.IpAccess)
 		updateCallback(edgeproto.UpdateTask, "Setting Up Root LB")
 		TrustPolicy := edgeproto.TrustPolicy{}
-		err := v.SetupRootLB(ctx, rootLBName, &clusterInst.Key.CloudletKey, &TrustPolicy, false, updateCallback)
+		err := v.SetupRootLB(ctx, rootLBName, rootLBName, &clusterInst.Key.CloudletKey, &TrustPolicy, false, updateCallback)
 		if err != nil {
 			return err
 		}

--- a/vmlayer/vmprovider.go
+++ b/vmlayer/vmprovider.go
@@ -471,7 +471,8 @@ func (v *VMPlatform) Init(ctx context.Context, platformConfig *platform.Platform
 
 	log.SpanLog(ctx, log.DebugLevelInfra, "calling SetupRootLB")
 	updateCallback(edgeproto.UpdateTask, "Setting up RootLB")
-	err = v.SetupRootLB(ctx, v.VMProperties.SharedRootLBName, v.VMProperties.CommonPf.PlatformConfig.CloudletKey, nil, true, updateCallback)
+	rootLBFQDN := v.GetRootLBFQDN(v.VMProperties.CommonPf.PlatformConfig.CloudletKey)
+	err = v.SetupRootLB(ctx, v.VMProperties.SharedRootLBName, rootLBFQDN, v.VMProperties.CommonPf.PlatformConfig.CloudletKey, nil, true, updateCallback)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5267 Existing cloudlets use 2 sharedrootlbs after CRM upgrade 

### Description

After CRM upgrade there were two shared-rootLBs because the existence check was checking for the new lbname. Unfortunately it's quite tricky to try to transition the rootLB to the new name for existing cloudlets, so we continue to use the old name for the VM, and only use the new name format for the FQDN (which is the only place it's really needed, to accommodate a single wildcard cert).

So, the rootLB VM name will always be the old format. Then there are 3 cases:
1. Existing Cloudlet with un-upgraded CRM. CRM will register old-style DNS name, Controller will detect compatibility version and use the old-style DNS name for new AppInsts.
2. Existing Cloudlet with upgraded CRM. CRM will register new-style DNS name, Controller will detect compatibility version and use the new-style DNS name for new AppInsts. Note the old-style DNS name still exists. We can clean up manually.
3. New Cloudlets. Same as 2, but the old-style DNS name will not exist.
Again, in all cases the rootLB VM name remains the old-style format.