### PR TITLE
Fix CreateCloudlet after GetCloudletProps

### DIFF
--- a/vmlayer/cloudlet.go
+++ b/vmlayer/cloudlet.go
@@ -789,19 +789,22 @@ func (v *VMPlatform) GetCloudletProps(ctx context.Context) (*edgeproto.CloudletP
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletProps")
 
 	props := edgeproto.CloudletProps{}
-	props.Properties = VMProviderProps
-
-	for k, v := range infracommon.InfraCommonProps {
-		props.Properties[k] = v
+	props.Properties = make(map[string]*edgeproto.PropertyInfo)
+	for k, v := range VMProviderProps {
+		val := *v
+		props.Properties[k] = &val
 	}
-
+	for k, v := range infracommon.InfraCommonProps {
+		val := *v
+		props.Properties[k] = &val
+	}
 	providerProps, err := v.VMProvider.GetProviderSpecificProps(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for k, v := range providerProps {
-		props.Properties[k] = v
+		val := *v
+		props.Properties[k] = &val
 	}
-
 	return &props, nil
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5539 CreateCloudlet fails after GetCloudletProps

### Description

Ran into the following after the demo testing:
- CreateCloudlet for OpenStack was failing because of mandatory properties not set for VCD.  Eventually reproduced this by doing the following.  It happens consistently. 
1) Run GetCloudletProps for VCD
2) Run CreateCloudlet for OpenStack

The issue is that the implementation of GetCloudletProps copies pointers of edgeproto.PropertyInfo.  Fix is to make local copies of the properties to avoid trampling 