### PR TITLE
EDGECLOUD-5565: R3.0 Orange_Spain MXFUN-EDC99 cloudlet upgrade failed

### DIFF
--- a/crm-platforms/openstack/openstack-objs.go
+++ b/crm-platforms/openstack/openstack-objs.go
@@ -14,16 +14,16 @@ type OSServer struct {
 }
 
 type OSFlavorDetail struct {
-	Name        string                `json:"name"`
-	ID          string                `json:"id"`
-	RAM         int                   `json:"ram"`
-	Ephemeral   int                   `json:"OS-FLV-EXT-DATA:ephemeral"`
-	VCPUs       int                   `json:"vcpus"`
-	Disk        int                   `json:"disk"`
-	Public      bool                  `json:"os-flavor-access:is_public"`
-	Properties  string                `json:"properties"`
-	Swap        util.CustomJsonNumber `json:"swap"`
-	RXTX_Factor util.CustomJsonNumber `json:"rxtx factor"`
+	Name        string                     `json:"name"`
+	ID          string                     `json:"id"`
+	RAM         int                        `json:"ram"`
+	Ephemeral   int                        `json:"OS-FLV-EXT-DATA:ephemeral"`
+	VCPUs       int                        `json:"vcpus"`
+	Disk        int                        `json:"disk"`
+	Public      bool                       `json:"os-flavor-access:is_public"`
+	Properties  string                     `json:"properties"`
+	Swap        util.EmptyStringJsonNumber `json:"swap"`
+	RXTX_Factor util.EmptyStringJsonNumber `json:"rxtx factor"`
 }
 
 type OSAZone struct {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5565: R3.0 Orange_Spain MXFUN-EDC99 cloudlet upgrade failed

### Description

* Openstack output for `flavor list` returned inconsistent values for `swap` & `rxtx_factor`. It is supposed to return int & float respectively, which it does. But it also returns`""`. Fixed the JSON unmarshal code to handle this inconsistency. Defined custom JSON number type, which is essentially a `json.Number` which ignores empty string.
* Please refer this PR for the implementation of custom marshal code:
   https://github.com/mobiledgex/edge-cloud/pull/1482