### PR TITLE
EDGECLOUD-5529 EDGECLOUD-5534 Check for startage/endage. Change Port from value to a tag

### DIFF
--- a/mc/orm/metrics_test.go
+++ b/mc/orm/metrics_test.go
@@ -206,11 +206,20 @@ func TestGetSelectorForMeasurement(t *testing.T) {
 }
 
 func TestGetTimeDefinition(t *testing.T) {
+	// Invalid start end age
+	testApps.StartTime = time.Time{}
+	testApps.EndTime = time.Time{}
+	testApps.StartAge = edgeproto.Duration(time.Second)
+	testApps.EndAge = edgeproto.Duration(2 * time.Second)
+	testApps.Limit = 0
+	err := validateMetricsCommon(&testApps.MetricsCommon)
+	require.NotNil(t, err)
+	require.Equal(t, "start age must be before (older than) end age", err.Error())
 	// With nothing set in testApps we get last 100 data points
 	testApps.StartTime = time.Time{}
 	testApps.EndTime = time.Time{}
 	testApps.Limit = 0
-	err := validateMetricsCommon(&testApps.MetricsCommon)
+	err = validateMetricsCommon(&testApps.MetricsCommon)
 	require.Nil(t, err)
 	require.Equal(t, "", getTimeDefinition(&testApps.MetricsCommon, 0))
 	require.Equal(t, MaxNumSamples, testApps.Limit)

--- a/mc/orm/timedef.go
+++ b/mc/orm/timedef.go
@@ -61,8 +61,10 @@ func validateMetricsCommon(obj *ormapi.MetricsCommon) error {
 		}
 	}
 
-	// If the limit is set, and no start/end time, don't add it
-	if obj.Limit != 0 && obj.StartTime.IsZero() && obj.EndTime.IsZero() {
+	// If the limit is set, and no start/end time/age, don't add it
+	if obj.Limit != 0 &&
+		obj.StartTime.IsZero() && obj.EndTime.IsZero() &&
+		obj.StartAge == 0 && obj.EndAge == 0 {
 		return nil
 	}
 	// resolve and fill in time fields

--- a/shepherd/proxy-stats.go
+++ b/shepherd/proxy-stats.go
@@ -733,7 +733,7 @@ func MarshallTcpProxyMetric(scrapePoint ProxyScrapePoint, data *shepherd_common.
 		metric.AddTag("apporg", scrapePoint.Key.AppKey.Organization)
 		metric.AddTag("app", util.DNSSanitize(scrapePoint.Key.AppKey.Name))
 		metric.AddTag("ver", util.DNSSanitize(scrapePoint.Key.AppKey.Version))
-		metric.AddIntVal("port", uint64(port))
+		metric.AddTag("port", fmt.Sprintf("%d", port))
 
 		metric.AddIntVal("active", data.EnvoyTcpStats[port].ActiveConn)
 		metric.AddIntVal("accepts", data.EnvoyTcpStats[port].Accepts)
@@ -763,7 +763,7 @@ func MarshallUdpProxyMetric(scrapePoint ProxyScrapePoint, data *shepherd_common.
 		metric.AddTag("apporg", scrapePoint.Key.AppKey.Organization)
 		metric.AddTag("app", util.DNSSanitize(scrapePoint.Key.AppKey.Name))
 		metric.AddTag("ver", util.DNSSanitize(scrapePoint.Key.AppKey.Version))
-		metric.AddIntVal("port", uint64(port))
+		metric.AddTag("port", fmt.Sprintf("%d", port))
 
 		metric.AddIntVal("bytesSent", data.EnvoyUdpStats[port].SentBytes)
 		metric.AddIntVal("bytesRecvd", data.EnvoyUdpStats[port].RecvBytes)
@@ -791,6 +791,7 @@ func MarshallNginxMetric(scrapePoint ProxyScrapePoint, data *shepherd_common.Pro
 	metric.AddTag("apporg", scrapePoint.Key.AppKey.Organization)
 	metric.AddTag("app", util.DNSSanitize(scrapePoint.Key.AppKey.Name))
 	metric.AddTag("ver", util.DNSSanitize(scrapePoint.Key.AppKey.Version))
+	metric.AddTag("port", "")
 
 	metric.AddIntVal("active", data.ActiveConn)
 	metric.AddIntVal("accepts", data.Accepts)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5529 metrics clientappusage does not error when starttage is newer than endage
* EDGECLOUD-5534 Not seeing port connections/network data when internal port for the second instance is the same

### Description
EDGECLOUD-5534
Change port from value to a tag, if it is not part of the key it would overwrite the previous value and only one port would be stored per appInstance. This change will require reset of influxDB `connections` measurement. Also might require some changes in the UI as well.

EDGECLOUD-5529
Check for startage and endage to be not set before skipping `Resolve` call.
Added unit-test for it