### PR TITLE
EDGECLOUD-4894  Alerts: Request to include timestamp

### DIFF
--- a/ansible/roles/alertmanager/files/alertmanager.tmpl
+++ b/ansible/roles/alertmanager/files/alertmanager.tmpl
@@ -63,6 +63,8 @@ SOFTWARE.
                 {{ range .Alerts.Firing }}
                 <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                   <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Alert started at</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    {{ .StartsAt }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Labels</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
                     {{ if gt (len .Annotations) 0 }}<strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Annotations</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
@@ -90,6 +92,8 @@ SOFTWARE.
                 {{ range .Alerts.Resolved }}
                 <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                   <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Alert started at</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    {{ .StartsAt }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Labels</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
                     {{ if gt (len .Annotations) 0 }}<strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Annotations</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
@@ -153,6 +157,8 @@ MobiledX Monitoring System: {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}
 
 *Description:* {{ .Annotations.description }}
 
+*Started at:* {{ .StartsAt }}
+
 *Details:*
   {{ range .Labels.SortedPairs }} • *{{ .Name }}:* {{ .Value }}
   {{ end }}
@@ -162,6 +168,7 @@ MobiledX Monitoring System: {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}
 # use description as the title of the alert, so no need to add "description" label, subsequently skip description annotation
 {{ define "pagerduty.instances" -}}
 {{ range . }}{{ .Annotations.title }} - {{ .Annotations.description }}
+Started at: {{ .StartsAt }}
 Labels:
 {{ range .Labels.SortedPairs }} {{ .Name }} = {{ .Value }}
 {{ end }}{{ end }}{{ end }}

--- a/e2e-tests/data/alertmanager.tmpl
+++ b/e2e-tests/data/alertmanager.tmpl
@@ -60,6 +60,8 @@ SOFTWARE.
                 {{ range .Alerts.Firing }}
                 <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                   <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Alert started at</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    {{ .StartsAt }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Labels</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
                     {{ if gt (len .Annotations) 0 }}<strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Annotations</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
@@ -87,6 +89,8 @@ SOFTWARE.
                 {{ range .Alerts.Resolved }}
                 <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                   <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Alert started at</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    {{ .StartsAt }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Labels</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
                     {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
                     {{ if gt (len .Annotations) 0 }}<strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Annotations</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
@@ -145,11 +149,14 @@ MobiledX Monitoring System: {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}
 {{ template "status.title" . }} | {{template "console.link" .}}
 {{ end }}
 
+# NOTE: *Started at:* is set to "time-to-test" for e2e testing, in production template it's {{.StartsAt}}
 {{ define "slack.text" }}
 {{ range .Alerts -}}
 *Alert:* {{ .Annotations.title }}{{ if .Labels.severity }} - {{ .Labels.severity }}{{ end }}
 
 *Description:* {{ .Annotations.description }}
+
+*Started at:* time-to-test
 
 *Details:*
   {{ range .Labels.SortedPairs }} • *{{ .Name }}:* {{ .Value }}
@@ -162,8 +169,10 @@ https://console.mobiledgex.net
 {{ end }}
 
 # use description as the title of the alert, so no need to add "description" label, subsequently skip description annotation
+# NOTE: for e2e Stared at is set to "time-to-test" for e2e testing, in production template it's {{.StartsAt}}
 {{ define "pagerduty.instances" -}}
 {{ range . }}{{ .Annotations.title }} - {{ .Annotations.description }}
+Started at: time-to-test
 Labels:
 {{ range .Labels.SortedPairs }} {{ .Name }} = {{ .Value }}
 {{ end }}{{ end }}{{ end }}

--- a/e2e-tests/data/pagerdutydata_alert_firing.yml
+++ b/e2e-tests/data/pagerdutydata_alert_firing.yml
@@ -7,6 +7,7 @@
     customdetails:
       firing: |
         AppInstDown - Application server port is not responding
+        Started at: time-to-test
         Labels:
          alertname = AppInstDown
          app = someapplication1

--- a/e2e-tests/data/pagerdutydata_alert_resolved.yml
+++ b/e2e-tests/data/pagerdutydata_alert_resolved.yml
@@ -7,6 +7,7 @@
     customdetails:
       firing: |
         AppInstDown - Application server port is not responding
+        Started at: time-to-test
         Labels:
          alertname = AppInstDown
          app = someapplication1
@@ -36,6 +37,7 @@
       numresolved: "1"
       resolved: |
         AppInstDown - Application server port is not responding
+        Started at: time-to-test
         Labels:
          alertname = AppInstDown
          app = someapplication1

--- a/e2e-tests/data/slackdata_alert_firing.yml
+++ b/e2e-tests/data/slackdata_alert_firing.yml
@@ -5,7 +5,7 @@
     titlelink: |
       https://console.mobiledgex.net
     text: "\n*Alert:* AppInstDown - error\n\n*Description:* Application server port
-      is not responding\n\n*Details:*\n   • *alertname:* AppInstDown\n   • *app:*
+      is not responding\n\n*Started at:* time-to-test\n\n*Details:*\n   • *alertname:* AppInstDown\n   • *app:*
       someapplication1\n   • *apporg:* AcmeAppCo\n   • *appver:* 1.0\n   • *cloudlet:*
       tmus-cloud-1\n   • *cloudletorg:* tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:*
       AcmeAppCo\n   • *region:* local\n   • *scope:* Application\n   • *severity:*

--- a/e2e-tests/data/slackdata_alert_resolved.yml
+++ b/e2e-tests/data/slackdata_alert_resolved.yml
@@ -5,7 +5,7 @@
     titlelink: |
       https://console.mobiledgex.net
     text: "\n*Alert:* AppInstDown - error\n\n*Description:* Application server port
-      is not responding\n\n*Details:*\n   • *alertname:* AppInstDown\n   • *app:*
+      is not responding\n\n*Started at:* time-to-test\n\n*Details:*\n   • *alertname:* AppInstDown\n   • *app:*
       someapplication1\n   • *apporg:* AcmeAppCo\n   • *appver:* 1.0\n   • *cloudlet:*
       tmus-cloud-1\n   • *cloudletorg:* tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:*
       AcmeAppCo\n   • *region:* local\n   • *scope:* Application\n   • *severity:*
@@ -20,7 +20,7 @@
     titlelink: |
       https://console.mobiledgex.net
     text: "\n*Alert:* AppInstDown - error\n\n*Description:* Application server port
-      is not responding\n\n*Details:*\n   • *alertname:* AppInstDown\n   • *app:*
+      is not responding\n\n*Started at:* time-to-test\n\n*Details:*\n   • *alertname:* AppInstDown\n   • *app:*
       someapplication1\n   • *apporg:* AcmeAppCo\n   • *appver:* 1.0\n   • *cloudlet:*
       tmus-cloud-1\n   • *cloudletorg:* tmus\n   • *cluster:* SmallCluster\n   • *clusterorg:*
       AcmeAppCo\n   • *region:* local\n   • *scope:* Application\n   • *severity:*


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-4894  Alerts: Request to include timestamp

### Description
Added timestamp to alert notification templates. A new format looks like the email here:
https://mobiledgex.atlassian.net/wiki/spaces/EDGECLOUD/pages/1336901657/External+notification+examples#AppInst-notification