### PR TITLE
EDGECLOUD-5328: GPUdriver gets pre-installed on k8s worker node in WWT setup

### DIFF
--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -172,7 +172,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 			return err
 		}
 		setupStage := v.VMProvider.GetGPUSetupStage(ctx)
-		if appInst.OptRes == "gpu" && cloudcommon.IsSideCarApp(app) && setupStage == AppInstStage {
+		if appInst.OptRes == "gpu" && !cloudcommon.IsSideCarApp(app) && setupStage == AppInstStage {
 			// setup GPU drivers
 			err = v.setupGPUDrivers(ctx, client, clusterInst, updateCallback, ActionCreate)
 			if err != nil {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5328: GPUdriver gets pre-installed on k8s worker node in WWT setup

### Description

* Small typo in my last commit, fixed it here.