### PR TITLE
EDGECLOUD-5554: GPU driver state is not shown for Operator Manager

### DIFF
--- a/mc/orm/authz_show.go
+++ b/mc/orm/authz_show.go
@@ -295,6 +295,7 @@ func (s *AuthzGPUDriverShow) Filter(obj *edgeproto.GPUDriver) {
 	obj.Key = output.Key
 	obj.Properties = output.Properties
 	obj.Builds = output.Builds
+	obj.State = output.State
 	if output.LicenseConfig != "" {
 		obj.LicenseConfig = "*****"
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5554: GPU driver state is not shown for Operator Manager

### Description

* This state is required as it will be used for streaming GPU driver stream messages on UI console.