### PR TITLE
EDGECLOUD-5299 Controller throws error while generating the report

### DIFF
--- a/mc/mcctl/mccli/reports.go
+++ b/mc/mcctl/mccli/reports.go
@@ -49,7 +49,7 @@ func (s *RootCommand) runGenerateReport(path string) func(c *cli.Command, args [
 		}
 
 		filename := ormapi.GetReportFileName(report)
-		st, err := s.sendReqAndDownloadPDF(path, filename, in)
+		st, err := s.sendReqAndDownloadPDF(path, filename, in.Data)
 		return check(c, st, err, nil)
 	}
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5299 Controller throws error while generating the report

### Description

* Namespace was being passed as part of the request. Fixed the code to just pass `data`