### PR TITLE
EDGECLOUD-5268 need to sanitize the metrics args before building and sending influxdb query

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -711,7 +711,7 @@ func GetMetricsCommon(c echo.Context) error {
 		}
 		// validate all the passed in arguments
 		if err = util.ValidateNames(in.AppInst.GetTags()); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		// New metrics api request
@@ -738,7 +738,7 @@ func GetMetricsCommon(c echo.Context) error {
 		}
 		// validate all the passed in arguments
 		if err = util.ValidateNames(in.ClusterInst.GetTags()); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		rc.region = in.Region
@@ -764,7 +764,7 @@ func GetMetricsCommon(c echo.Context) error {
 		}
 		// validate all the passed in arguments
 		if err = util.ValidateNames(in.Cloudlet.GetTags()); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		rc.region = in.Region
@@ -788,7 +788,7 @@ func GetMetricsCommon(c echo.Context) error {
 		// validate all the passed in arguments
 		args := getClientApiUsageMetricsArgs(&in)
 		if err = util.ValidateNames(args); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		rc.region = in.Region
@@ -822,7 +822,7 @@ func GetMetricsCommon(c echo.Context) error {
 		}
 		// validate all the passed in arguments
 		if err = util.ValidateNames(in.Cloudlet.GetTags()); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		if err = validateSelectorString(in.Selector, CLOUDLETUSAGE); err != nil {
@@ -853,7 +853,7 @@ func GetMetricsCommon(c echo.Context) error {
 		// validate all the passed in arguments
 		args := getClientAppUsageMetricsArgs(&in)
 		if err = util.ValidateNames(args); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		rc.region = in.Region
@@ -888,7 +888,7 @@ func GetMetricsCommon(c echo.Context) error {
 		// validate all the passed in arguments
 		args := getClientCloudletUsageMetricsArgs(&in)
 		if err = util.ValidateNames(args); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		rc.region = in.Region

--- a/mc/orm/influx_events.go
+++ b/mc/orm/influx_events.go
@@ -132,7 +132,7 @@ func GetEventsCommon(c echo.Context) error {
 		}
 		// validate all the passed in arguments
 		if err = util.ValidateNames(in.AppInst.GetTags()); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		rc.region = in.Region
@@ -150,7 +150,7 @@ func GetEventsCommon(c echo.Context) error {
 		}
 		// validate all the passed in arguments
 		if err = util.ValidateNames(in.ClusterInst.GetTags()); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		rc.region = in.Region
@@ -176,7 +176,7 @@ func GetEventsCommon(c echo.Context) error {
 		}
 		// validate all the passed in arguments
 		if err = util.ValidateNames(in.Cloudlet.GetTags()); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		rc.region = in.Region

--- a/mc/orm/influx_events_test.go
+++ b/mc/orm/influx_events_test.go
@@ -112,14 +112,14 @@ func goodPermTestEvents(t *testing.T, mcClient *mctestclient.Client, uri, devTok
 	}
 	list, status, err = testPermShowAppInstEvents(mcClient, uri, devToken, region, devOrg, &appInst)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Invalid app passed in")
+	require.Contains(t, err.Error(), "Invalid app")
 	require.Equal(t, http.StatusBadRequest, status)
 	cloudlet := edgeproto.CloudletKey{
 		Name: "select * from api",
 	}
 	list, status, err = testPermShowCloudletEvents(mcClient, uri, operToken, region, operOrg, &cloudlet)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Invalid cloudlet passed in")
+	require.Contains(t, err.Error(), "Invalid cloudlet")
 	require.Equal(t, http.StatusBadRequest, status)
 	cluster := edgeproto.ClusterInstKey{
 		ClusterKey: edgeproto.ClusterKey{
@@ -128,7 +128,7 @@ func goodPermTestEvents(t *testing.T, mcClient *mctestclient.Client, uri, devTok
 	}
 	list, status, err = testPermShowClusterEvents(mcClient, uri, operToken, region, operOrg, &cluster)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Invalid cluster passed in")
+	require.Contains(t, err.Error(), "Invalid cluster")
 	require.Equal(t, http.StatusBadRequest, status)
 
 }

--- a/mc/orm/influx_test.go
+++ b/mc/orm/influx_test.go
@@ -229,14 +229,14 @@ func goodPermTestMetrics(t *testing.T, mcClient *mctestclient.Client, uri, devTo
 	}
 	list, status, err = testPermShowClientMetrics(mcClient, uri, devToken, region, devOrg, "cpu", &appInst)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Invalid app passed in")
+	require.Contains(t, err.Error(), "Invalid app")
 	require.Equal(t, http.StatusBadRequest, status)
 	cloudlet := edgeproto.CloudletKey{
 		Name: "select * from api",
 	}
 	list, status, err = testPermShowCloudletMetrics(mcClient, uri, operToken, region, operOrg, "utilization", &cloudlet)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Invalid cloudlet passed in")
+	require.Contains(t, err.Error(), "Invalid cloudlet")
 	require.Equal(t, http.StatusBadRequest, status)
 	cluster := edgeproto.ClusterInstKey{
 		ClusterKey: edgeproto.ClusterKey{
@@ -245,7 +245,7 @@ func goodPermTestMetrics(t *testing.T, mcClient *mctestclient.Client, uri, devTo
 	}
 	list, status, err = testPermShowClusterMetrics(mcClient, uri, operToken, region, operOrg, "utilization", &cluster)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Invalid cluster passed in")
+	require.Contains(t, err.Error(), "Invalid cluster")
 	require.Equal(t, http.StatusBadRequest, status)
 }
 

--- a/mc/orm/metrics.go
+++ b/mc/orm/metrics.go
@@ -66,7 +66,7 @@ func GetAppMetrics(c echo.Context, in *ormapi.RegionAppInstMetrics) error {
 		}
 		// validate input
 		if err = util.ValidateNames(app.GetTags()); err != nil {
-			return fmt.Errorf("%s passed in", err.Error())
+			return err
 		}
 
 		orgsToCheck = append(orgsToCheck, org)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5268 need to sanitize the metrics args before building and sending influxdb query

### Description

Change function signature, which I missed.