### PR TITLE
EDGECLOUD-5389 Permissions for operators that are also developer

### DIFF
--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -923,6 +923,13 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 	// cloudlet pool operator wants to see metrics on one of the pool members
 	testPassCheckPermissionsAndGetCloudletList(t, ctx, oper.Name, ctrl.Region, []string{org1}, ResourceAppAnalytics,
 		[]edgeproto.CloudletKey{*tc3}, []string{tc3.Name})
+	// operator developer can see the cloudlet pool apps even if no app is specified
+	devOper, _, _ := testCreateUser(t, mcClient, uri, "devOper")
+	testAddUserRole(t, mcClient, uri, tokenAd, org3, "OperatorContributor", devOper.Name, Success)
+	testAddUserRole(t, mcClient, uri, tokenAd, org1, "DeveloperContributor", devOper.Name, Success)
+	testPassCheckPermissionsAndGetCloudletList(t, ctx, devOper.Name, ctrl.Region, []string{}, ResourceAppAnalytics,
+		[]edgeproto.CloudletKey{org3Cloudlet.Key}, []string{"org3"})
+	testDeleteUser(t, mcClient, uri, tokenAd, "devOper")
 
 	// developer2 confirms invitation
 	op2accept := op2

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -973,17 +973,6 @@ func checkPermissionsAndGetCloudletList(ctx context.Context, username, region st
 	if devOrgPermOk, authDevOrgs, err = isDeveloperAuthorized(ctx, username, devOrgs, devResource); err != nil {
 		return []string{}, err
 	}
-	// if a developer is authorized, just return the list now
-	if devOrgPermOk {
-		return getListFromMap(uniqueCloudlets), nil
-	} else {
-		// no perms for specified orgs, or they forgot to specify an org that
-		// they have perms to (since there are two choices)
-		if len(devOrgs) == 0 && len(authDevOrgs) > 0 {
-			// developer but didn't specify App org
-			return []string{}, fmt.Errorf("Developers please specify the %s Organization", orgField)
-		}
-	}
 
 	// At this point we need to check what cloudlets(cloudletPool members) are allowed for this operator
 	authOperOrgs, err := enforcer.GetAuthorizedOrgs(ctx, username, ResourceCloudletAnalytics, ActionView)
@@ -1001,6 +990,18 @@ func checkPermissionsAndGetCloudletList(ctx context.Context, username, region st
 				operOrgPermOk = false
 				break
 			}
+		}
+	}
+
+	// if a developer is authorized, just return the list now
+	if devOrgPermOk {
+		return getListFromMap(uniqueCloudlets), nil
+	} else if !operOrgPermOk { // it could be operator and developer
+		// no perms for specified orgs, or they forgot to specify an org that
+		// they have perms to (since there are two choices)
+		if len(devOrgs) == 0 && len(authDevOrgs) > 0 {
+			// developer but didn't specify App org
+			return []string{}, fmt.Errorf("Developers please specify the %s Organization", orgField)
 		}
 	}
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5389 [WebUI-Monitoring] Operator Can not view Developer's metrics on monitoring page even though they are part of Cloudlet Pool

### Description

Add case for an operator that is also a developer. Also added a unit test for this case.