### PR TITLE
EDGECLOUD-5242: remove "custom" selector from clientappusage metrics

### DIFF
--- a/e2e-tests/e2e-setup/mcapi.go
+++ b/e2e-tests/e2e-setup/mcapi.go
@@ -889,9 +889,6 @@ func showMcClientAppMetrics(uri, token string, targets *MetricTargets, rc *bool)
 		},
 	}
 	for _, selector := range ormapi.ClientAppUsageSelectors {
-		if selector == "custom" {
-			continue
-		}
 		if selector == "latency" {
 			clientAppUsageQuery.LocationTile = targets.LocationTileLatency
 		} else {
@@ -915,9 +912,6 @@ func showMcClientCloudletMetrics(uri, token string, targets *MetricTargets, rc *
 		},
 	}
 	for _, selector := range ormapi.ClientCloudletUsageSelectors {
-		if selector == "custom" {
-			continue
-		}
 		if selector == "latency" {
 			clientCloudletUsageQuery.LocationTile = targets.LocationTileLatency
 		} else {

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -625,7 +625,6 @@ func getFieldsSlice(selector, measurementType string) []string {
 			fields = append(fields, LatencyFields...)
 		case "deviceinfo":
 			fields = append(fields, DeviceInfoFields...)
-		case "custom":
 		}
 	}
 	return fields

--- a/mc/orm/influx_clientmetrics.go
+++ b/mc/orm/influx_clientmetrics.go
@@ -434,8 +434,6 @@ func validateClientAppUsageMetricReq(req *ormapi.RegionClientAppUsageMetrics, se
 		if req.LocationTile != "" {
 			return fmt.Errorf("LocationTile not allowed for appinst deviceinfo metric")
 		}
-	case "custom":
-		return fmt.Errorf("Custom stat not implemented yet")
 	default:
 		return fmt.Errorf("Provided selector \"%s\" is not valid. Must provide only one of \"%s\"", selector, strings.Join(ormapi.ClientAppUsageSelectors, "\", \""))
 	}

--- a/mc/ormapi/metricsapi.go
+++ b/mc/ormapi/metricsapi.go
@@ -36,7 +36,6 @@ var ClientApiUsageSelectors = []string{
 var ClientAppUsageSelectors = []string{
 	"latency",
 	"deviceinfo",
-	"custom",
 }
 
 var ClientCloudletUsageSelectors = []string{


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5242: remove "custom" selector from clientappusage metrics

### Description

