### PR TITLE
EDGECLOUD-5512: Failed to refresh TLS certs as expired SSH certs are used

### DIFF
--- a/crm-platforms/azure/azure.go
+++ b/crm-platforms/azure/azure.go
@@ -126,6 +126,10 @@ func (a *AzurePlatform) GetNodePlatformClient(ctx context.Context, node *edgepro
 	return &pc.LocalClient{}, nil
 }
 
+func (a *AzurePlatform) GetSSHClient(ctx context.Context, addr string) (ssh.Client, error) {
+	return &pc.LocalClient{}, nil
+}
+
 func (a *AzurePlatform) ListCloudletMgmtNodes(ctx context.Context, clusterInsts []edgeproto.ClusterInst, vmAppInsts []edgeproto.AppInst) ([]edgeproto.CloudletMgmtNode, error) {
 	return []edgeproto.CloudletMgmtNode{}, nil
 }
@@ -170,4 +174,8 @@ func (a *AzurePlatform) SetProperties(props *infracommon.InfraProperties) error 
 
 func (a *AzurePlatform) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
 	return nil, nil
+}
+
+func (a *AzurePlatform) GetRootLBAddrs(ctx context.Context) (string, map[string]string, error) {
+	return "", nil, nil
 }

--- a/crm-platforms/edgebox/edgebox.go
+++ b/crm-platforms/edgebox/edgebox.go
@@ -99,6 +99,10 @@ func (s *EdgeboxPlatform) GetNodePlatformClient(ctx context.Context, node *edgep
 	return s.generic.GetNodePlatformClient(ctx, node)
 }
 
+func (s *EdgeboxPlatform) GetSSHClient(ctx context.Context, addr string) (ssh.Client, error) {
+	return s.generic.GetSSHClient(ctx, addr)
+}
+
 func (s *EdgeboxPlatform) ListCloudletMgmtNodes(ctx context.Context, clusterInsts []edgeproto.ClusterInst, vmAppInsts []edgeproto.AppInst) ([]edgeproto.CloudletMgmtNode, error) {
 	return s.generic.ListCloudletMgmtNodes(ctx, clusterInsts, vmAppInsts)
 }
@@ -113,4 +117,8 @@ func (s *EdgeboxPlatform) GetAccessData(ctx context.Context, cloudlet *edgeproto
 
 func (s *EdgeboxPlatform) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
 	return s.generic.GetRootLBClients(ctx)
+}
+
+func (s *EdgeboxPlatform) GetRootLBAddrs(ctx context.Context) (string, map[string]string, error) {
+	return s.generic.GetRootLBAddrs(ctx)
 }

--- a/crm-platforms/gcp/gcp.go
+++ b/crm-platforms/gcp/gcp.go
@@ -173,3 +173,7 @@ func (g *GCPPlatform) SetProperties(props *infracommon.InfraProperties) error {
 func (g *GCPPlatform) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
 	return nil, nil
 }
+
+func (g *GCPPlatform) GetRootLBAddrs(ctx context.Context) (string, map[string]string, error) {
+	return "", nil, nil
+}

--- a/crm-platforms/k8s-baremetal/k8sbm.go
+++ b/crm-platforms/k8s-baremetal/k8sbm.go
@@ -136,6 +136,14 @@ func (k *K8sBareMetalPlatform) GetNodePlatformClient(ctx context.Context, node *
 	return k.commonPf.GetSSHClientFromIPAddr(ctx, controlIp, ops...)
 }
 
