### PR TITLE
EDGECLOUD-5255 better MC json unmarshal err msgs

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -855,16 +855,6 @@ func GetMetricsCommon(c echo.Context) error {
 	return nil
 }
 
-func checkForTimeError(errStr string) string {
-	// special case for errors regarding time format
-	// golang's reference time is "2006-01-02T15:04:05Z07:00" (123456 in the posix date command), which is confusing
-	refTime := "2006-01-02T15:04:05Z07:00"
-	if strings.Contains(errStr, refTime) {
-		return fmt.Sprintf("%s into RFC3339 format failed. Example: \"%s\"", strings.Split(errStr, " as")[0], refTime)
-	}
-	return errStr
-}
-
 // Check that the user is authorized to access all of the devOrgsPruned's devResource resources
 func isDeveloperAuthorized(ctx context.Context, username string, devOrgsPruned []string, devResource string) (bool, map[string]struct{}, error) {
 	authDevOrgs, err := enforcer.GetAuthorizedOrgs(ctx, username, devResource, ActionView)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5255 invalid limit/numsamples/startage/endage for clientapiusage/clientappusage/clientcloudletusage needs better error handling

### Description

Some of my recent changes to call json.Unmarshal() directly in ReadConn, instead of c.Bind(), skips some of the error handling that echo did, resulting in error messages that weren't so great. So I've restored the error handling of c.Bind().

Additionally, I noticed there's some special handling of time.Parse errors, which is done when MC parses JSON, but is not done when mcctl parses args. So that is now moved to edge-cloud so it can be common between the two so that we get a consistent error in both cases.

The other special cases that were removed are already handled in auditlog.go:getErrorResult(), which is called from the main error handler, auditlog.go:errorHandler().