### PR TITLE
fix GetAppInstRuntime in public cloudlet

### DIFF
--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -39,7 +39,8 @@ RUN apt-get update && apt-get install -y \
 	tzdata \
 	unzip \
 	vim-tiny \
-	wget
+	wget \
+	jq
 
 # Turn off auto-upgrades
 RUN sed -i 's/"1"/"0"/' /etc/apt/apt.conf.d/20auto-upgrades


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5616 for public cloudlet containers

### Description

ShowLogs and Terminal are not working for public cloudlet (managed k8s) platforms. The reason is that some time back the k8smgmt.GetAppInstRuntime code was modified to use the jq utillity to parse the pod output. For VM based deployments this is not a problem because the ssh client runs through ubuntu which has jq, but in the case of managed k8s the ssh client is just a local client and so to make this work we need jq installed in our docker image