### PR TITLE
EDGECLOUD-5284 shepherd using wrong rootlb name

### DIFF
--- a/crm-platforms/k8s-baremetal/k8sbm-lb.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-lb.go
@@ -25,7 +25,7 @@ type LbInfo struct {
 
 func (k *K8sBareMetalPlatform) GetSharedLBName(ctx context.Context, key *edgeproto.CloudletKey) string {
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetSharedLBName", "key", key)
-	name := cloudcommon.GetRootLBFQDN(key, k.commonPf.PlatformConfig.AppDNSRoot)
+	name := cloudcommon.GetRootLBFQDNOld(key, k.commonPf.PlatformConfig.AppDNSRoot)
 	return name
 }
 

--- a/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
+++ b/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
@@ -70,7 +70,7 @@ func (s *ShepherdPlatform) Init(ctx context.Context, pc *platform.PlatformConfig
 		defer s.VMPlatform.VMProvider.InitOperationContext(ctx, vmlayer.OperationInitComplete)
 	}
 	//need to have a separate one for dedicated rootlbs, see openstack.go line 111,
-	s.rootLbName = cloudcommon.GetRootLBFQDN(pc.CloudletKey, s.appDNSRoot)
+	s.rootLbName = s.VMPlatform.GetRootLBName(pc.CloudletKey)
 
 	start := time.Now()
 	// first wait for the rootlb to exist so we can get a client


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5284 Shepherd keeps restarting with "Error getting rootlb client"

### Description

The change to have a new fqdn for the rootlb, but keep the old fqdn format as the VM name, was missing an update in the Shepherd code. Needed to get shepherd to use the old fqdn for the VM name. Also for consistency changed it for k8s-bare-metal as well.