### PR TITLE
Disable VCD template import property

### DIFF
--- a/crm-platforms/vcd/vcd-prop.go
+++ b/crm-platforms/vcd/vcd-prop.go
@@ -30,7 +30,7 @@ var VcdProps = map[string]*edgeproto.PropertyInfo{
 		Description: "currently unused",
 	},
 	"MEX_ENABLE_VCD_DISK_RESIZE": {
-		Description: "VM disks cloned from the VDC template will be resized based on flavor if set to \"true\".  Must be set to \"false\" if fast provisioning is enabled in the VDC or VM creation will fail.",
+		Description: "VM disks cloned from the VDC template will be resized based on flavor if set to \"true\" or \"yes\".  Set to \"false\" if fast provisioning is enabled in the VDC or VM creation will fail.",
 		Value:       "true",
 	},
 	"VCDVerbose": {
@@ -62,9 +62,13 @@ var VcdProps = map[string]*edgeproto.PropertyInfo{
 		Value:       "3600",
 	},
 	"VCD_VM_APP_INTERNAL_DHCP_SERVER": {
-		Description: "If true sets up an internal DHCP server for VM Apps, otherwise uses VCD server",
+		Description: "If \"true\" or \"yes\" sets up an internal DHCP server for VM Apps, otherwise uses VCD server",
 		Value:       "false",
 		Internal:    true,
+	},
+	"VCD_TEMPLATE_ARTIFACTORY_IMPORT_ENABLED": {
+		Description: "If \"true\" or \"yes\" VCD tempates are stored in Artifactory and imported to VCD.  Otherwise, templates must already exist in the catalog",
+		Value:       "true",
 	},
 }
 
@@ -178,7 +182,7 @@ func (v *VcdPlatform) GetCatalogName() string {
 
 func (v *VcdPlatform) GetEnableVcdDiskResize() bool {
 	val, _ := v.vmProperties.CommonPf.Properties.GetValue("MEX_ENABLE_VCD_DISK_RESIZE")
-	return strings.ToLower(val) == "true"
+	return strings.ToLower(val) == "true" || strings.ToLower(val) == "yes"
 }
 
 // the normal methods of querying this seem sometimes unreliable e.g. vdc.IsNsxv()
@@ -193,7 +197,7 @@ func (v *VcdPlatform) GetNsxType() string {
 // the normal methods of querying this seem sometimes unreliable e.g. vdc.IsNsxv()
 func (v *VcdPlatform) GetCleanupOrphanedNetworks() bool {
 	val, _ := v.vmProperties.CommonPf.Properties.GetValue("VCD_CLEANUP_ORPHAN_NETS")
-	return strings.ToLower(val) == "true"
+	return strings.ToLower(val) == "true" || strings.ToLower(val) == "yes"
 }
 
 func (v *VcdPlatform) GetVmAppStatsVdcMaxCacheTime() (uint64, error) {
@@ -210,7 +214,7 @@ func (v *VcdPlatform) GetVmAppStatsVdcMaxCacheTime() (uint64, error) {
 
 func (v *VcdPlatform) GetVmAppInternalDhcpServer() bool {
 	val, _ := v.vmProperties.CommonPf.Properties.GetValue("VCD_VM_APP_INTERNAL_DHCP_SERVER")
-	return strings.ToLower(val) == "true"
+	return strings.ToLower(val) == "true" || strings.ToLower(val) == "yes"
 }
 
 // start fetching access  bits from vault
@@ -272,15 +276,20 @@ func (v *VcdPlatform) GetVcpuSpeedOverride(ctx context.Context) int64 {
 func (v *VcdPlatform) GetLeaseOverride() bool {
 	if v.TestMode {
 		or := os.Getenv("VCD_OVERRIDE_LEASE_DISABLE")
-		if or == "true" {
+		if or == "true" || or == "yes" {
 			return true
 		}
 		return false
 	}
 	val, _ := v.vmProperties.CommonPf.Properties.GetValue("VCD_OVERRIDE_LEASE_DISABLE")
-	if val == "true" {
+	if strings.ToLower(val) == "true" || strings.ToLower(val) == "yes" {
 		return true
 	} else {
 		return false
 	}
+}
+
+func (v *VcdPlatform) GetTemplateArtifactoryImportEnabled() bool {
+	val, _ := v.vmProperties.CommonPf.Properties.GetValue("VCD_TEMPLATE_ARTIFACTORY_IMPORT_ENABLED")
+	return strings.ToLower(val) == "true" || strings.ToLower(val) == "yes"
 }

--- a/crm-platforms/vcd/vcd-vapptemplate.go
+++ b/crm-platforms/vcd/vcd-vapptemplate.go
@@ -380,6 +380,10 @@ func (v *VcdPlatform) AddImageIfNotPresent(ctx context.Context, imageInfo *infra
 		defer resp.Body.Close()
 	}
 
+	if !v.GetTemplateArtifactoryImportEnabled() {
+		return fmt.Errorf("Template not found in catalog and import is disabled.  Please upload ovf from \"%s\" manually to catalog and name as \"%s\" and try again", artifactoryOvfPath, imageInfo.LocalImageName)
+	}
+
 	// get a token that VCD can use to pull from the artifactory
 	token, err := cloudcommon.GetAuthToken(ctx, artifactoryHost, v.vmProperties.CommonPf.PlatformConfig.AccessApi, vcdDirectUser)
 	if err != nil {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5466 VM deployment issues (disable import)

### Description

TEF is still having trouble getting their firewall open between VCD and Artifactory.  Template import is therefore not working.  They have therefore requested us to disable this feature for now.  For this I created VCD_TEMPLATE_ARTIFACTORY_IMPORT_ENABLED to control whether or not to try to import the template.  If disabled, the appinst create will error out after the template is uploaded to Artifactory with instructions given on how to do the import manually and try again.

I also changed a couple other VCD parms to accept "yes" as well as "true" because the base infra ones are all looking for "yes" whereas the VCD ones are currently only looking for "true" and so I thought it might cause an issue due to the inconsistency and resulting confusion.
