### PR TITLE
EDGECLOUD-5273 EDGECLOUD-5248 EDGECLOUD-5435 Metrics api fixes

### DIFF
--- a/mc/mcctl/ormctl/metrics.go
+++ b/mc/mcctl/ormctl/metrics.go
@@ -189,6 +189,8 @@ var ClientApiUsageMetricOptionalArgs = []string{
 	"app-org",
 	"cloudlet",
 	"cloudlet-org",
+	"dme-cloudlet",
+	"dme-org",
 	"method",
 	"cellid",
 	"limit",
@@ -205,12 +207,16 @@ var ClientApiUsageMetricAliasArgs = []string{
 	"appvers=appinst.appkey.version",
 	"cloudlet-org=appinst.clusterinstkey.cloudletkey.organization",
 	"cloudlet=appinst.clusterinstkey.cloudletkey.name",
+	"dme-cloudlet=dmecloudlet",
+	"dme-org=dmecloudletorg",
 }
 
 var ClientApiUsageMetricComments = map[string]string{
-	"method":   "Api call method, one of: FindCloudlet, PlatformFindCloudlet, RegisterClient, VerifyLocation",
-	"cellid":   "Cell tower Id(experimental)",
-	"selector": "Comma separated list of metrics to view. Currently only \"api\" is supported.",
+	"method":       "Api call method, one of: FindCloudlet, PlatformFindCloudlet, RegisterClient, VerifyLocation",
+	"cellid":       "Cell tower Id(experimental)",
+	"selector":     "Comma separated list of metrics to view. Currently only \"api\" is supported.",
+	"dme-cloudlet": "Cloudlet name where DME is running",
+	"dme-org":      "Operator org where DME is running",
 }
 
 var ClientAppUsageMetricRequiredArgs = []string{

--- a/mc/orm/cloudletpool_usage.go
+++ b/mc/orm/cloudletpool_usage.go
@@ -21,6 +21,17 @@ func generateCloudletList(cloudletList []string) string {
 	return new
 }
 
+// For Dme metrics cloudlets are stored in foundCloudlet field
+func generateDmeApiUsageCloudletList(cloudletList []string) string {
+	if len(cloudletList) == 0 {
+		return ""
+	}
+	// format needs to be: foundCloudlet='cloudlet1' OR foundCloudlet='cloudlet2' ... OR foundCloudlet='cloudlet3'
+	new := strings.Join(cloudletList, "' OR foundCloudlet='")
+	new = "foundCloudlet='" + new + "'"
+	return new
+}
+
 func cloudletPoolEventsQuery(obj *ormapi.RegionCloudletPoolUsage, cloudletList []string, queryType string) string {
 	arg := influxQueryArgs{
 		OrgField:     "cloudletorg",

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -192,6 +192,7 @@ var devInfluxDBT = `SELECT {{.Selector}} from {{.Measurement}}` +
 	`{{if .AppInstName}} AND "app"='{{.AppInstName}}'{{end}}` +
 	`{{if .AppOrg}} AND "apporg"='{{.AppOrg}}'{{end}}` +
 	`{{if .ClusterName}} AND "cluster"='{{.ClusterName}}'{{end}}` +
+	`{{if .ClusterOrg}} AND "clusterorg"='{{.ClusterOrg}}'{{end}}` +
 	`{{if .AppVersion}} AND "ver"='{{.AppVersion}}'{{end}}` +
 	`{{if .CloudletName}} AND "cloudlet"='{{.CloudletName}}'{{end}}` +
 	`{{if .CloudletOrg}} AND "cloudletorg"='{{.CloudletOrg}}'{{end}}` +
@@ -389,6 +390,7 @@ func AppInstMetricsQuery(obj *ormapi.RegionAppInstMetrics, cloudletList []string
 		AppInstName:  util.DNSSanitize(obj.AppInst.AppKey.Name),
 		AppVersion:   util.DNSSanitize(obj.AppInst.AppKey.Version),
 		ClusterName:  obj.AppInst.ClusterInstKey.ClusterKey.Name,
+		ClusterOrg:   obj.AppInst.ClusterInstKey.Organization,
 		CloudletList: generateCloudletList(cloudletList),
 		Last:         obj.Last,
 	}
@@ -676,6 +678,8 @@ func getCloudletPlatformTypes(ctx context.Context, username, region string, key 
 func getClientApiUsageMetricsArgs(in *ormapi.RegionClientApiUsageMetrics) map[string]string {
 	args := in.AppInst.GetTags()
 	args["method"] = in.Method
+	args["dme cloudlet"] = in.DmeCloudlet
+	args["dme cloudlet org"] = in.DmeCloudletOrg
 	return args
 }
 
@@ -811,6 +815,9 @@ func GetMetricsCommon(c echo.Context) error {
 			return err
 		}
 		if err = validateSelectorString(in.Selector, CLIENT_APIUSAGE); err != nil {
+			return err
+		}
+		if err = validateMethodString(&in); err != nil {
 			return err
 		}
 		if err = validateMetricsCommon(&in.MetricsCommon); err != nil {

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -505,12 +505,14 @@ type RegionCloudletMetrics struct {
 }
 
 type RegionClientApiUsageMetrics struct {
-	Region        string
-	AppInst       edgeproto.AppInstKey
-	Method        string `json:",omitempty"`
-	CellId        int    `json:",omitempty"`
-	Selector      string
-	MetricsCommon `json:",inline"`
+	Region         string
+	AppInst        edgeproto.AppInstKey
+	Method         string `json:",omitempty"`
+	CellId         int    `json:",omitempty"`
+	DmeCloudlet    string `json:",omitempty"`
+	DmeCloudletOrg string `json:",omitempty"`
+	Selector       string
+	MetricsCommon  `json:",inline"`
 }
 
 type RegionClientAppUsageMetrics struct {


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5273 unable to query dme metrics query with real cloudlet/cloudletorg
* EDGECLOUD-5248 VM app instance disk stats are not reported correctly for OpenStack
* EDGECLOUD-5435 metrics filtered by cluster-org doesnt work

### Description
EDGECLOUD-5273 unable to query dme metrics query with real cloudlet/cloudletorg
   - Added dme-cloudlet and dme-org options to command to correspond to dme-key cloudlet and org
   - Cloudlet/cloudlet-org specified are now used as `foundCloudlet` and `foundOperator`, and are only available for `FindCloudlet` and `PlatformFindCloudlet` methods
   - Added unit-tests for validation of the method
EDGECLOUD-5248 VM app instance disk stats are not reported correctly for OpenStack
   - removed disk from the collected metrics for openstack VM instances
EDGECLOUD-5435 metrics filtered by cluster-org doesn't work
   - added cluster-org to the influxDB query request for app metrics.
