### PR TITLE
EDGECLOUD-5584  cloudletusage metrics gives db error when using unknown cloudlet org

### DIFF
--- a/mc/orm/influx.go
+++ b/mc/orm/influx.go
@@ -642,7 +642,7 @@ func getCloudletPlatformTypes(ctx context.Context, username, region string, key 
 		return nil, err
 	}
 	if len(platformTypes) == 0 {
-		return nil, fmt.Errorf("Unable to find platform for the cloudlet")
+		return nil, fmt.Errorf("Cloudlet does not exist")
 	}
 	return platformTypes, nil
 }

--- a/mc/orm/influx_test.go
+++ b/mc/orm/influx_test.go
@@ -269,7 +269,7 @@ func testInvalidOrgForCloudletUsage(t *testing.T, mcClient *mctestclient.Client,
 	invalidCloudlet := edgeproto.CloudletKey{Organization: "InvalidCloudletOrg"}
 	_, status, err := testPermShowCloudletUsage(mcClient, uri, adminToken, region, operOrg, "resourceusage", &invalidCloudlet)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Unable to find platform for the cloudlet")
+	require.Contains(t, err.Error(), "Cloudlet does not exist")
 	require.Equal(t, http.StatusBadRequest, status)
 }
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5584  cloudletusage metrics gives db error when using unknown cloudlet org

### Description
Make error more useful for end-user