### PR TITLE
EDGECLOUD-5343 rate limit mc e2e-test ShowApp2 failed

### DIFF
--- a/e2e-tests/e2e-setup/mcapi.go
+++ b/e2e-tests/e2e-setup/mcapi.go
@@ -429,7 +429,6 @@ func runMcDataAPI(api, uri, apiFile, curUserFile, outputDir string, mods []strin
 		if errs == nil || len(errs) == 0 {
 			util.PrintToYamlFile("show-commands.yml", outputDir, dataOut, true)
 			util.PrintToYamlFile("api-output.yml", outputDir, "", true)
-
 		} else {
 			util.PrintToYamlFile("api-output.yml", outputDir, errs, true)
 			util.PrintToYamlFile("show-commands.yml", outputDir, "", true)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5343 rate limit e2e-test fails intermittently

### Description

When the rate limit test succeeded (instead of getting an error message as expected), it wrote to the show-commands.yml, But the test description was doing a compareyaml against the api-output.yml, which was leftover from a previous test. So we ended getting a confusing error. To fix, write both files out, since one gets written on success and one gets written on failure. This way they're both up-to-date. The actual fix for the test failing is in the edge-cloud PR https://github.com/mobiledgex/edge-cloud/pull/1434. This just fixes a confusing error message.