### PR TITLE
EDGECLOUD-4988 disallow cloudletpool add with existing developer objects

### DIFF
--- a/mc/mcctl/mctestclient/mctestclient_generatedfuncs.go
+++ b/mc/mcctl/mctestclient/mctestclient_generatedfuncs.go
@@ -1070,6 +1070,22 @@ func (s *Client) ShowFlavorsForCloudlet(uri string, token string, in *ormapi.Reg
 	return out, rundata.RetStatus, rundata.RetError
 }
 
+func (s *Client) GetOrganizationsOnCloudlet(uri string, token string, in *ormapi.RegionCloudletKey) ([]edgeproto.Organization, int, error) {
+	rundata := RunData{}
+	rundata.Uri = uri
+	rundata.Token = token
+	rundata.In = in
+	var out []edgeproto.Organization
+	rundata.Out = &out
+
+	apiCmd := ormctl.MustGetCommand("GetOrganizationsOnCloudlet")
+	s.ClientRun.Run(apiCmd, &rundata)
+	if rundata.RetError != nil {
+		return nil, rundata.RetStatus, rundata.RetError
+	}
+	return out, rundata.RetStatus, rundata.RetError
+}
+
 func (s *Client) RevokeAccessKey(uri string, token string, in *ormapi.RegionCloudletKey) (*edgeproto.Result, int, error) {
 	rundata := RunData{}
 	rundata.Uri = uri

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -398,6 +398,23 @@ var ShowFlavorsForCloudletCmd = &ApiCommand{
 	ProtobufApi:          true,
 }
 
+var GetOrganizationsOnCloudletCmd = &ApiCommand{
+	Name:                 "GetOrganizationsOnCloudlet",
+	Use:                  "getorganizationson",
+	Short:                "Get organizations of ClusterInsts and AppInsts on cloudlet",
+	RequiredArgs:         "region " + strings.Join(CloudletKeyRequiredArgs, " "),
+	OptionalArgs:         strings.Join(CloudletKeyOptionalArgs, " "),
+	AliasArgs:            strings.Join(CloudletKeyAliasArgs, " "),
+	SpecialArgs:          &CloudletKeySpecialArgs,
+	Comments:             addRegionComment(CloudletKeyComments),
+	ReqData:              &ormapi.RegionCloudletKey{},
+	ReplyData:            &edgeproto.Organization{},
+	Path:                 "/auth/ctrl/GetOrganizationsOnCloudlet",
+	StreamOut:            true,
+	StreamOutIncremental: true,
+	ProtobufApi:          true,
+}
+
 var RevokeAccessKeyCmd = &ApiCommand{
 	Name:         "RevokeAccessKey",
 	Use:          "revokeaccesskey",
@@ -440,6 +457,7 @@ var CloudletApiCmds = []*ApiCommand{
 	RemoveCloudletResMappingCmd,
 	FindFlavorMatchCmd,
 	ShowFlavorsForCloudletCmd,
+	GetOrganizationsOnCloudletCmd,
 	RevokeAccessKeyCmd,
 	GenerateAccessKeyCmd,
 }

--- a/mc/orm/alert.mc2.go
+++ b/mc/orm/alert.mc2.go
@@ -939,6 +939,16 @@ func addControllerApis(method string, group *echo.Group) {
 	//   403: forbidden
 	//   404: notFound
 	group.Match([]string{method}, "/ctrl/ShowFlavorsForCloudlet", ShowFlavorsForCloudlet)
+	// swagger:route POST /auth/ctrl/GetOrganizationsOnCloudlet CloudletKey GetOrganizationsOnCloudlet
+	// Get organizations of ClusterInsts and AppInsts on cloudlet.
+	// Security:
+	//   Bearer:
+	// responses:
+	//   200: success
+	//   400: badRequest
+	//   403: forbidden
+	//   404: notFound
+	group.Match([]string{method}, "/ctrl/GetOrganizationsOnCloudlet", GetOrganizationsOnCloudlet)
 	// swagger:route POST /auth/ctrl/RevokeAccessKey CloudletKey RevokeAccessKey
 	// Revoke crm access key.
 	// Security:

--- a/mc/orm/authz_cloudletpool.go
+++ b/mc/orm/authz_cloudletpool.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/mobiledgex/edge-cloud-infra/mc/ormapi"
+	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 )
 
@@ -30,4 +31,88 @@ func authzDeleteCloudletPool(ctx context.Context, region, username string, obj *
 		usedBy = append(usedBy, fmt.Sprintf("%s %s", pool.Org, pool.Type))
 	}
 	return fmt.Errorf("Cannot delete CloudletPool region %s name %s because it is referenced by %s", region, obj.Key.Name, strings.Join(usedBy, ", "))
+}
+
+func authzCreateCloudletPool(ctx context.Context, region, username string, obj *edgeproto.CloudletPool, resource, action string) error {
+	if err := authorized(ctx, username, obj.Key.Organization, resource, action, withRequiresOrg(obj.Key.Organization)); err != nil {
+		return err
+	}
+	// OrgCloudletPool memberships cannot exist before the CloudletPool
+	// exists, so any developers on the cloudlets would not be part of
+	// the pool.
+	rc := RegionContext{}
+	rc.username = username
+	rc.region = region
+	rc.skipAuthz = true
+	for _, cloudletName := range obj.Cloudlets {
+		key := edgeproto.CloudletKey{
+			Name:         cloudletName,
+			Organization: obj.Key.Organization,
+		}
+		err := GetOrganizationsOnCloudletStream(ctx, &rc, &key, func(org *edgeproto.Organization) error {
+			if org.Name == cloudcommon.OrganizationMobiledgeX {
+				return nil
+			}
+			return fmt.Errorf("Cannot create CloudletPool with cloudlet %s with existing developer %s ClusterInsts or AppInsts. To include them as part of the pool, first create an empty pool, invite the developer to the pool, then add the cloudlet to the pool.", key.Name, org.Name)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func authzUpdateCloudletPool(ctx context.Context, region, username string, pool *edgeproto.CloudletPool, resource, action string) error {
+	return authzCloudletPoolMembers(ctx, region, username, pool, resource, action)
+}
+
+func authzAddCloudletPoolMember(ctx context.Context, region, username string, obj *edgeproto.CloudletPoolMember, resource, action string) error {
+	pool := &edgeproto.CloudletPool{}
+	pool.Key = obj.Key
+	pool.Cloudlets = []string{obj.CloudletName}
+	return authzCloudletPoolMembers(ctx, region, username, pool, resource, action)
+}
+
+func authzCloudletPoolMembers(ctx context.Context, region, username string, pool *edgeproto.CloudletPool, resource, action string) error {
+	if err := authorized(ctx, username, pool.Key.Organization, resource, action); err != nil {
+		return err
+	}
+	// find developers that are part of pool.
+	filter := make(map[string]interface{})
+	filter["region"] = region
+	filter["cloudlet_pool"] = pool.Key.Name
+	filter["cloudlet_pool_org"] = pool.Key.Organization
+	orgPools, err := showCloudletPoolAccessObj(ctx, username, filter, accessTypeGranted)
+	if err != nil {
+		return err
+	}
+	orgPoolsMap := make(map[string]struct{})
+	for _, orgPool := range orgPools {
+		orgPoolsMap[orgPool.Org] = struct{}{}
+	}
+	// make sure that cloudlet being added to the pool does not
+	// have AppInsts/ClusterInsts from developers not part of the pool.
+	rc := RegionContext{}
+	rc.username = username
+	rc.region = region
+	rc.skipAuthz = true
+	for _, cloudletName := range pool.Cloudlets {
+		key := edgeproto.CloudletKey{
+			Name:         cloudletName,
+			Organization: pool.Key.Organization,
+		}
+		err = GetOrganizationsOnCloudletStream(ctx, &rc, &key, func(org *edgeproto.Organization) error {
+			if org.Name == cloudcommon.OrganizationMobiledgeX {
+				return nil
+			}
+			if _, found := orgPoolsMap[org.Name]; found {
+				return nil
+			}
+			return fmt.Errorf("Cannot add cloudlet %s to CloudletPool with existing developer %s ClusterInsts or AppInsts which are not authorized to deploy to the CloudletPool. Please invite the developer first, or remove the developer from the Cloudlet.", key.Name, org.Name)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/mc/orm/cloudlet_mc2_test.go
+++ b/mc/orm/cloudlet_mc2_test.go
@@ -498,6 +498,27 @@ func goodPermShowFlavorsForCloudlet(t *testing.T, mcClient *mctestclient.Client,
 
 var _ = edgeproto.GetFields
 
+func badPermGetOrganizationsOnCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, status, err := testutil.TestPermGetOrganizationsOnCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
+	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badGetOrganizationsOnCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, st, err := testutil.TestPermGetOrganizationsOnCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
+func goodPermGetOrganizationsOnCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, status, err := testutil.TestPermGetOrganizationsOnCloudlet(mcClient, uri, token, region, org, modFuncs...)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, status)
+}
+
+var _ = edgeproto.GetFields
+
 func badPermRevokeAccessKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
 	_, status, err := testutil.TestPermRevokeAccessKey(mcClient, uri, token, region, org, modFuncs...)
 	require.NotNil(t, err)

--- a/mc/orm/cloudletpool.mc2.go
+++ b/mc/orm/cloudletpool.mc2.go
@@ -63,8 +63,8 @@ func CreateCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		return nil, err
 	}
 	if !rc.skipAuthz {
-		if err := authorized(ctx, rc.username, obj.Key.Organization,
-			ResourceCloudletPools, ActionManage, withRequiresOrg(obj.Key.Organization)); err != nil {
+		if err := authzCreateCloudletPool(ctx, rc.region, rc.username, obj,
+			ResourceCloudletPools, ActionManage); err != nil {
 			return nil, err
 		}
 	}
@@ -179,7 +179,7 @@ func UpdateCloudletPoolObj(ctx context.Context, rc *RegionContext, obj *edgeprot
 		return nil, err
 	}
 	if !rc.skipAuthz {
-		if err := authorized(ctx, rc.username, obj.Key.Organization,
+		if err := authzUpdateCloudletPool(ctx, rc.region, rc.username, obj,
 			ResourceCloudletPools, ActionManage); err != nil {
 			return nil, err
 		}
@@ -323,7 +323,7 @@ func AddCloudletPoolMemberObj(ctx context.Context, rc *RegionContext, obj *edgep
 		return nil, err
 	}
 	if !rc.skipAuthz {
-		if err := authorized(ctx, rc.username, obj.Key.Organization,
+		if err := authzAddCloudletPoolMember(ctx, rc.region, rc.username, obj,
 			ResourceCloudletPools, ActionManage); err != nil {
 			return nil, err
 		}

--- a/mc/orm/testutil/cloudlet_mc2_testutil.go
+++ b/mc/orm/testutil/cloudlet_mc2_testutil.go
@@ -393,6 +393,21 @@ func TestPermShowFlavorsForCloudlet(mcClient *mctestclient.Client, uri, token, r
 	return TestShowFlavorsForCloudlet(mcClient, uri, token, region, in, modFuncs...)
 }
 
+func TestGetOrganizationsOnCloudlet(mcClient *mctestclient.Client, uri, token, region string, in *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.CloudletKey)) ([]edgeproto.Organization, int, error) {
+	dat := &ormapi.RegionCloudletKey{}
+	dat.Region = region
+	dat.CloudletKey = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletKey)
+	}
+	return mcClient.GetOrganizationsOnCloudlet(uri, token, dat)
+}
+func TestPermGetOrganizationsOnCloudlet(mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) ([]edgeproto.Organization, int, error) {
+	in := &edgeproto.CloudletKey{}
+	in.Organization = org
+	return TestGetOrganizationsOnCloudlet(mcClient, uri, token, region, in, modFuncs...)
+}
+
 func TestRevokeAccessKey(mcClient *mctestclient.Client, uri, token, region string, in *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.CloudletKey)) (*edgeproto.Result, int, error) {
 	dat := &ormapi.RegionCloudletKey{}
 	dat.Region = region
@@ -493,6 +508,18 @@ func (s *TestClient) ShowFlavorsForCloudlet(ctx context.Context, in *edgeproto.C
 		CloudletKey: *in,
 	}
 	out, status, err := s.McClient.ShowFlavorsForCloudlet(s.Uri, s.Token, inR)
+	if err == nil && status != 200 {
+		err = fmt.Errorf("status: %d\n", status)
+	}
+	return out, err
+}
+
+func (s *TestClient) GetOrganizationsOnCloudlet(ctx context.Context, in *edgeproto.CloudletKey) ([]edgeproto.Organization, error) {
+	inR := &ormapi.RegionCloudletKey{
+		Region:      s.Region,
+		CloudletKey: *in,
+	}
+	out, status, err := s.McClient.GetOrganizationsOnCloudlet(s.Uri, s.Token, inR)
 	if err == nil && status != 200 {
 		err = fmt.Errorf("status: %d\n", status)
 	}

--- a/mc/ormapi/cloudlet.mc2.go
+++ b/mc/ormapi/cloudlet.mc2.go
@@ -339,6 +339,13 @@ type swaggerShowFlavorsForCloudlet struct {
 	Body RegionCloudletKey
 }
 
+// Request summary for GetOrganizationsOnCloudlet
+// swagger:parameters GetOrganizationsOnCloudlet
+type swaggerGetOrganizationsOnCloudlet struct {
+	// in: body
+	Body RegionCloudletKey
+}
+
 // Request summary for RevokeAccessKey
 // swagger:parameters RevokeAccessKey
 type swaggerRevokeAccessKey struct {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-4988 Disallow adding a public cloudlet to private pool if there are existing clusterinst/appinsts deployed on the cloudlet

### Description

Checks that cloudlets being added to a cloudlet pool do not have existing developers on them that would be disallowed from deploying to the cloudlet pool. This affects the Create, Update, and AddMember CloudletPool APIs.