### PR TITLE
Flag to control actual staging deployment

### DIFF
--- a/jenkins/console-deploy.Jenkinsfile
+++ b/jenkins/console-deploy.Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
     }
     parameters {
         string name: 'TAG', defaultValue: 'latest', description: 'Console version (tag) to deploy'
+        booleanParam name: 'DO_DEPLOY', defaultValue: false, description: 'Flag to control if deployment is actually attempted'
     }
     stages {
         stage('Set up build tag') {
@@ -30,6 +31,11 @@ export GITHUB_USER="${GITHUB_CREDS_USR}"
 export GITHUB_TOKEN="${GITHUB_CREDS_PSW}"
 export VAULT_ROLE_ID="${ANSIBLE_ROLE_USR}"
 export VAULT_SECRET_ID="${ANSIBLE_ROLE_PSW}"
+
+if ! $DO_DEPLOY; then
+        echo "Skipping the staging deployment"
+        exit 0
+fi
 
 CMD=( ./deploy.sh -y -s setup,mc )
 [[ "$TAG" != "latest" ]] && CMD+=( -C ${TAG} )


### PR DESCRIPTION
Right now, on every console release, a Github action attempts to
deploy the console to the staging setup. However, there are times when
the staging setup is locked down, and this ends up triggering a false
failure in the Github action.

With this change, we can control the actual deployment of the console
with a flag (manually configued in Jenkins), and if the flag is not set,
the Jenkins job will succeed without actually doing anything.
