### PR TITLE
Revert Azure vault secrets management temporarily

### DIFF
--- a/ansible/roles/kafka/tasks/loadbalancer-ips.yml
+++ b/ansible/roles/kafka/tasks/loadbalancer-ips.yml
@@ -1,18 +1,10 @@
 ---
 - block:
-  - import_role:
-      name: load-vault-creds
-      tasks_from: azure-aks-credentials
-
   - name: Retrieve kube config
     azure_rm_aks_info:
       name: "{{ k8s_cluster_name }}"
       resource_group: "{{ resource_group }}"
       show_kubeconfig: admin
-      subscription_id: "{{ azure_subscription_id }}"
-      tenant: "{{ azure_tenant_id }}"
-      client_id: "{{ azure_aks_client_id }}"
-      secret: "{{ azure_aks_client_secret }}"
     register: aks_facts
     check_mode: no
 

--- a/ansible/roles/mexplat_k8s/tasks/load-kubeconfig.yml
+++ b/ansible/roles/mexplat_k8s/tasks/load-kubeconfig.yml
@@ -1,17 +1,9 @@
 ---
-- import_role:
-    name: load-vault-creds
-    tasks_from: azure-aks-credentials
-
 - name: Retrieve kube config
   azure_rm_aks_info:
     name: "{{ k8s_cluster_name }}"
     resource_group: "{{ resource_group }}"
     show_kubeconfig: admin
-    subscription_id: "{{ azure_subscription_id }}"
-    tenant: "{{ azure_tenant_id }}"
-    client_id: "{{ azure_aks_client_id }}"
-    secret: "{{ azure_aks_client_secret }}"
   register: aks_facts
   check_mode: no
 


### PR DESCRIPTION
Azure generated secrets can sometimes take a very long time (over ten
seconds) which is interfering with QA regressions. Reverting this for
now.