### PR TITLE
EDGECLOUD-5602 Edge-cloud docker baseimage update for security issues

### DIFF
--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y \
 	azure-cli=2.0.75-1~bionic \
 	google-cloud-sdk=267.0.0-0 \
 	kubectl=1.16.2-00 \
-	qemu-utils=1:2.11+dfsg-1ubuntu7.36
+	qemu-utils=1:2.11+dfsg-1ubuntu7.37
 
 COPY --from=python /python/ /
 


### PR DESCRIPTION
Rebuild pulls in the latest version of the ubuntu:18.04 image that the edge-cloud-base-image builds on.
