### PR TITLE
fix help

### DIFF
--- a/mc/mcctl/ormctl/alert_receiver.go
+++ b/mc/mcctl/ormctl/alert_receiver.go
@@ -89,7 +89,7 @@ var AlertReceiverArgsComments = map[string]string{
 	"region":                    "Region where alert originated",
 	"user":                      "User name, if not the same as the logged in user",
 	"name":                      "Unique name of this receiver",
-	"type":                      "Receiver type - email or slack",
+	"type":                      "Receiver type - email, slack or pagerduty",
 	"severity":                  "Alert severity level - one of " + cloudcommon.GetValidAlertSeverityString(),
 	"email":                     "Email address receiving the alert (by default email associated with the account)",
 	"slack-channel":             "Slack channel to be receiving the alert",


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5314  mcctl alertreceiver create does not show pagerduty for type arg

### Description

Add pagerduty to the help text.