+func (k *K8sBareMetalPlatform) GetSSHClient(ctx context.Context, addr string) (ssh.Client, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetSSHClient", "addr", addr)
+	if addr == "" {
+		return nil, fmt.Errorf("cannot GetSSHClient, addr is empty")
+	}
+	return k.commonPf.GetSSHClientFromIPAddr(ctx, addr)
+}
+
 // TODO
 func (k *K8sBareMetalPlatform) ListCloudletMgmtNodes(ctx context.Context, clusterInsts []edgeproto.ClusterInst, vmAppInsts []edgeproto.AppInst) ([]edgeproto.CloudletMgmtNode, error) {
 	return []edgeproto.CloudletMgmtNode{}, nil
@@ -192,6 +200,10 @@ func (k *K8sBareMetalPlatform) GetRestrictedCloudletStatus(ctx context.Context, 
 
 func (k *K8sBareMetalPlatform) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
 	return nil, nil
+}
+
+func (k *K8sBareMetalPlatform) GetRootLBAddrs(ctx context.Context) (string, map[string]string, error) {
+	return "", nil, nil
 }
 
 func (k *K8sBareMetalPlatform) GetVersionProperties() map[string]string {

--- a/managedk8s/mk8s-cloudlet.go
+++ b/managedk8s/mk8s-cloudlet.go
@@ -135,3 +135,7 @@ func (v *ManagedK8sPlatform) GetRestrictedCloudletStatus(ctx context.Context, cl
 func (v *ManagedK8sPlatform) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
 	return nil, nil
 }
+
+func (v *ManagedK8sPlatform) GetRootLBAddrs(ctx context.Context) (string, map[string]string, error) {
+	return "", nil, nil
+}

--- a/managedk8s/mk8s-provider.go
+++ b/managedk8s/mk8s-provider.go
@@ -76,6 +76,10 @@ func (m *ManagedK8sPlatform) GetNodePlatformClient(ctx context.Context, node *ed
 	return &pc.LocalClient{}, nil
 }
 
+func (m *ManagedK8sPlatform) GetSSHClient(ctx context.Context, addr string) (ssh.Client, error) {
+	return &pc.LocalClient{}, nil
+}
+
 func (m *ManagedK8sPlatform) ListCloudletMgmtNodes(ctx context.Context, clusterInsts []edgeproto.ClusterInst, vmAppInsts []edgeproto.AppInst) ([]edgeproto.CloudletMgmtNode, error) {
 	return []edgeproto.CloudletMgmtNode{}, nil
 }

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -313,10 +313,12 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		}
 		var proxyOps []proxy.Op
 		client, err := v.GetSSHClientForServer(ctx, orchVals.externalServerName, v.VMProperties.GetCloudletExternalNetwork())
+		serverIp, err := v.GetIPFromServerName(ctx, v.VMProperties.GetCloudletExternalNetwork(), "", orchVals.externalServerName)
 		if err != nil {
 			return err
 		}
-		proxycerts.NewDedicatedLB(ctx, &appInst.Key.ClusterInstKey.CloudletKey, orchVals.lbName, client, v.VMProperties.CommonPf.PlatformConfig.NodeMgr)
+		rootLBAddr := serverIp.ExternalAddr
+		proxycerts.NewDedicatedLB(ctx, &appInst.Key.ClusterInstKey.CloudletKey, orchVals.lbName, rootLBAddr, v.VMProperties.CommonPf.PlatformConfig.NodeMgr)
 		// clusterInst is empty but that is ok here
 		names, err := k8smgmt.GetKubeNames(clusterInst, app, appInst)
 		if err != nil {

--- a/vmlayer/cluster.go
+++ b/vmlayer/cluster.go
@@ -494,7 +494,13 @@ func (v *VMPlatform) setupClusterRootLBAndNodes(ctx context.Context, rootLBName 
 		}
 	}
 	if clusterInst.IpAccess == edgeproto.IpAccess_IP_ACCESS_DEDICATED {
-		proxycerts.NewDedicatedLB(ctx, &clusterInst.Key.CloudletKey, rootLBName, client, v.VMProperties.CommonPf.PlatformConfig.NodeMgr)
+		rootLBName = cloudcommon.GetDedicatedLBFQDN(v.VMProperties.CommonPf.PlatformConfig.CloudletKey, &clusterInst.Key.ClusterKey, v.VMProperties.CommonPf.PlatformConfig.AppDNSRoot)
+		serverIp, err := v.GetIPFromServerName(ctx, v.VMProperties.GetCloudletExternalNetwork(), "", rootLBName)
+		if err != nil {
+			return err
+		}
+		rootLBAddr := serverIp.ExternalAddr
+		proxycerts.NewDedicatedLB(ctx, &clusterInst.Key.CloudletKey, rootLBName, rootLBAddr, v.VMProperties.CommonPf.PlatformConfig.NodeMgr)
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "created cluster")
 	return nil


### PR DESCRIPTION
### Issues Fixed
* EDGECLOUD-5512: Failed to refresh TLS certs as expired SSH certs are used

### Description
* Refer PR:
   https://github.com/mobiledgex/edge-cloud/pull/1467