### PR TITLE
Compact and defrag etcd after backup

### DIFF
--- a/ansible/mexdemo/list
+++ b/ansible/mexdemo/list
@@ -24,6 +24,7 @@ influxdb_volume_size=10Gi
 console_prod=yes
 events_elasticsearch_cleanup_age=183
 controller_replicas=1
+etcd_compact_after_backup=true
 
 [platform]
 localhost	ansible_connection=local

--- a/ansible/roles/etcd_backup_k8s/defaults/main.yml
+++ b/ansible/roles/etcd_backup_k8s/defaults/main.yml
@@ -1,0 +1,1 @@
+etcd_compact_after_backup: false

--- a/ansible/roles/etcd_backup_k8s/files/etcd-compact.sh
+++ b/ansible/roles/etcd_backup_k8s/files/etcd-compact.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+export ETCDCTL_API=3
+ENDPOINTS="http://mex-etcd-0.mex-etcd:2379,http://mex-etcd-1.mex-etcd:2379,http://mex-etcd-2.mex-etcd:2379"
+
+echo "==== BEFORE COMPACTION ===="
+etcdctl --endpoints="$ENDPOINTS" endpoint status -w table
+
+REV=$( etcdctl --endpoints="$ENDPOINTS" get abc123 -w json | sed -n 's/.*"revision":\([0-9]*\).*/\1/p' )
+echo "Current revision: $REV"
+
+COMPREV=$(( REV - 5000 ))
+echo "Compacting to $COMPREV"
+OUT=$( etcdctl --endpoints="$ENDPOINTS" compact "$COMPREV" 2>&1; ); RC=$?
+
+if [[ "$RC" != 0 ]]; then
+        if echo "$OUT" | grep "required revision has been compacted" >/dev/null 2>&1; then
+                echo "Compaction not necessary"
+                exit 0
+        fi
+
+        # Unknown error during compaction; abort
+        echo "$OUT" >&2
+        exit "$RC"
+fi
+
+echo "Defragging"
+etcdctl --endpoints="$ENDPOINTS" defrag
+
+echo "==== AFTER COMPACTION ===="
+etcdctl --endpoints="$ENDPOINTS" endpoint status -w table

--- a/ansible/roles/etcd_backup_k8s/tasks/main.yml
+++ b/ansible/roles/etcd_backup_k8s/tasks/main.yml
@@ -28,3 +28,26 @@
 - import_role:
     name: controller
     tasks_from: etcd-backup
+
+- block:
+  - name: Copy compact script to host
+    copy:
+      src: etcd-compact.sh
+      dest: /tmp/etcd-compact.sh
+    register: compact_script
+
+  - name: Copy compact script to etcd pod
+    command: "kubectl --kubeconfig {{ kubeconfig_file.path }} cp {{ compact_script.dest }} mex-etcd-0:{{ etcd_compact_script_path }}"
+    changed_when: false
+
+  - name: Compact etcd database
+    command: "kubectl --kubeconfig {{ kubeconfig_file.path }} exec mex-etcd-0 -- sh {{ etcd_compact_script_path }}"
+    register: compact_out
+
+  - debug:
+      msg: "{{ compact_out.stdout }}"
+
+  - debug:
+      msg: "STDERR: {{ compact_out.stderr }}"
+
+  when: etcd_compact_after_backup|bool

--- a/ansible/roles/etcd_backup_k8s/vars/main.yml
+++ b/ansible/roles/etcd_backup_k8s/vars/main.yml
@@ -1,0 +1,1 @@
+etcd_compact_script_path: /usr/bin/etcd-compact.sh


### PR DESCRIPTION
Support for compacting and defragging the etcd database after backup. This is controlled by the "etcd_compact_after_backup" flag, and is currently only configured on the main setup.
