### PR TITLE
Switch back to the full edge-cloud image for the controller

### DIFF
--- a/ansible/roles/controller/templates/deploy.yml.j2
+++ b/ansible/roles/controller/templates/deploy.yml.j2
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: "{{ edge_cloud_image }}-controller:{{ edge_cloud_version }}"
+        image: "{{ edge_cloud_image }}:{{ edge_cloud_version }}"
         imagePullPolicy: Always
         resources:
           requests:


### PR DESCRIPTION
Right now, the controller spins up crmserver instances internally
for Fake/Edgebox platforms.
