### PR TITLE
EDGECLOUD-5514 authz addcloudletpoolmember fix error messages

### DIFF
--- a/mc/mcctl/ormctl/cloudletpool.mc2.go
+++ b/mc/mcctl/ormctl/cloudletpool.mc2.go
@@ -92,8 +92,8 @@ var AddCloudletPoolMemberCmd = &ApiCommand{
 	Name:         "AddCloudletPoolMember",
 	Use:          "addmember",
 	Short:        "Add a Cloudlet to a CloudletPool",
-	RequiredArgs: "region " + strings.Join(CloudletPoolMemberRequiredArgs, " "),
-	OptionalArgs: strings.Join(CloudletPoolMemberOptionalArgs, " "),
+	RequiredArgs: "region " + strings.Join(AddCloudletPoolMemberRequiredArgs, " "),
+	OptionalArgs: strings.Join(AddCloudletPoolMemberOptionalArgs, " "),
 	AliasArgs:    strings.Join(CloudletPoolMemberAliasArgs, " "),
 	SpecialArgs:  &CloudletPoolMemberSpecialArgs,
 	Comments:     addRegionComment(CloudletPoolMemberComments),
@@ -107,8 +107,8 @@ var RemoveCloudletPoolMemberCmd = &ApiCommand{
 	Name:         "RemoveCloudletPoolMember",
 	Use:          "removemember",
 	Short:        "Remove a Cloudlet from a CloudletPool",
-	RequiredArgs: "region " + strings.Join(CloudletPoolMemberRequiredArgs, " "),
-	OptionalArgs: strings.Join(CloudletPoolMemberOptionalArgs, " "),
+	RequiredArgs: "region " + strings.Join(RemoveCloudletPoolMemberRequiredArgs, " "),
+	OptionalArgs: strings.Join(RemoveCloudletPoolMemberOptionalArgs, " "),
 	AliasArgs:    strings.Join(CloudletPoolMemberAliasArgs, " "),
 	SpecialArgs:  &CloudletPoolMemberSpecialArgs,
 	Comments:     addRegionComment(CloudletPoolMemberComments),
@@ -132,6 +132,18 @@ func init() {
 	AllApis.AddGroup(CloudletPoolGroup, "Manage CloudletPools", CloudletPoolApiCmds)
 }
 
+var AddCloudletPoolMemberRequiredArgs = []string{
+	"org",
+	"pool",
+	"cloudlet",
+}
+var AddCloudletPoolMemberOptionalArgs = []string{}
+var RemoveCloudletPoolMemberRequiredArgs = []string{
+	"org",
+	"pool",
+	"cloudlet",
+}
+var RemoveCloudletPoolMemberOptionalArgs = []string{}
 var CloudletPoolRequiredArgs = []string{
 	"org",
 	"name",
@@ -174,6 +186,6 @@ var CloudletPoolMemberAliasArgs = []string{
 var CloudletPoolMemberComments = map[string]string{
 	"org":      "Name of the organization this pool belongs to",
 	"pool":     "CloudletPool Name",
-	"cloudlet": "Cloudlet key",
+	"cloudlet": "Cloudlet name",
 }
 var CloudletPoolMemberSpecialArgs = map[string]string{}

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -796,7 +796,7 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 		}
 		_, status, err = mcClient.CreateCloudletPool(uri, tokenOper, &badpool)
 		require.NotNil(t, err)
-		require.Equal(t, "Cannot create CloudletPool with cloudlet somecloudlet with existing developer org1 ClusterInsts or AppInsts. To include them as part of the pool, first create an empty pool, invite the developer to the pool, then add the cloudlet to the pool.", err.Error())
+		require.Equal(t, "Cannot add cloudlet somecloudlet to CloudletPool because it has AppInsts/ClusterInsts from developer org1, which are not authorized to deploy to the CloudletPool. To include them as part of the pool, first create an empty pool, invite the developer to the pool, then add the cloudlet to the pool.", err.Error())
 
 		// create empty pool
 		pool := ormapi.RegionCloudletPool{
@@ -821,7 +821,7 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 		}
 		_, status, err = mcClient.AddCloudletPoolMember(uri, tokenOper, &member)
 		require.NotNil(t, err)
-		require.Equal(t, "Cannot add cloudlet somecloudlet to CloudletPool with existing developer org1 ClusterInsts or AppInsts which are not authorized to deploy to the CloudletPool. Please invite the developer first, or remove the developer from the Cloudlet.", err.Error())
+		require.Equal(t, "Cannot add cloudlet somecloudlet to CloudletPool because it has AppInsts/ClusterInsts from developer org1, which are not authorized to deploy to the CloudletPool. Please invite the developer first, or remove the developer from the Cloudlet.", err.Error())
 
 		// add org1 to pool
 		op1 := ormapi.OrgCloudletPool{
@@ -844,6 +844,12 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 		_, status, err = mcClient.AddCloudletPoolMember(uri, tokenOper, &member)
 		require.Nil(t, err)
 		require.Equal(t, http.StatusOK, status)
+
+		// negative test - add without cloudlet specified
+		member.CloudletPoolMember.CloudletName = ""
+		_, status, err = mcClient.AddCloudletPoolMember(uri, tokenOper, &member)
+		require.NotNil(t, err)
+		require.Equal(t, "Invalid Cloudlet name", err.Error())
 
 		// clean up
 		status, err = mcClient.DeleteCloudletPoolAccessResponse(uri, tokenDev, &op1accept)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5514 AddCloudletPoolMember gives incorrect error when missing args

### Description

Makes sure all parameters are specified correctly. Refactored some of the code to avoid a bit of code duplication. If there are multiple developers, make sure they come out in sorted order for deterministic error messages.