### PR TITLE
EDGECLOUD-5300 gcp/azure/aws url no dns

### DIFF
--- a/crm-platforms/aws/aws-eks/aws-eks.go
+++ b/crm-platforms/aws/aws-eks/aws-eks.go
@@ -22,6 +22,7 @@ func (o *AwsEksPlatform) GetFeatures() *platform.Features {
 		SupportsMultiTenantCluster:    true,
 		SupportsKubernetesOnly:        true,
 		KubernetesRequiresWorkerNodes: true,
+		IPAllocatedPerService:         true,
 	}
 }
 

--- a/crm-platforms/azure/azure.go
+++ b/crm-platforms/azure/azure.go
@@ -47,6 +47,7 @@ func (o *AzurePlatform) GetFeatures() *platform.Features {
 		SupportsMultiTenantCluster:    true,
 		SupportsKubernetesOnly:        true,
 		KubernetesRequiresWorkerNodes: true,
+		IPAllocatedPerService:         true,
 	}
 }
 

--- a/crm-platforms/gcp/gcp.go
+++ b/crm-platforms/gcp/gcp.go
@@ -47,6 +47,7 @@ func (o *GCPPlatform) GetFeatures() *platform.Features {
 		SupportsMultiTenantCluster:    true,
 		SupportsKubernetesOnly:        true,
 		KubernetesRequiresWorkerNodes: true,
+		IPAllocatedPerService:         true,
 	}
 }
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5300 Port is not reachable for AppInst running on GCP/Azure

### Description

Somehow I forgot to add the ip-per-service feature to the platforms I defined it for. This caused the URI and fqdn-prefix handling for AppInsts on these platforms to be incorrect, making the AppInsts unreachable from the SDK/client side.