### PR TITLE
GPU driver validation should happen after license config is setup

### DIFF
--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.5.0
+VERSION = 4.5.1
 DISTRIBUTION = cirrus
 COMPONENT = main
 

--- a/openstack-tenant/packages/mobiledgex/install-gpu-driver.sh
+++ b/openstack-tenant/packages/mobiledgex/install-gpu-driver.sh
@@ -65,11 +65,6 @@ ldconfig
 [[ $? -ne 0 ]] && die "Failed to rebuild ldcache"
 echo ""
 
-echo ">> Verify GPU driver $DRIVERPATH is installed..."
-nvidia-smi -L
-[[ $? -ne 0 ]] && die "Failed to verify if $DRIVERPATH package is installed"
-echo ""
-
 if [[ ! -z $LICENSECFGPATH ]]; then
 	# License configuration for nvidia-gridd service
 	systemctl cat nvidia-gridd.service > /dev/null
@@ -120,5 +115,10 @@ if [[ ! -z $LICENSECFGPATH ]]; then
 	fi
 	echo ""
 fi
+
+echo ">> Verify GPU driver $DRIVERPATH is installed..."
+nvidia-smi -L
+[[ $? -ne 0 ]] && die "Failed to verify if $DRIVERPATH package is installed"
+echo ""
 
 echo ">> Done setting up GPU driver $DRIVERNAME"

--- a/version/package-version.go
+++ b/version/package-version.go
@@ -1,3 +1,3 @@
 package version
 
-var MobiledgeXPackageVersion = "4.5.0"
+var MobiledgeXPackageVersion = "4.5.1"

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -42,7 +42,7 @@ const MINIMUM_VCPUS uint64 = 2
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.5.0"
+var MEXInfraVersion = "4.5.1"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5317: License config is not setup when GPU driver is already installed on the cluster VM

### Description

* For VCD, If VM is not configured to use GPU and driver is installed, then GPU validation will fail. Once the VM is configured to use GPU, then the next installation of GPU will be skipped and hence license will not be configured. Updated the code to perform validation only after license is configured