### PR TITLE
developer namespaces

### DIFF
--- a/crm-platforms/edgebox/edgebox-appinst.go
+++ b/crm-platforms/edgebox/edgebox-appinst.go
@@ -67,6 +67,10 @@ func (e *EdgeboxPlatform) CreateAppInst(ctx context.Context, clusterInst *edgepr
 			if err != nil {
 				return err
 			}
+			err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
+			if err != nil {
+				return err
+			}
 			err = infracommon.CreateDockerRegistrySecret(ctx, client, k8smgmt.GetKconfName(clusterInst), imagePath, e.commonPf.PlatformConfig.AccessApi, names, existingCreds)
 			if err != nil {
 				return err
@@ -147,6 +151,10 @@ func (e *EdgeboxPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgepr
 			}
 			// secret may have changed, so delete and re-create
 			err = infracommon.DeleteDockerRegistrySecret(ctx, client, kconf, imagePath, e.commonPf.PlatformConfig.AccessApi, names, existingCreds)
+			if err != nil {
+				return err
+			}
+			err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
 			if err != nil {
 				return err
 			}

--- a/crm-platforms/k8s-baremetal/k8sbm-appinst.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-appinst.go
@@ -40,6 +40,10 @@ func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *e
 		updateCallback(edgeproto.UpdateTask, "Setting up registry secret")
 		kconf := k8smgmt.GetKconfName(clusterInst)
 		for _, imagePath := range names.ImagePaths {
+			err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
+			if err != nil {
+				return err
+			}
 			err = infracommon.CreateDockerRegistrySecret(ctx, client, kconf, imagePath, k.commonPf.PlatformConfig.AccessApi, names, nil)
 			if err != nil {
 				return err

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -200,6 +200,10 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		if err != nil {
 			return err
 		}
+		err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
+		if err != nil {
+			return err
+		}
 		updateCallback(edgeproto.UpdateTask, "Setting up registry secret")
 		kconf := k8smgmt.GetKconfName(clusterInst)
 		for _, imagePath := range names.ImagePaths {
@@ -703,6 +707,10 @@ func (v *VMPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		for _, imagePath := range names.ImagePaths {
 			// secret may have changed, so delete and re-create
 			err = infracommon.DeleteDockerRegistrySecret(ctx, client, kconf, imagePath, v.VMProperties.CommonPf.PlatformConfig.AccessApi, names, nil)
+			if err != nil {
+				return err
+			}
+			err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5432 K8s deployment failure with custom namespaces
### Description

Apps which provide their own k8s manifest and include their own namespaces will fail for the following reasons:
- Secrets are not created in these namespaces
- We don't look at these namespaces when checking pod status

To resolve this we have to pre-create the namespaces before creating the secrets, which are now created in all of these namespaces.   Note when the actual manifest is loaded, this is overwritten, and when the manifest is deleted, the namespace deletion happens 

See also edge cloud portion