### PR TITLE
EDGECLOUD-5265 mc context deadline exceeded errors - conn cache

### DIFF
--- a/mc/mcctl/mccli/cmd.go
+++ b/mc/mcctl/mccli/cmd.go
@@ -135,7 +135,7 @@ func (s *RootCommand) PreRunE(cmd *cobra.Command, args []string) error {
 		s.token = os.Getenv("TOKEN")
 	}
 	if s.token == "" {
-		tok, err := ioutil.ReadFile(getTokenFile())
+		tok, err := ioutil.ReadFile(GetTokenFile())
 		if err == nil {
 			s.token = strings.TrimSpace(string(tok))
 		}
@@ -146,7 +146,7 @@ func (s *RootCommand) PreRunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getTokenFile() string {
+func GetTokenFile() string {
 	home := os.Getenv("HOME")
 	return home + "/.mctoken"
 }

--- a/mc/mcctl/mccli/login.go
+++ b/mc/mcctl/mccli/login.go
@@ -47,12 +47,12 @@ func (s *RootCommand) runLogin(path string) func(c *cli.Command, args []string) 
 			return err
 		}
 		fmt.Fprintln(wr, "login successful")
-		err = ioutil.WriteFile(getTokenFile(), []byte(token), 0600)
+		err = ioutil.WriteFile(GetTokenFile(), []byte(token), 0600)
 		if err != nil {
-			fmt.Fprintf(wr, "warning, cannot save token file %s, %v\n", getTokenFile(), err)
+			fmt.Fprintf(wr, "warning, cannot save token file %s, %v\n", GetTokenFile(), err)
 			fmt.Fprintf(wr, "token: %s\n", token)
 		} else {
-			fmt.Fprintf(wr, "token saved to %s\n", getTokenFile())
+			fmt.Fprintf(wr, "token saved to %s\n", GetTokenFile())
 		}
 		if err == nil && admin {
 			ioutil.WriteFile(GetAdminFile(), []byte{}, 0600)

--- a/mc/orm/alert.mc2.go
+++ b/mc/orm/alert.mc2.go
@@ -70,17 +70,18 @@ func ShowAlertStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Aler
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAlertApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowAlert(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/alertpolicy.mc2.go
+++ b/mc/orm/alertpolicy.mc2.go
@@ -68,17 +68,18 @@ func CreateAlertPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAlertPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateAlertPolicy(ctx, obj)
 }
 
@@ -123,17 +124,18 @@ func DeleteAlertPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAlertPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteAlertPolicy(ctx, obj)
 }
 
@@ -182,17 +184,18 @@ func UpdateAlertPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAlertPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateAlertPolicy(ctx, obj)
 }
 
@@ -237,17 +240,18 @@ func ShowAlertPolicyStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAlertPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowAlertPolicy(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/app.mc2.go
+++ b/mc/orm/app.mc2.go
@@ -69,17 +69,18 @@ func CreateAppObj(ctx context.Context, rc *RegionContext, obj *edgeproto.App) (*
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateApp(ctx, obj)
 }
 
@@ -124,17 +125,18 @@ func DeleteAppObj(ctx context.Context, rc *RegionContext, obj *edgeproto.App) (*
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteApp(ctx, obj)
 }
 
@@ -183,17 +185,18 @@ func UpdateAppObj(ctx context.Context, rc *RegionContext, obj *edgeproto.App) (*
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateApp(ctx, obj)
 }
 
@@ -238,17 +241,18 @@ func ShowAppStream(ctx context.Context, rc *RegionContext, obj *edgeproto.App, c
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowApp(ctx, obj)
 	if err != nil {
 		return err
@@ -324,17 +328,18 @@ func AddAppAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AddAppAutoProvPolicy(ctx, obj)
 }
 
@@ -378,17 +383,18 @@ func RemoveAppAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edg
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RemoveAppAutoProvPolicy(ctx, obj)
 }
 
@@ -432,17 +438,18 @@ func AddAppAlertPolicyObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AddAppAlertPolicy(ctx, obj)
 }
 
@@ -486,17 +493,18 @@ func RemoveAppAlertPolicyObj(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RemoveAppAlertPolicy(ctx, obj)
 }
 
