### PR TITLE
EDGECLOUD-5421: Remove latency stats from ClientApiUsage 

### DIFF
--- a/e2e-tests/data/mc_clientapimetrics_show.yml
+++ b/e2e-tests/data/mc_clientapimetrics_show.yml
@@ -2,12 +2,6 @@
   columns:
   - reqs
   - errs
-  - 0s
-  - 5ms
-  - 10ms
-  - 25ms
-  - 50ms
-  - 100ms
   tags:
     app: someapplication1
     apporg: AcmeAppCo
@@ -17,22 +11,10 @@
   values:
   - - 1
   - - 0
-  - - 1
-  - - 0
-  - - 0
-  - - 0
-  - - 0
-  - - 0
 - name: dme-api
   columns:
   - reqs
   - errs
-  - 0s
-  - 5ms
-  - 10ms
-  - 25ms
-  - 50ms
-  - 100ms
   tags:
     app: someapplication1
     apporg: AcmeAppCo
@@ -41,10 +23,4 @@
     method: RegisterClient
   values:
   - - 1
-  - - 0
-  - - 1
-  - - 0
-  - - 0
-  - - 0
-  - - 0
   - - 0

--- a/mc/orm/influx_clientmetrics.go
+++ b/mc/orm/influx_clientmetrics.go
@@ -63,23 +63,11 @@ var ClientApiUsageTags = []string{
 var ApiFields = []string{
 	"\"reqs\"",
 	"\"errs\"",
-	"\"0s\"",
-	"\"5ms\"",
-	"\"10ms\"",
-	"\"25ms\"",
-	"\"50ms\"",
-	"\"100ms\"",
 }
 
 var ClientApiAggregationFunctions = map[string]string{
-	"reqs":  "sum(\"reqs\")",
-	"errs":  "sum(\"errs\")",
-	"0s":    "sum(\"0s\")",
-	"5ms":   "sum(\"5ms\")",
-	"10ms":  "sum(\"10ms\")",
-	"25ms":  "sum(\"25ms\")",
-	"50ms":  "sum(\"50ms\")",
-	"100ms": "sum(\"100ms\")",
+	"reqs": "sum(\"reqs\")",
+	"errs": "sum(\"errs\")",
 }
 
 var ClientAppUsageTags = []string{


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5421: Remove latency stats from ClientApiUsage 

### Description

No need for latency values of how long DME took to process api requests. UI will have less data to process without these latency counts