### PR TITLE
EDGECLOUD-5241  better error when using unsupported selectors

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -509,12 +509,12 @@ func validateSelectorString(selector, metricType string) error {
 		if !Contains(validSelectors, s) {
 			helpStr := strings.Join(validSelectors, "\", \"")
 			if len(validSelectors) > 1 {
-				helpStr = "Must be one of \"" + helpStr + "\""
+				helpStr = "must be one of \"" + helpStr + "\""
 			} else {
-				helpStr = "Only \"" + helpStr + "\" is supported"
+				helpStr = "only \"" + helpStr + "\" is supported"
 			}
 
-			return fmt.Errorf("Invalid %s selector: %s. %s", metricType, s, helpStr)
+			return fmt.Errorf("Invalid %s selector: %s, %s", metricType, s, helpStr)
 		}
 	}
 	return nil

--- a/mc/orm/influx_clientmetrics.go
+++ b/mc/orm/influx_clientmetrics.go
@@ -435,7 +435,7 @@ func validateClientAppUsageMetricReq(req *ormapi.RegionClientAppUsageMetrics, se
 			return fmt.Errorf("LocationTile not allowed for appinst deviceinfo metric")
 		}
 	default:
-		return fmt.Errorf("Provided selector \"%s\" is not valid. Must provide only one of \"%s\"", selector, strings.Join(ormapi.ClientAppUsageSelectors, "\", \""))
+		return fmt.Errorf("Provided selector \"%s\" is not valid, must provide only one of \"%s\"", selector, strings.Join(ormapi.ClientAppUsageSelectors, "\", \""))
 	}
 	return nil
 }
@@ -456,7 +456,7 @@ func validateClientCloudletUsageMetricReq(req *ormapi.RegionClientCloudletUsageM
 			return fmt.Errorf("DataNetworkType not allowed for cloudlet deviceinfo metric")
 		}
 	default:
-		return fmt.Errorf("Provided selector \"%s\" is not valid. Must provide only one of \"%s\"", selector, strings.Join(ormapi.ClientCloudletUsageSelectors, "\", \""))
+		return fmt.Errorf("Provided selector \"%s\" is not valid, must provide only one of \"%s\"", selector, strings.Join(ormapi.ClientCloudletUsageSelectors, "\", \""))
 	}
 	return nil
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5241 clientapiusage and clientcloudletusage metrics should give better error when using unsupported selectors

### Description

Generate a help string with valid selectors to show in an error