### PR TITLE
EDGECLOUD-5584  cloudletusage metrics gives db error when using unknown cloudlet org

### DIFF
--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -682,6 +682,7 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 	goodPermTestClusterInst(t, mcClient, uri, tokenDev3, ctrl.Region, org1, tc3, dcnt)
 	goodPermTestMetrics(t, mcClient, uri, tokenDev3, tokenOper3, ctrl.Region, org1, org3)
 	goodPermTestEvents(t, mcClient, uri, tokenDev3, tokenOper3, ctrl.Region, org1, org3)
+	testInvalidOrgForCloudletUsage(t, mcClient, uri, tokenAd, ctrl.Region, org1)
 
 	// test users with different roles
 	goodPermTestCloudlet(t, mcClient, uri, tokenOper3, ctrl.Region, org3, ccount)

--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -891,7 +891,6 @@ func GetMetricsCommon(c echo.Context) error {
 		var db string
 		cmd, db = ClientAppUsageMetricsQuery(&in, cloudletList, settings)
 		dbNames = append(dbNames, db)
-
 	} else if strings.HasSuffix(c.Path(), "metrics/clientcloudletusage") {
 		in := ormapi.RegionClientCloudletUsageMetrics{}
 		_, err := ReadConn(c, &in)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5584  cloudletusage metrics gives db error when using unknown cloudlet org

### Description
Added a check that we found a platform type.
Also moved the code around to authorize request before generating a query