### PR TITLE
EDGECLOUD-5551  VCD cloudlet metrics don't get recorded

### DIFF
--- a/crm-platforms/vcd/vcd-resources.go
+++ b/crm-platforms/vcd/vcd-resources.go
@@ -48,6 +48,7 @@ func (v *VcdPlatform) GetPlatformResourceInfo(ctx context.Context) (*vmlayer.Pla
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetPlatformResourceInfo")
 
 	var resources = vmlayer.PlatformResources{}
+	resources.CollectTime, _ = prototypes.TimestampProto(time.Now())
 	resinfo, err := v.GetCloudletInfraResourcesInfo(ctx)
 	if err != nil {
 		return nil, err

--- a/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
+++ b/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
@@ -198,6 +198,7 @@ func (s *ShepherdPlatform) GetPlatformStats(ctx context.Context) (shepherd_commo
 	if err != nil {
 		return cloudletMetric, err
 	}
+	log.SpanLog(ctx, log.DebugLevelMetrics, "Got PlatformStats", "platformResources", platformResources, "err", err)
 	cloudletMetric = shepherd_common.CloudletMetrics(*platformResources)
 	return cloudletMetric, nil
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5551  VCD cloudlet metrics don't get recorded

### Description
Set collect time for cloudlet metrics - without a timestamp we do not push the metrics to influxDB.