### PR TITLE
EDGECLOUD-5294 Cluster prometheus AppInst fails to deploy

### DIFF
--- a/infracommon/dns.go
+++ b/infracommon/dns.go
@@ -43,7 +43,8 @@ func (c *CommonPlatform) CreateAppDNSAndPatchKubeSvc(ctx context.Context, client
 	log.SpanLog(ctx, log.DebugLevelInfra, "createAppDNS")
 
 	if kubeNames.AppURI == "" {
-		return fmt.Errorf("URI not specified")
+		log.SpanLog(ctx, log.DebugLevelInfra, "URI not specified, no DNS entries to create")
+		return nil
 	}
 	if !kubeNames.IsUriIPAddr {
 		err := validateDomain(kubeNames.AppURI)
@@ -114,7 +115,8 @@ func (c *CommonPlatform) CreateAppDNSAndPatchKubeSvc(ctx context.Context, client
 func (c *CommonPlatform) DeleteAppDNS(ctx context.Context, client ssh.Client, kubeNames *k8smgmt.KubeNames, overrideDns string) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "DeleteAppDNS", "kubeNames", kubeNames)
 	if kubeNames.AppURI == "" {
-		return fmt.Errorf("URI not specified")
+		log.SpanLog(ctx, log.DebugLevelInfra, "URI not specified, no DNS entry to delete")
+		return nil
 	}
 	err := validateDomain(kubeNames.AppURI)
 	if err != nil {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5294 Cluster prometheus AppInst fails to deploy

### Description

As part of changes for fqdn prefix, I removed URIs from AppInsts that didn't need it, i.e. with no ports or internal-ports only. Partly because, they didn't need it, and also because it made fixing up the e2e test files easier.

Unfortunately that hit a check in the infra code that cause any AppInst without a URI to fail, even if it wasn't going to need any DNS records. So I've changed the infra code to assume that if the Controller didn't assign a URI, then it doesn't need DNS.