### PR TITLE
make shepherd wait on startup for non-empty token

### DIFF
--- a/crm-platforms/vcd/vcd-security.go
+++ b/crm-platforms/vcd/vcd-security.go
@@ -316,7 +316,7 @@ func (v *VcdPlatform) WaitForOauthTokenViaNotify(ctx context.Context, ckey *edge
 			return
 		}
 		token, ok := cloudletInternal.Props[vmlayer.CloudletAccessToken]
-		if ok {
+		if ok && token != "" {
 			log.SpanLog(ctx, log.DebugLevelInfra, "found token in cloudlet cache")
 			v.vmProperties.CloudletAccessToken = token
 			select {


### PR DESCRIPTION
### Issues Fixed

EDGECLOUD-5274  Small tweak to previous PR to have shepherd wait for a non-empty token to avoid quick shepherd restarts on startup if getting a token fails at CRM

### Description
