### PR TITLE
 MC fails to set rate limit setting during init

### DIFF
--- a/mc/orm/ratelimitmc.go
+++ b/mc/orm/ratelimitmc.go
@@ -89,7 +89,7 @@ func InitRateLimitMc(ctx context.Context) error {
 	db := loggedDB(ctx)
 
 	createFunc := func(settings interface{}) error {
-		return db.Create(settings).Error
+		return db.FirstOrCreate(settings).Error
 	}
 
 	// Create Global RateLimitSettings and UserCreate RateLimitSettings entries in postgres


### PR DESCRIPTION
**Issues**

* EDGECLOUD-5311 mc fails to set rate limit setting during init
