### PR TITLE
EDGECLOUD-5066 show filter by empty value failed because value null

### DIFF
--- a/mc/orm/postgres.go
+++ b/mc/orm/postgres.go
@@ -126,6 +126,15 @@ func InitData(ctx context.Context, superuser, superpass string, pingInterval tim
 			continue
 		}
 		log.SpanLog(ctx, log.DebugLevelApi, "init data done")
+
+		if err := fixPostgresNullValues(ctx); err != nil {
+			if unitTest {
+				initDone <- err
+				return
+			}
+			// not a fatal error, so just log it
+			log.SpanLog(ctx, log.DebugLevelApi, "fix postgres null values failed", "err", err)
+		}
 		break
 	}
 	go func() {
@@ -269,4 +278,134 @@ func sqlListenerWorkFunc(ctx context.Context, k interface{}) {
 			log.SpanLog(ctx, log.DebugLevelApi, "failed to refresh controller clients", "err", err)
 		}
 	}
+}
+
+// fixPostgresNullValues fixes columns that are added to existing tables,
+// which end up getting NULL values instead of empty values (0, "", false).
+// This causes show filtering on those values to fail, because the filter
+// query is looking for 0, but the value is NULL.
+func fixPostgresNullValues(ctx context.Context) error {
+	log.SpanLog(ctx, log.DebugLevelInfo, "fix postgres null values")
+	db := loggedDB(ctx)
+	// refresh null_frac stats
+	err := db.Exec("ANALYZE").Error
+	if err != nil {
+		return err
+	}
+	// here, null_frac is the fractional amount of the column's
+	// rows that have null values
+	cmd := "SELECT tablename, attname, null_frac FROM pg_stats WHERE schemaname='public' AND null_frac > 0"
+	res := db.Raw(cmd)
+	if res.Error != nil {
+		return res.Error
+	}
+	rows, err := res.Rows()
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var colTypes map[postgresTableCol]string
+
+	for rows.Next() {
+		var tableName, colName string
+		var nullFrac float64
+		err = rows.Scan(&tableName, &colName, &nullFrac)
+		if err != nil {
+			return err
+		}
+		log.SpanLog(ctx, log.DebugLevelInfo, "fixing column null values", "table", tableName, "column", colName, "nullFrac", nullFrac)
+		if tableName == "" || colName == "" {
+			continue
+		}
+		if colTypes == nil {
+			colTypes, err = getPostgresColumnTypes(ctx)
+			if err != nil {
+				return err
+			}
+		}
+		tableCol := postgresTableCol{
+			table: tableName,
+			col:   colName,
+		}
+		dataType, ok := colTypes[tableCol]
+		if !ok {
+			return fmt.Errorf("column type for %s %s not found", tableName, colName)
+		}
+		emptyVal, err := getPostgresEmptyVal(dataType)
+		if err != nil {
+			return fmt.Errorf("get empty val for %s %s failed, %s", tableName, colName, err)
+		}
+		cmd := fmt.Sprintf("UPDATE %s SET %s = %s WHERE %s IS NULL", tableName, colName, emptyVal, colName)
+		err = db.Exec(cmd).Error
+		if err != nil {
+			return fmt.Errorf("run cmd %q failed, %s", cmd, err)
+		}
+	}
+	return nil
+}
+
+type postgresTableCol struct {
+	table string
+	col   string
+}
+
+func getPostgresColumnTypes(ctx context.Context) (map[postgresTableCol]string, error) {
+	db := loggedDB(ctx)
+	cmd := "SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema='public'"
+	res := db.Raw(cmd)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	rows, err := res.Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	colTypes := map[postgresTableCol]string{}
+
+	for rows.Next() {
+		var tableName, colName, dataType string
+		err = rows.Scan(&tableName, &colName, &dataType)
+		if err != nil {
+			return nil, err
+		}
+		if tableName == "" || colName == "" || dataType == "" {
+			continue
+		}
+		tableCol := postgresTableCol{
+			table: tableName,
+			col:   colName,
+		}
+		colTypes[tableCol] = dataType
+
+	}
+	return colTypes, nil
+}
+
+var postgresNumericTypes = []string{"bigint", "int8", "bigserial", "serial8",
+	"double precision", "float8", "integer", "int", "int4",
+	"numeric", "decimal", "real", "float4", "smallint", "int2",
+	"smallserial", "serial2", "serial", "serial4", "money"}
+var postgresStringTypes = []string{"bit", "bit varying", "varbit", "char",
+	"varchar", "json", "text", "citext"}
+
+func getPostgresEmptyVal(dataType string) (string, error) {
+	if strings.HasPrefix(dataType, "boolean") {
+		return `'false'`, nil
+	}
+	if strings.HasPrefix(dataType, "timestamp") {
+		return "'epoch'", nil
+	}
+	for _, t := range postgresNumericTypes {
+		if strings.HasPrefix(dataType, t) {
+			return `0`, nil
+		}
+	}
+	for _, t := range postgresStringTypes {
+		if strings.HasPrefix(dataType, t) {
+			return `''`, nil
+		}
+	}
+	return "", fmt.Errorf("unrecognized type %s", dataType)
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5066: org show filter by deleteinprogress and edgeboxonly does not work correctly

### Description

Show filtering for some fields was failing because some records were present before those fields were added (like deleteinprogress and edgeboxonly). The way the gorm library addes new columns to existing tables causes the fields for existing records to be set to NULL. In some cases this is desirable, because this allows a way for us to detect which records were not configured to a proper default value and take some action. Those actions (like the ones done for orgcloudletpool) can be run during that object's init. After that, the changes below will look for any NULL values and replace them with an appropriate empty value, so that they can be used for show filtering.