### PR TITLE
EDGECLOUD-5218:Add vcd-cli as rundebug cmd

### DIFF
--- a/crm-platforms/vcd/vcd-debug.go
+++ b/crm-platforms/vcd/vcd-debug.go
@@ -1,0 +1,53 @@
+package vcd
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mobiledgex/edge-cloud-infra/infracommon"
+	"github.com/mobiledgex/edge-cloud/cloudcommon/node"
+	"github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/log"
+)
+
+func (v *VcdPlatform) initDebug(nodeMgr *node.NodeMgr) {
+	nodeMgr.Debug.AddDebugFunc("govcdcmd", v.runVcdCliCommand)
+}
+
+func (v *VcdPlatform) runVcdCliCommand(ctx context.Context, req *edgeproto.DebugRequest) string {
+
+	if req.Args == "" {
+		return "please specify vcd command in args field"
+	}
+	rd := csv.NewReader(strings.NewReader(req.Args))
+	rd.Comma = ' '
+	args, err := rd.Read()
+	if err != nil {
+		return fmt.Sprintf("failed to split args string, %v", err)
+	}
+	log.SpanLog(ctx, log.DebugLevelInfra, "runVcdCliCommand ", "args[0]", args[0], "args[1:]...", args[1:])
+	out, err := v.TimedVcdCliCommand(ctx, args[0], args[1:]...)
+	if err != nil {
+		return fmt.Sprintf("given vcd cmd command failed: %v, %s", err, string(out))
+	}
+	return string(out)
+}
+
+func (v *VcdPlatform) TimedVcdCliCommand(ctx context.Context, name string, a ...string) ([]byte, error) {
+	parmstr := strings.Join(a, " ")
+	start := time.Now()
+	log.SpanLog(ctx, log.DebugLevelInfra, "govcdcmd Command Start", "name", name, "parms", parmstr)
+	newSh := infracommon.Sh(v.vcdVars)
+
+	out, err := newSh.Command(name, a).CombinedOutput()
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfra, "govcdcmd command returned error", "parms", parmstr, "out", string(out), "err", err, "elapsed time", time.Since(start))
+		return out, err
+	}
+
+	log.SpanLog(ctx, log.DebugLevelInfra, "govcdcmd Command Done", "parmstr", parmstr, "elapsed time", time.Since(start))
+	return out, nil
+}

--- a/crm-platforms/vcd/vcd.go
+++ b/crm-platforms/vcd/vcd.go
@@ -119,6 +119,7 @@ func (v *VcdPlatform) InitProvider(ctx context.Context, caches *platform.Caches,
 				return err
 			}
 		}
+		v.initDebug(v.vmProperties.CommonPf.PlatformConfig.NodeMgr)
 	}
 	return nil
 }

--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -75,4 +75,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 RUN curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz" | tar xz -C /tmp \
 	&& mv /tmp/eksctl /usr/local/bin
 
+## VCD CLI
+RUN curl -sL -u apt:mobiledgex -O "https://artifactory.mobiledgex.net:443/artifactory/downloads/vcd/vcd-cli_24.0.1-1_amd64.deb" \
+    && dpkg -i vcd-cli_24.0.1-1_amd64.deb \
+
 COPY edge-cloud-base-image.root/_ssh /root/.ssh


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5218 

### Description
Add vcd cli to debug rundebug CLI cmd for diagnostic/debugging.
New vcd-debug.go and edits to Dockerfile.edge-cloud-base-image 

example login: mcctl --addr https://console-vcd.mobiledgex.net:443 debug rundebug region=US cloudlet=cld1 organization=packet type=crm cmd=govcdcmd args="/usr/bin/env LC_ALL=C.UTF-8 LANG=C.UTF-8 /home/ubuntu/venv/bin/vcd login https://139.178.87.44 jimorg mex -w -i -p admin123"
- node:
    name: cld1-packet-pf
    type: crm
    cloudletkey:
      organization: packet
      name: cld1
    region: US
  output: "\rmex logged in, org: 'jimorg', vdc: 'jimvdc'\n"

Example vcd vapp info: 
 mcctl  --addr https://console-vcd.mobiledgex.net:443 --output-format=json  debug rundebug region=US cloudlet=cld1 organization=packet type=crm cmd=govcdcmd args="/usr/bin/env LC_ALL=C.UTF-8 LANG=C.UTF-8 /home/ubuntu/venv/bin/vcd vapp info cld1-packet-pf-vapp" | jq -r '.[0].output'
property                 value
-----------------------  ------------------------------------
deployment_lease         0.0w, 0.0d, 0.0h
description              vapp for cld1-packet-pf-0.1-alpha
id                       2b3f8439-bc51-4698-9be7-b9314cc8d3cc
is_shared_to_everyone    False
name                     cld1-packet-pf-vapp
owner                    mex
status                   Powered on
storage_lease            4.285714285714286w, 0.0d, 0.0h
vapp-net-1               ext-net
vapp-net-1-mode          bridged
vm-1: 4 virtual CPU(s)   4
vm-1: 4096 MB of memory  4,096
vm-1: Hard disk 1        21,474,836,480 byte
vm-1: Network adapter 0  POOL: 139.178.87.4
vm-1: SCSI Controller 0  SCSI Controller
vm-1: computer-name      cld1-packet-pf
vm-1: moid               vm-11787
vm-1: name               cld1-packet-pf
vm-1: storage-profile    *

