### PR TITLE
EDGECLOUD-5405  clientappusage metrics not giving the correct interval as developer

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -302,7 +302,7 @@ func getSettings(ctx context.Context, idc *InfluxDBContext) (*edgeproto.Settings
 	in := &edgeproto.Settings{}
 	rc := &RegionContext{
 		region:    idc.region,
-		skipAuthz: true, // this is internal call, so ok not to call
+		skipAuthz: true, // this is internal call, so no auth needed
 	}
 	return ShowSettingsObj(ctx, rc, in)
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5405  clientappusage metrics not giving the correct interval as developer

### Description

Reason there are differences between admin and developer requesting metrics is due to the fact that we rely on settings  to decide on time definition. However, settings are not allowed for non-admin users. Changed the code to get metrics skipping auth, since this is an internal call anyways.