### PR TITLE
EDGECLOUD-5427 allow operator to see apps for cloudlet pools

### DIFF
--- a/mc/orm/alertpolicy_mc2_test.go
+++ b/mc/orm/alertpolicy_mc2_test.go
@@ -158,8 +158,12 @@ func goodPermTestShowAlertPolicy(t *testing.T, mcClient *mctestclient.Client, ur
 	// make sure region check works
 	list, status, err = testutil.TestPermShowAlertPolicy(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/app_mc2_test.go
+++ b/mc/orm/app_mc2_test.go
@@ -264,8 +264,12 @@ func goodPermTestShowApp(t *testing.T, mcClient *mctestclient.Client, uri, token
 	// make sure region check works
 	list, status, err = testutil.TestPermShowApp(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/appinst_mc2_test.go
+++ b/mc/orm/appinst_mc2_test.go
@@ -180,8 +180,12 @@ func goodPermTestShowAppInst(t *testing.T, mcClient *mctestclient.Client, uri, t
 	// make sure region check works
 	list, status, err = testutil.TestPermShowAppInst(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/autoprovpolicy_mc2_test.go
+++ b/mc/orm/autoprovpolicy_mc2_test.go
@@ -202,8 +202,12 @@ func goodPermTestShowAutoProvPolicy(t *testing.T, mcClient *mctestclient.Client,
 	// make sure region check works
 	list, status, err = testutil.TestPermShowAutoProvPolicy(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/autoscalepolicy_mc2_test.go
+++ b/mc/orm/autoscalepolicy_mc2_test.go
@@ -158,8 +158,12 @@ func goodPermTestShowAutoScalePolicy(t *testing.T, mcClient *mctestclient.Client
 	// make sure region check works
 	list, status, err = testutil.TestPermShowAutoScalePolicy(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/cloudlet_mc2_test.go
+++ b/mc/orm/cloudlet_mc2_test.go
@@ -222,8 +222,12 @@ func goodPermTestShowGPUDriver(t *testing.T, mcClient *mctestclient.Client, uri,
 	// make sure region check works
 	list, status, err = testutil.TestPermShowGPUDriver(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 
@@ -583,8 +587,12 @@ func goodPermTestShowCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, 
 	// make sure region check works
 	list, status, err = testutil.TestPermShowCloudlet(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/cloudletpool_mc2_test.go
+++ b/mc/orm/cloudletpool_mc2_test.go
@@ -195,8 +195,12 @@ func goodPermTestShowCloudletPool(t *testing.T, mcClient *mctestclient.Client, u
 	// make sure region check works
 	list, status, err = testutil.TestPermShowCloudletPool(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/clusterinst_mc2_test.go
+++ b/mc/orm/clusterinst_mc2_test.go
@@ -180,8 +180,12 @@ func goodPermTestShowClusterInst(t *testing.T, mcClient *mctestclient.Client, ur
 	// make sure region check works
 	list, status, err = testutil.TestPermShowClusterInst(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/flavor_mc2_test.go
+++ b/mc/orm/flavor_mc2_test.go
@@ -200,8 +200,12 @@ func goodPermTestShowFlavor(t *testing.T, mcClient *mctestclient.Client, uri, to
 	// make sure region check works
 	list, status, err = testutil.TestPermShowFlavor(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/operatorcode_mc2_test.go
+++ b/mc/orm/operatorcode_mc2_test.go
@@ -131,8 +131,12 @@ func goodPermTestShowOperatorCode(t *testing.T, mcClient *mctestclient.Client, u
 	// make sure region check works
 	list, status, err = testutil.TestPermShowOperatorCode(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/restagtable_mc2_test.go
+++ b/mc/orm/restagtable_mc2_test.go
@@ -215,8 +215,12 @@ func goodPermTestShowResTagTable(t *testing.T, mcClient *mctestclient.Client, ur
 	// make sure region check works
 	list, status, err = testutil.TestPermShowResTagTable(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/trustpolicy_mc2_test.go
+++ b/mc/orm/trustpolicy_mc2_test.go
@@ -158,8 +158,12 @@ func goodPermTestShowTrustPolicy(t *testing.T, mcClient *mctestclient.Client, ur
 	// make sure region check works
 	list, status, err = testutil.TestPermShowTrustPolicy(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/mc/orm/vmpool_mc2_test.go
+++ b/mc/orm/vmpool_mc2_test.go
@@ -202,8 +202,12 @@ func goodPermTestShowVMPool(t *testing.T, mcClient *mctestclient.Client, uri, to
 	// make sure region check works
 	list, status, err = testutil.TestPermShowVMPool(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 

--- a/protoc-gen-mc2/genmc2.go
+++ b/protoc-gen-mc2/genmc2.go
@@ -997,8 +997,12 @@ func goodPermTestShow{{.Message}}(t *testing.T, mcClient *mctestclient.Client, u
 	// make sure region check works
 	list, status, err = testutil.TestPermShow{{.Message}}(mcClient, uri, token, "bad region", org)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "\"bad region\" not found")
-	require.Equal(t, http.StatusBadRequest, status)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
 	require.Equal(t, 0, len(list))
 }
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5427 need ability to get deployment type from appinst

### Description

This allows Operators to see App definitions for developer orgs that have accepted private cloudlet pool invitations.