### PR TITLE
Fix MC crash as ratelimitmgr is not initialised

### DIFF
--- a/mc/orm/ratelimitmc.go
+++ b/mc/orm/ratelimitmc.go
@@ -81,10 +81,6 @@ var UserCreatePerIpMcRateLimitSettings = &ormapi.McRateLimitSettings{
  * Add RateLimitSettings to RateLimitMgr
  */
 func InitRateLimitMc(ctx context.Context) error {
-	if getDisableRateLimit(ctx) {
-		return nil
-	}
-
 	log.SpanLog(ctx, log.DebugLevelApi, "init ratelimit")
 	db := loggedDB(ctx)
 


### PR DESCRIPTION
Ratelimitmgr should be initialized regardless of ratelimit being disabled or enabled. Code does take care of skipping rate limit check if it is disabled