### PR TITLE
EDGECLOUD-5328: GPUdriver gets pre-installed on k8s worker node in WWT setup

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -172,7 +172,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 			return err
 		}
 		setupStage := v.VMProvider.GetGPUSetupStage(ctx)
-		if appInst.OptRes == "gpu" && appInst.Liveness != edgeproto.Liveness_LIVENESS_DYNAMIC && setupStage == AppInstStage {
+		if appInst.OptRes == "gpu" && cloudcommon.IsSideCarApp(app) && setupStage == AppInstStage {
 			// setup GPU drivers
 			err = v.setupGPUDrivers(ctx, client, clusterInst, updateCallback, ActionCreate)
 			if err != nil {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5328: GPU driver gets pre-installed on k8s worker node in WWT setup

### Description

* On k8s cluster, `cluster-svc` creates internal appInsts (mexprom, nfs). This was installing a GPU driver and setting up a GPU operator on the cluster. Fixed the code to skip it, if AppInst is an internal app. So that it won't interfere when the developer instantiates an app on this cluster