### PR TITLE
EDGECLOUD-2352   Clean up mexenv.json from local vault, comment changes

### DIFF
--- a/e2e-tests/data/alertmanager.tmpl
+++ b/e2e-tests/data/alertmanager.tmpl
@@ -169,7 +169,7 @@ https://console.mobiledgex.net
 {{ end }}
 
 # use description as the title of the alert, so no need to add "description" label, subsequently skip description annotation
-# NOTE: for e2e Stared at is set to "time-to-test" for e2e testing, in production template it's {{.StartsAt}}
+# NOTE: For e2e tests, Started at is set to "time-to-test" and in the production template, it is {{.StartsAt}}
 {{ define "pagerduty.instances" -}}
 {{ range . }}{{ .Annotations.title }} - {{ .Annotations.description }}
 Started at: time-to-test

--- a/e2e-tests/int-process/process_local.go
+++ b/e2e-tests/int-process/process_local.go
@@ -469,12 +469,6 @@ func SetupVault(p *process.Vault, opts ...process.StartOp) (*VaultRoles, error) 
 	p.GetAppRole("", "rotator", &roles.RotatorRoleID, &roles.RotatorSecretID, &err)
 	p.PutSecret("", "mcorm", mcormSecret+"-old", &err)
 	p.PutSecret("", "mcorm", mcormSecret, &err)
-	// Set up local mexenv.json in the vault to allow local edgebox to run
-	localMexenv := gopath + "/src/github.com/mobiledgex/edge-cloud-infra/mgmt/cloudlets/mexenv.json"
-	p.Run("vault", fmt.Sprintf("write %s @%s", "/secret/data/cloudlet/openstack/mexenv.json", localMexenv), &err)
-	if err != nil {
-		return &roles, err
-	}
 
 	// Setup up dummy key to be used with local chef server to provision cloudlets
 	chefApiKeyPath := "/tmp/dummyChefApiKey.json"

--- a/mc/mcctl/ormctl/alertpolicy.mc2.go
+++ b/mc/mcctl/ormctl/alertpolicy.mc2.go
@@ -142,9 +142,9 @@ var AlertPolicyAliasArgs = []string{
 var AlertPolicyComments = map[string]string{
 	"alert-org":          "Name of the organization for the app that this alert can be applied to",
 	"name":               "Alert Policy name",
-	"cpu-utilization":    "container or pod CPU utilization rate(percentage) across all nodes. Valid values 1-100",
-	"mem-utilization":    "container or pod memory utilization rate(percentage) across all nodes. Valid values 1-100",
-	"disk-utilization":   "container or pod disk utilization rate(percentage) across all nodes. Valid values 1-100",
+	"cpu-utilization":    "Container or pod CPU utilization rate(percentage) across all nodes. Valid values 1-100",
+	"mem-utilization":    "Container or pod memory utilization rate(percentage) across all nodes. Valid values 1-100",
+	"disk-utilization":   "Container or pod disk utilization rate(percentage) across all nodes. Valid values 1-100",
 	"active-connections": "Active Connections alert threshold. Valid values 1-4294967295",
 	"severity":           "Alert severity level - one of info, warning, error",
 	"trigger-time":       "Duration for which alert interval is active (max 72 hours)",

--- a/vault/setup.sh
+++ b/vault/setup.sh
@@ -94,24 +94,3 @@ vault write auth/approle/role/rotator period="720h" policies="rotator"
 # get rotator app roleID and generate secretID
 vault read auth/approle/role/rotator/role-id
 vault write -f auth/approle/role/rotator/secret-id
-
-# mexenv approle
-# This is used by edgebox to access registry secrets only.
-# It does not have full access of crm role, so we can put it in
-# the local_dind.yml setup file. Once we make our demo
-# apps public, we can remove this app role.
-cat > /tmp/mexenv-pol.hcl <<EOF
-path "auth/approle/login" {
-  capabilities = [ "create", "read" ]
-}
-
-path "secret/data/cloudlet/openstack/mexenv.json" {
-  capabilities = [ "read" ]
-}
-EOF
-vault policy write mexenv /tmp/mexenv-pol.hcl
-rm /tmp/mexenv-pol.hcl
-vault write auth/approle/role/mexenv period="720h" policies="mexenv"
-# get mexenv app roleID and generate secretID
-vault read auth/approle/role/mexenv/role-id
-vault write -f auth/approle/role/mexenv/secret-id


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-2352  Clean up mexenv.json from local vault
* EDGECLOUD-5473 mcctl help text for alertpolicy need to capitalize sentences

### Description

Remove mexenv.json from local vault setup.
Comment fix, autogen files.