### PR TITLE
fix edgeevents unit test

### DIFF
--- a/edge-events/edge-events-handler_test.go
+++ b/edge-events/edge-events-handler_test.go
@@ -208,6 +208,14 @@ func testAddRemoveKeysSerial(t *testing.T, ctx context.Context) {
 	e.RemoveClient(ctx, appinst4, client0)
 	e.RemoveClient(ctx, appinst5, client1)
 
+	// Remove AppInsts
+	e.RemoveAppInst(ctx, appinst0)
+	e.RemoveAppInst(ctx, appinst1)
+	e.RemoveAppInst(ctx, appinst2)
+	e.RemoveAppInst(ctx, appinst3)
+	e.RemoveAppInst(ctx, appinst4)
+	e.RemoveAppInst(ctx, appinst5)
+
 	// All Cloudlets, AppInsts, and Clients should have been removed
 	require.Equal(t, 0, len(e.Cloudlets))
 }
@@ -273,6 +281,14 @@ func testAddRemoveKeysConcurrent(t *testing.T, ctx context.Context) {
 			fmt.Printf("%s completed add remove cycle\n", client)
 		}
 	}
+
+	// Remove AppInsts
+	e.RemoveAppInst(ctx, appinst0)
+	e.RemoveAppInst(ctx, appinst1)
+	e.RemoveAppInst(ctx, appinst2)
+	e.RemoveAppInst(ctx, appinst3)
+	e.RemoveAppInst(ctx, appinst4)
+	e.RemoveAppInst(ctx, appinst5)
 
 	// All Cloudlets, AppInsts, and Clients should have been removed
 	require.Equal(t, 0, len(e.Cloudlets))


### PR DESCRIPTION
### Description

In https://github.com/mobiledgex/edge-cloud-infra/pull/1709, I added the SendAvailableAppInst function, which is called when a new appinst is created. So, I now only add the appinst to the EdgeEventsHandlerPlugin maps inside that function (no longer in AddClient, since the appinst had to have been created before the client connected to it).

So, because I do not add appinst information to maps in AddClient, I took out the code that removes the appinst and cloudlet from the maps if the appinst has 0 clients (otherwise adding a client after a lull where there are no clients wouldn't work).

Previously, in this unit test, when all the clients were removed, the appinsts and cloudlets were also removed. But, because I don't remove appinsts anymore, I have to call the actual function that removes the appinsts and cloudlets. (This more closely matches how DME behaves anyways)


