### PR TITLE
EDGECLOUD-5191:fix units add misisng  m for settings e2e tests

### DIFF
--- a/e2e-tests/data/autoprov_settings_restored_exp.yml
+++ b/e2e-tests/data/autoprov_settings_restored_exp.yml
@@ -40,5 +40,5 @@ regiondata:
       alertpolicymintriggertime: 1s
       disableratelimit: true
       maxnumperipratelimiters: 10000
-      resourcesnapshotthreadinterval: 10
+      resourcesnapshotthreadinterval: 10m
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5191 periodic task infra resources.

### Description
add missing units 'm' to settings
