### PR TITLE
EDGECLOUD-5538  Need configurable cluster-svc app flavor

### DIFF
--- a/ansible/roles/cluster-svc/templates/deploy.yml.j2
+++ b/ansible/roles/cluster-svc/templates/deploy.yml.j2
@@ -40,8 +40,6 @@ spec:
          - "{{ deployment_tag_override | default(deploy_environ) }}"
          - "--d"
          - "infra,notify,api"
-         - "--flavor"
-         - "x1.medium"
          - "--scrapeInterval"
          - "5s"
         env:

--- a/e2e-tests/data/mc_admin_show.yml
+++ b/e2e-tests/data/mc_admin_show.yml
@@ -256,7 +256,7 @@ regiondata:
       imagetype: Helm
       accessports: tcp:9090
       defaultflavor:
-        name: x1.medium
+        name: x1.small
       annotations: version=9.4.10
       deployment: helm
       delopt: AutoDelete


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5538  Need configurable cluster-svc app flavor

### Description
See https://github.com/mobiledgex/edge-cloud/pull/1474 for the edge-cloud changes.
Removed flavor arg from cluster-svc deployment template since we don't use it anymore.
e2e-test update.