@@ -544,17 +552,18 @@ func ShowCloudletsForAppDeploymentStream(ctx context.Context, rc *RegionContext,
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowCloudletsForAppDeployment(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/appinst.mc2.go
+++ b/mc/orm/appinst.mc2.go
@@ -71,17 +71,18 @@ func CreateAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.CreateAppInst(ctx, obj)
 	if err != nil {
 		return err
@@ -155,17 +156,18 @@ func DeleteAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.DeleteAppInst(ctx, obj)
 	if err != nil {
 		return err
@@ -239,17 +241,18 @@ func RefreshAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.RefreshAppInst(ctx, obj)
 	if err != nil {
 		return err
@@ -327,17 +330,18 @@ func UpdateAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.UpdateAppInst(ctx, obj)
 	if err != nil {
 		return err
@@ -414,17 +418,18 @@ func ShowAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Ap
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowAppInst(ctx, obj)
 	if err != nil {
 		return err
@@ -505,16 +510,17 @@ func RequestAppInstLatencyObj(ctx context.Context, rc *RegionContext, obj *edgep
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppInstLatencyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RequestAppInstLatency(ctx, obj)
 }

--- a/mc/orm/appinstclient.mc2.go
+++ b/mc/orm/appinstclient.mc2.go
@@ -66,17 +66,18 @@ func ShowAppInstClientStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppInstClientApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowAppInstClient(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/autoprovpolicy.mc2.go
+++ b/mc/orm/autoprovpolicy.mc2.go
@@ -70,17 +70,18 @@ func CreateAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoProvPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateAutoProvPolicy(ctx, obj)
 }
 
@@ -125,17 +126,18 @@ func DeleteAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoProvPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteAutoProvPolicy(ctx, obj)
 }
 
@@ -184,17 +186,18 @@ func UpdateAutoProvPolicyObj(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoProvPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateAutoProvPolicy(ctx, obj)
 }
 
@@ -239,17 +242,18 @@ func ShowAutoProvPolicyStream(ctx context.Context, rc *RegionContext, obj *edgep
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoProvPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowAutoProvPolicy(ctx, obj)
 	if err != nil {
 		return err
@@ -326,17 +330,18 @@ func AddAutoProvPolicyCloudletObj(ctx context.Context, rc *RegionContext, obj *e
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoProvPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AddAutoProvPolicyCloudlet(ctx, obj)
 }
 
@@ -381,16 +386,17 @@ func RemoveAutoProvPolicyCloudletObj(ctx context.Context, rc *RegionContext, obj
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoProvPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RemoveAutoProvPolicyCloudlet(ctx, obj)
 }

--- a/mc/orm/autoscalepolicy.mc2.go
+++ b/mc/orm/autoscalepolicy.mc2.go
@@ -68,17 +68,18 @@ func CreateAutoScalePolicyObj(ctx context.Context, rc *RegionContext, obj *edgep
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoScalePolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateAutoScalePolicy(ctx, obj)
 }
 
@@ -123,17 +124,18 @@ func DeleteAutoScalePolicyObj(ctx context.Context, rc *RegionContext, obj *edgep
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoScalePolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteAutoScalePolicy(ctx, obj)
 }
 
@@ -182,17 +184,18 @@ func UpdateAutoScalePolicyObj(ctx context.Context, rc *RegionContext, obj *edgep
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoScalePolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateAutoScalePolicy(ctx, obj)
 }
 
@@ -237,17 +240,18 @@ func ShowAutoScalePolicyStream(ctx context.Context, rc *RegionContext, obj *edge
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAutoScalePolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowAutoScalePolicy(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/cloudlet.mc2.go
+++ b/mc/orm/cloudlet.mc2.go
@@ -71,17 +71,18 @@ func CreateGPUDriverStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewGPUDriverApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.CreateGPUDriver(ctx, obj)
 	if err != nil {
 		return err
@@ -155,17 +156,18 @@ func DeleteGPUDriverStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewGPUDriverApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.DeleteGPUDriver(ctx, obj)
 	if err != nil {
 		return err
@@ -243,17 +245,18 @@ func UpdateGPUDriverStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewGPUDriverApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.UpdateGPUDriver(ctx, obj)
 	if err != nil {
 		return err
@@ -330,17 +333,18 @@ func ShowGPUDriverStream(ctx context.Context, rc *RegionContext, obj *edgeproto.
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewGPUDriverApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowGPUDriver(ctx, obj)
 	if err != nil {
 		return err
@@ -423,17 +427,18 @@ func AddGPUDriverBuildStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewGPUDriverApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.AddGPUDriverBuild(ctx, obj)
 	if err != nil {
 		return err
@@ -507,17 +512,18 @@ func RemoveGPUDriverBuildStream(ctx context.Context, rc *RegionContext, obj *edg
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewGPUDriverApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.RemoveGPUDriverBuild(ctx, obj)
 	if err != nil {
 		return err
@@ -586,17 +592,18 @@ func GetGPUDriverBuildURLObj(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewGPUDriverApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.GetGPUDriverBuildURL(ctx, obj)
 }
 
@@ -643,17 +650,18 @@ func CreateCloudletStream(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.CreateCloudlet(ctx, obj)
 	if err != nil {
 		return err
@@ -727,17 +735,18 @@ func DeleteCloudletStream(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.DeleteCloudlet(ctx, obj)
 	if err != nil {
 		return err
@@ -815,17 +824,18 @@ func UpdateCloudletStream(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.UpdateCloudlet(ctx, obj)
 	if err != nil {
 		return err
@@ -901,17 +911,18 @@ func ShowCloudletStream(ctx context.Context, rc *RegionContext, obj *edgeproto.C
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowCloudlet(ctx, obj)
 	if err != nil {
 		return err
@@ -991,17 +1002,18 @@ func GetCloudletManifestObj(ctx context.Context, rc *RegionContext, obj *edgepro
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.GetCloudletManifest(ctx, obj)
 }
 
@@ -1042,17 +1054,18 @@ func GetCloudletPropsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.GetCloudletProps(ctx, obj)
 }
 
@@ -1093,17 +1106,18 @@ func GetCloudletResourceQuotaPropsObj(ctx context.Context, rc *RegionContext, ob
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.GetCloudletResourceQuotaProps(ctx, obj)
 }
 
@@ -1145,17 +1159,18 @@ func GetCloudletResourceUsageObj(ctx context.Context, rc *RegionContext, obj *ed
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.GetCloudletResourceUsage(ctx, obj)
 }
 
@@ -1200,17 +1215,18 @@ func AddCloudletResMappingObj(ctx context.Context, rc *RegionContext, obj *edgep
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AddCloudletResMapping(ctx, obj)
 }
 
@@ -1255,17 +1271,18 @@ func RemoveCloudletResMappingObj(ctx context.Context, rc *RegionContext, obj *ed
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RemoveCloudletResMapping(ctx, obj)
 }
 
@@ -1307,17 +1324,18 @@ func FindFlavorMatchObj(ctx context.Context, rc *RegionContext, obj *edgeproto.F
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.FindFlavorMatch(ctx, obj)
 }
 
@@ -1359,17 +1377,18 @@ func ShowFlavorsForCloudletStream(ctx context.Context, rc *RegionContext, obj *e
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowFlavorsForCloudlet(ctx, obj)
 	if err != nil {
 		return err
@@ -1440,17 +1459,18 @@ func RevokeAccessKeyObj(ctx context.Context, rc *RegionContext, obj *edgeproto.C
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RevokeAccessKey(ctx, obj)
 }
 
@@ -1494,17 +1514,18 @@ func GenerateAccessKeyObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.GenerateAccessKey(ctx, obj)
 }
 
@@ -1549,17 +1570,18 @@ func ShowCloudletInfoStream(ctx context.Context, rc *RegionContext, obj *edgepro
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletInfoApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowCloudletInfo(ctx, obj)
 	if err != nil {
 		return err
@@ -1636,17 +1658,18 @@ func InjectCloudletInfoObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletInfoApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.InjectCloudletInfo(ctx, obj)
 }
 
@@ -1691,16 +1714,17 @@ func EvictCloudletInfoObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletInfoApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.EvictCloudletInfo(ctx, obj)
 }

--- a/mc/orm/cloudletpool.mc2.go
+++ b/mc/orm/cloudletpool.mc2.go
@@ -69,17 +69,18 @@ func CreateCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateCloudletPool(ctx, obj)
 }
 
@@ -124,17 +125,18 @@ func DeleteCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteCloudletPool(ctx, obj)
 }
 
@@ -183,17 +185,18 @@ func UpdateCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateCloudletPool(ctx, obj)
 }
 
@@ -238,17 +241,18 @@ func ShowCloudletPoolStream(ctx context.Context, rc *RegionContext, obj *edgepro
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowCloudletPool(ctx, obj)
 	if err != nil {
 		return err
@@ -325,17 +329,18 @@ func AddCloudletPoolMemberObj(ctx context.Context, rc *RegionContext, obj *edgep
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AddCloudletPoolMember(ctx, obj)
 }
 
@@ -380,16 +385,17 @@ func RemoveCloudletPoolMemberObj(ctx context.Context, rc *RegionContext, obj *ed
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RemoveCloudletPoolMember(ctx, obj)
 }

--- a/mc/orm/clusterinst.mc2.go
+++ b/mc/orm/clusterinst.mc2.go
@@ -71,17 +71,18 @@ func CreateClusterInstStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewClusterInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.CreateClusterInst(ctx, obj)
 	if err != nil {
 		return err
@@ -155,17 +156,18 @@ func DeleteClusterInstStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewClusterInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.DeleteClusterInst(ctx, obj)
 	if err != nil {
 		return err
@@ -243,17 +245,18 @@ func UpdateClusterInstStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewClusterInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.UpdateClusterInst(ctx, obj)
 	if err != nil {
 		return err
@@ -330,17 +333,18 @@ func ShowClusterInstStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewClusterInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowClusterInst(ctx, obj)
 	if err != nil {
 		return err
@@ -419,16 +423,17 @@ func DeleteIdleReservableClusterInstsObj(ctx context.Context, rc *RegionContext,
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewClusterInstApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteIdleReservableClusterInsts(ctx, obj)
 }

--- a/mc/orm/debug.mc2.go
+++ b/mc/orm/debug.mc2.go
@@ -66,17 +66,18 @@ func EnableDebugLevelsStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectNotifyRoot(ctx)
+		conn, err := connCache.GetNotifyRootConn(ctx)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewDebugApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.EnableDebugLevels(ctx, obj)
 	if err != nil {
 		return err
@@ -148,17 +149,18 @@ func DisableDebugLevelsStream(ctx context.Context, rc *RegionContext, obj *edgep
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectNotifyRoot(ctx)
+		conn, err := connCache.GetNotifyRootConn(ctx)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewDebugApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.DisableDebugLevels(ctx, obj)
 	if err != nil {
 		return err
@@ -227,17 +229,18 @@ func ShowDebugLevelsStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectNotifyRoot(ctx)
+		conn, err := connCache.GetNotifyRootConn(ctx)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewDebugApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowDebugLevels(ctx, obj)
 	if err != nil {
 		return err
@@ -309,17 +312,18 @@ func RunDebugStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Debug
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectNotifyRoot(ctx)
+		conn, err := connCache.GetNotifyRootConn(ctx)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewDebugApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.RunDebug(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/device.mc2.go
+++ b/mc/orm/device.mc2.go
@@ -67,17 +67,18 @@ func InjectDeviceObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Devi
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewDeviceApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.InjectDevice(ctx, obj)
 }
 
@@ -121,17 +122,18 @@ func ShowDeviceStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Dev
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewDeviceApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowDevice(ctx, obj)
 	if err != nil {
 		return err
@@ -207,17 +209,18 @@ func EvictDeviceObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Devic
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewDeviceApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.EvictDevice(ctx, obj)
 }
 
@@ -261,17 +264,18 @@ func ShowDeviceReportStream(ctx context.Context, rc *RegionContext, obj *edgepro
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewDeviceApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowDeviceReport(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/exec.mc2.go
+++ b/mc/orm/exec.mc2.go
@@ -64,17 +64,18 @@ func RunCommandObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ExecRe
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewExecApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RunCommand(ctx, obj)
 }
 
@@ -118,17 +119,18 @@ func RunConsoleObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ExecRe
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewExecApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RunConsole(ctx, obj)
 }
 
@@ -169,17 +171,18 @@ func ShowLogsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ExecRequ
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewExecApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.ShowLogs(ctx, obj)
 }
 
@@ -222,16 +225,17 @@ func AccessCloudletObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Ex
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewExecApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AccessCloudlet(ctx, obj)
 }

--- a/mc/orm/flavor.mc2.go
+++ b/mc/orm/flavor.mc2.go
@@ -67,17 +67,18 @@ func CreateFlavorObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flav
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewFlavorApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateFlavor(ctx, obj)
 }
 
@@ -121,17 +122,18 @@ func DeleteFlavorObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flav
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewFlavorApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteFlavor(ctx, obj)
 }
 
@@ -179,17 +181,18 @@ func UpdateFlavorObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flav
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewFlavorApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateFlavor(ctx, obj)
 }
 
@@ -225,17 +228,18 @@ func ShowFlavor(c echo.Context) error {
 
 func ShowFlavorStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Flavor, cb func(res *edgeproto.Flavor) error) error {
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewFlavorApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowFlavor(ctx, obj)
 	if err != nil {
 		return err
@@ -306,17 +310,18 @@ func AddFlavorResObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Flav
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewFlavorApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AddFlavorRes(ctx, obj)
 }
 
@@ -360,16 +365,17 @@ func RemoveFlavorResObj(ctx context.Context, rc *RegionContext, obj *edgeproto.F
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewFlavorApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RemoveFlavorRes(ctx, obj)
 }

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -439,6 +439,9 @@ func CloudletUsageMetricsQuery(obj *ormapi.RegionCloudletMetrics, platformTypes 
 // TODO: This function should be a streaming function, but currently client library for influxDB
 // doesn't implement it in a way could really be using it
 func influxStream(ctx context.Context, rc *InfluxDBContext, databases []string, dbQuery string, cb func(Data interface{}) error) error {
+	log.SpanLog(ctx, log.DebugLevelApi, "start influxDB api", "region", rc.region)
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish influxDB api")
+
 	if rc.conn == nil {
 		conn, err := ConnectInfluxDB(ctx, rc.region)
 		if err != nil {

--- a/mc/orm/node.mc2.go
+++ b/mc/orm/node.mc2.go
@@ -65,17 +65,18 @@ func ShowNodeStream(ctx context.Context, rc *RegionContext, obj *edgeproto.Node,
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectNotifyRoot(ctx)
+		conn, err := connCache.GetNotifyRootConn(ctx)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewNodeApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowNode(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/operatorcode.mc2.go
+++ b/mc/orm/operatorcode.mc2.go
@@ -66,17 +66,18 @@ func CreateOperatorCodeObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewOperatorCodeApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateOperatorCode(ctx, obj)
 }
 
@@ -120,17 +121,18 @@ func DeleteOperatorCodeObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewOperatorCodeApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteOperatorCode(ctx, obj)
 }
 
@@ -174,17 +176,18 @@ func ShowOperatorCodeStream(ctx context.Context, rc *RegionContext, obj *edgepro
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewOperatorCodeApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowOperatorCode(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/ratelimit.mc2.go
+++ b/mc/orm/ratelimit.mc2.go
@@ -67,17 +67,18 @@ func ShowRateLimitSettingsStream(ctx context.Context, rc *RegionContext, obj *ed
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowRateLimitSettings(ctx, obj)
 	if err != nil {
 		return err
@@ -153,17 +154,18 @@ func CreateFlowRateLimitSettingsObj(ctx context.Context, rc *RegionContext, obj 
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateFlowRateLimitSettings(ctx, obj)
 }
 
@@ -211,17 +213,18 @@ func UpdateFlowRateLimitSettingsObj(ctx context.Context, rc *RegionContext, obj 
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateFlowRateLimitSettings(ctx, obj)
 }
 
@@ -265,17 +268,18 @@ func DeleteFlowRateLimitSettingsObj(ctx context.Context, rc *RegionContext, obj 
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteFlowRateLimitSettings(ctx, obj)
 }
 
@@ -319,17 +323,18 @@ func ShowFlowRateLimitSettingsStream(ctx context.Context, rc *RegionContext, obj
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowFlowRateLimitSettings(ctx, obj)
 	if err != nil {
 		return err
@@ -405,17 +410,18 @@ func CreateMaxReqsRateLimitSettingsObj(ctx context.Context, rc *RegionContext, o
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateMaxReqsRateLimitSettings(ctx, obj)
 }
 
@@ -463,17 +469,18 @@ func UpdateMaxReqsRateLimitSettingsObj(ctx context.Context, rc *RegionContext, o
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateMaxReqsRateLimitSettings(ctx, obj)
 }
 
@@ -517,17 +524,18 @@ func DeleteMaxReqsRateLimitSettingsObj(ctx context.Context, rc *RegionContext, o
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteMaxReqsRateLimitSettings(ctx, obj)
 }
 
@@ -571,17 +579,18 @@ func ShowMaxReqsRateLimitSettingsStream(ctx context.Context, rc *RegionContext, 
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewRateLimitSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowMaxReqsRateLimitSettings(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/refs.mc2.go
+++ b/mc/orm/refs.mc2.go
@@ -65,17 +65,18 @@ func ShowCloudletRefsStream(ctx context.Context, rc *RegionContext, obj *edgepro
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewCloudletRefsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowCloudletRefs(ctx, obj)
 	if err != nil {
 		return err
@@ -151,17 +152,18 @@ func ShowClusterRefsStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewClusterRefsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowClusterRefs(ctx, obj)
 	if err != nil {
 		return err
@@ -238,17 +240,18 @@ func ShowAppInstRefsStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewAppInstRefsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowAppInstRefs(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/restagtable.mc2.go
+++ b/mc/orm/restagtable.mc2.go
@@ -68,17 +68,18 @@ func CreateResTagTableObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewResTagTableApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateResTagTable(ctx, obj)
 }
 
@@ -123,17 +124,18 @@ func DeleteResTagTableObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewResTagTableApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteResTagTable(ctx, obj)
 }
 
@@ -182,17 +184,18 @@ func UpdateResTagTableObj(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewResTagTableApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateResTagTable(ctx, obj)
 }
 
@@ -237,17 +240,18 @@ func ShowResTagTableStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewResTagTableApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowResTagTable(ctx, obj)
 	if err != nil {
 		return err
@@ -324,17 +328,18 @@ func AddResTagObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ResTagT
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewResTagTableApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AddResTag(ctx, obj)
 }
 
@@ -379,17 +384,18 @@ func RemoveResTagObj(ctx context.Context, rc *RegionContext, obj *edgeproto.ResT
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewResTagTableApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RemoveResTag(ctx, obj)
 }
 
@@ -432,16 +438,17 @@ func GetResTagTableObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Re
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewResTagTableApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.GetResTagTable(ctx, obj)
 }

--- a/mc/orm/server.go
+++ b/mc/orm/server.go
@@ -108,6 +108,7 @@ var artifactorySync *AppStoreSync
 var nodeMgr *node.NodeMgr
 var AlertManagerServer *alertmgr.AlertMgrServer
 var allRegionCaches AllRegionCaches
+var connCache *ConnCache
 
 var unitTestNodeMgrOps []node.NodeOp
 var rateLimitMgr *ratelimit.RateLimitManager
@@ -288,6 +289,9 @@ func RunServer(config *ServerConfig) (retserver *Server, reterr error) {
 			err = nil
 		}
 	}
+
+	connCache = NewConnCache()
+	connCache.Start()
 
 	e := echo.New()
 	e.HideBanner = true
@@ -945,6 +949,9 @@ func (s *Server) Stop() {
 	}
 	if s.echo != nil {
 		s.echo.Close()
+	}
+	if connCache != nil {
+		connCache.Finish()
 	}
 	if s.database != nil {
 		s.database.Close()

--- a/mc/orm/settings.mc2.go
+++ b/mc/orm/settings.mc2.go
@@ -69,17 +69,18 @@ func UpdateSettingsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Se
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateSettings(ctx, obj)
 }
 
@@ -122,17 +123,18 @@ func ResetSettingsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Set
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.ResetSettings(ctx, obj)
 }
 
@@ -172,16 +174,17 @@ func ShowSettingsObj(ctx context.Context, rc *RegionContext, obj *edgeproto.Sett
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewSettingsApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.ShowSettings(ctx, obj)
 }

--- a/mc/orm/stream.mc2.go
+++ b/mc/orm/stream.mc2.go
@@ -64,17 +64,18 @@ func StreamAppInstStream(ctx context.Context, rc *RegionContext, obj *edgeproto.
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewStreamObjApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.StreamAppInst(ctx, obj)
 	if err != nil {
 		return err
@@ -144,17 +145,18 @@ func StreamClusterInstStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewStreamObjApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.StreamClusterInst(ctx, obj)
 	if err != nil {
 		return err
@@ -224,17 +226,18 @@ func StreamCloudletStream(ctx context.Context, rc *RegionContext, obj *edgeproto
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewStreamObjApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.StreamCloudlet(ctx, obj)
 	if err != nil {
 		return err
@@ -304,17 +307,18 @@ func StreamGPUDriverStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewStreamObjApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.StreamGPUDriver(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/trustpolicy.mc2.go
+++ b/mc/orm/trustpolicy.mc2.go
@@ -69,17 +69,18 @@ func CreateTrustPolicyStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewTrustPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.CreateTrustPolicy(ctx, obj)
 	if err != nil {
 		return err
@@ -153,17 +154,18 @@ func DeleteTrustPolicyStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewTrustPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.DeleteTrustPolicy(ctx, obj)
 	if err != nil {
 		return err
@@ -241,17 +243,18 @@ func UpdateTrustPolicyStream(ctx context.Context, rc *RegionContext, obj *edgepr
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewTrustPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.UpdateTrustPolicy(ctx, obj)
 	if err != nil {
 		return err
@@ -328,17 +331,18 @@ func ShowTrustPolicyStream(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewTrustPolicyApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowTrustPolicy(ctx, obj)
 	if err != nil {
 		return err

--- a/mc/orm/vmpool.mc2.go
+++ b/mc/orm/vmpool.mc2.go
@@ -70,17 +70,18 @@ func CreateVMPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.VMPo
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewVMPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.CreateVMPool(ctx, obj)
 }
 
@@ -125,17 +126,18 @@ func DeleteVMPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.VMPo
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewVMPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.DeleteVMPool(ctx, obj)
 }
 
@@ -184,17 +186,18 @@ func UpdateVMPoolObj(ctx context.Context, rc *RegionContext, obj *edgeproto.VMPo
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewVMPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.UpdateVMPool(ctx, obj)
 }
 
@@ -239,17 +242,18 @@ func ShowVMPoolStream(ctx context.Context, rc *RegionContext, obj *edgeproto.VMP
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewVMPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	stream, err := api.ShowVMPool(ctx, obj)
 	if err != nil {
 		return err
@@ -326,17 +330,18 @@ func AddVMPoolMemberObj(ctx context.Context, rc *RegionContext, obj *edgeproto.V
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewVMPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.AddVMPoolMember(ctx, obj)
 }
 
@@ -381,16 +386,17 @@ func RemoveVMPoolMemberObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		}
 	}
 	if rc.conn == nil {
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 		if err != nil {
 			return nil, err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.NewVMPoolApiClient(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.RemoveVMPoolMember(ctx, obj)
 }

--- a/protoc-gen-mc2/genmc2.go
+++ b/protoc-gen-mc2/genmc2.go
@@ -662,20 +662,21 @@ func {{.MethodName}}Obj(ctx context.Context, rc *RegionContext, obj *edgeproto.{
 {{- end}}
 	if rc.conn == nil {
 {{- if .NotifyRoot}}
-		conn, err := connectNotifyRoot(ctx)
+		conn, err := connCache.GetNotifyRootConn(ctx)
 {{- else}}
-		conn, err := connectController(ctx, rc.region)
+		conn, err := connCache.GetRegionConn(ctx, rc.region)
 {{- end}}
 		if err != nil {
 			return {{.ReturnErrArg}}err
 		}
 		rc.conn = conn
 		defer func() {
-			rc.conn.Close()
 			rc.conn = nil
 		}()
 	}
 	api := edgeproto.New{{.Service}}Client(rc.conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 {{- if .Outstream}}
 	stream, err := api.{{.MethodName}}(ctx, obj)
 	if err != nil {

--- a/punisher/punisher.go
+++ b/punisher/punisher.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mobiledgex/edge-cloud-infra/mc/mcctl/mccli"
+	"github.com/mobiledgex/edge-cloud-infra/mc/mcctl/mctestclient"
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormclient"
+)
+
+var numThreads = flag.Int("numthreads", 2, "number of threads")
+var numTries = flag.Int("numtries", 20, "number of tries")
+var addr = flag.String("addr", "https://127.0.0.1:9900", "MC address")
+var skipVerify = flag.Bool("skipverify", false, "skip TLS cert verification")
+var token = flag.String("token", "", "JWT Token, default uses mcctl token")
+var region = flag.String("region", "local", "region Controller to target")
+
+func main() {
+	flag.Parse()
+	if *token == "" {
+		*token = os.Getenv("TOKEN")
+	}
+	if *token == "" {
+		tok, err := ioutil.ReadFile(mccli.GetTokenFile())
+		if err != nil {
+			log.Fatal(err)
+		}
+		*token = strings.TrimSpace(string(tok))
+	}
+	if *token == "" {
+		log.Fatal("please login via mcctl, or specify --token, or set TOKEN env var")
+	}
+	log.Printf("Punishing MC with %d threads of %d tries each...\n", *numThreads, *numTries)
+	wg := sync.WaitGroup{}
+	for tid := 0; tid < *numThreads; tid++ {
+		wg.Add(1)
+		go run(tid, &wg)
+	}
+	wg.Wait()
+}
+
+func run(threadID int, wg *sync.WaitGroup) {
+	restClient := ormclient.Client{}
+	restClient.SkipVerify = *skipVerify
+	client := mctestclient.NewClient(&restClient)
+
+	start := time.Now()
+	filter := &ormapi.RegionFlavor{}
+	filter.Region = *region
+	ii := 0
+	for ii = 0; ii < *numTries; ii++ {
+		_, status, err := client.ShowFlavor(*addr+"/api/v1", *token, filter)
+		if err != nil || status != http.StatusOK {
+			log.Printf("thread %d try %d failed: status %d, %s\n", threadID, ii, status, err)
+			if strings.Contains(err.Error(), "Invalid or expired jwt") {
+				sv := ""
+				if *skipVerify {
+					sv = " --skipverify"
+				}
+				log.Printf("please use: mcctl --addr=%s%s login username=<x>", *addr, sv)
+			}
+			break
+		}
+
+	}
+	log.Printf("thread %d finished %d tries after %s\n", threadID, ii, time.Since(start).String())
+	wg.Done()
+}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5265 [Web UI] Unexpected Error related to Authentication Handshake Failed 

### Description

This is a potential fix for the connection timeout errors, plus some extra stuff for debug.

I have not been able to root-cause the source of the connection timeout errors. It could be anything from too many dropped packets, to controller being overloaded (does not appear to be so), to the k8s load balancer being overloaded, to the MC VM being overloaded (here overloaded could be either cpu or network i/o). Please see the bug for more debug information.

What I did notice from debugging this issue is that MC spends a significant amount of time apparently doing nothing, compared to the amount of time the Controller is actually doing work for the RPC. This can be seen in the Jaeger traces. This is not from postgres calls (we have logs that say how long those took), so it's likely either from connection setup or latency in the network path from MC -> Controller. To help debug this, I've added some debug logs when MC starts/finishes the controller API call. Combined with the logs that the Controller produces when it starts/finishes the RPC, we should be able to see how much time is spent in the connection/transit overhead.

And, to reduce the amount of overhead, I've added caching of grpc connections to the Controllers. Grpc connections are by default connection pools of channels over http/2, so there is no issue with sharing a single "ClientConn" with multiple callers in parallel. These are semi-persistent connections, they will persist as long as they are in use, or a cleanup thread will close them after a while if they haven't been used. Introducing connection caching reduces the amount of time to run MC->Controller API calls by more than half, for something like ShowFlavor. Also, the 20s timeout seen in the bug is an establishing connection timeout, so having a cache gets rid of the possibility of hitting that timeout - however, it may introduce higher delays in the presence of packet loss since after the connection is established, the timeouts are longer.

Finally, to help test this, I've added a small "punisher" program that will generate a bunch of threads and slam MC with ShowFlavor calls, looking for any failures. We can expand upon this in the future but for now I just wanted something quick and dirty to test with.

Local stats (make test-start) without connection caching:
```
> punisher --skipverify -numthreads 10 -numtries 200
2021/07/29 19:05:54 Punishing MC with 10 threads of 200 tries each...
2021/07/29 19:06:07 thread 6 finished 200 tries after 13.583297808s
2021/07/29 19:06:08 thread 7 finished 200 tries after 13.705873134s
2021/07/29 19:06:08 thread 0 finished 200 tries after 13.825229087s
2021/07/29 19:06:08 thread 3 finished 200 tries after 13.844577811s
2021/07/29 19:06:08 thread 4 finished 200 tries after 13.867702709s
2021/07/29 19:06:08 thread 9 finished 200 tries after 13.908463605s
2021/07/29 19:06:08 thread 5 finished 200 tries after 14.041290972s
2021/07/29 19:06:08 thread 8 finished 200 tries after 14.06768634s
2021/07/29 19:06:08 thread 1 finished 200 tries after 14.078758221s
2021/07/29 19:06:08 thread 2 finished 200 tries after 14.14512304s 
```
Local stats with connection caching:
```
> punisher --skipverify -numthreads 10 -numtries 200
2021/07/29 21:54:22 Punishing MC with 10 threads of 200 tries each...
2021/07/29 21:54:28 thread 8 finished 200 tries after 6.301867677s
2021/07/29 21:54:28 thread 7 finished 200 tries after 6.332144845s
2021/07/29 21:54:29 thread 3 finished 200 tries after 6.534518368s
2021/07/29 21:54:29 thread 4 finished 200 tries after 6.561385102s
2021/07/29 21:54:29 thread 9 finished 200 tries after 6.57917008s
2021/07/29 21:54:29 thread 0 finished 200 tries after 6.591192587s
2021/07/29 21:54:29 thread 2 finished 200 tries after 6.603318489s
2021/07/29 21:54:29 thread 5 finished 200 tries after 6.615477791s
2021/07/29 21:54:29 thread 1 finished 200 tries after 6.643863583s
2021/07/29 21:54:29 thread 6 finished 200 tries after 6.683383605s
```
QA MC stats without connection caching (note how much longer the times are)
```
> punisher --addr https://console-qa.mobiledgex.net --skipverify -region EU -numthreads 10 -numtries 200
2021/07/29 19:08:42 Punishing MC with 10 threads of 200 tries each...
2021/07/29 19:09:42 thread 0 try 61 failed: status 0, post https://console-qa.mobiledgex.net/api/v1/auth/ctrl/ShowFlavor client do failed, Post "https://console-qa.mobiledgex.net/api/v1/auth/ctrl/ShowFlavor": read tcp 192.168.1.141:57491-34.94.108.90:443: read: operation timed out
2021/07/29 19:09:42 thread 0 finished 61 tries after 1m0.375549845s
2021/07/29 19:10:49 thread 6 finished 200 tries after 2m6.950402339s
2021/07/29 19:10:49 thread 1 finished 200 tries after 2m6.973405267s
2021/07/29 19:10:49 thread 8 finished 200 tries after 2m7.000140165s
2021/07/29 19:10:49 thread 5 finished 200 tries after 2m7.025435553s
2021/07/29 19:10:49 thread 7 finished 200 tries after 2m7.069359104s
2021/07/29 19:10:49 thread 3 finished 200 tries after 2m7.075628968s
2021/07/29 19:10:50 thread 4 finished 200 tries after 2m7.681434078s
2021/07/29 19:27:28 thread 9 try 125 failed: status 400, Transport is closing
2021/07/29 19:27:28 thread 9 finished 125 tries after 18m45.732345191s
2021/07/29 19:27:37 thread 2 try 138 failed: status 200, Transport is closing
2021/07/29 19:27:37 thread 2 finished 138 tries after 18m55.436607969s 
```