### PR TITLE
EDGECLOUD-5358: Operator Should be able to view Developer's Audit, Event and Usage if they are part of Cloudlet Pool

### DIFF
--- a/mc/mcctl/ormctl/billingevents.go
+++ b/mc/mcctl/ormctl/billingevents.go
@@ -46,12 +46,11 @@ func init() {
 	AllApis.AddGroup(BillingEventsGroup, "View billing events ", cmds)
 }
 
-var AppEventRequiredArgs = []string{
-	"app-org",
-}
+var AppEventRequiredArgs = []string{}
 
 var AppEventOptionalArgs = []string{
 	"appname",
+	"app-org",
 	"appvers",
 	"cluster",
 	"cloudlet",
@@ -70,12 +69,11 @@ var AppEventAliasArgs = []string{
 	"cloudlet=appinst.clusterinstkey.cloudletkey.name",
 }
 
-var ClusterEventRequiredArgs = []string{
-	"cluster-org",
-}
+var ClusterEventRequiredArgs = []string{}
 
 var ClusterEventOptionalArgs = []string{
 	"cluster",
+	"cluster-org",
 	"cloudlet-org",
 	"cloudlet",
 	"last",


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5358: Operator Should be able to view Developer's Audit, Event and Usage if they are part of Cloudlet Pool

### Description

* Modified the code to query based on app-org or cloudlet-org so that operators can use this API