### PR TITLE
EDGECLOUD-5254 Validate limit or numsamples is a positive value

### DIFF
--- a/mc/orm/timedef.go
+++ b/mc/orm/timedef.go
@@ -50,12 +50,12 @@ func validateMetricsCommon(obj *ormapi.MetricsCommon) error {
 
 	// return error if Limit is a negative value
 	if obj.Limit < 0 {
-		return fmt.Errorf("Limit must be a positive value")
+		return fmt.Errorf("Limit cannot be negative")
 	}
 
 	// return error if NumSamples is a negative value
 	if obj.NumSamples < 0 {
-		return fmt.Errorf("NumSamples must be a positive value")
+		return fmt.Errorf("NumSamples cannot be negative")
 	}
 
 	// populate one of Last or NumSamples if neither are set


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5254 dme metrics with negative limit/numsamples needs better error handling

### Description
Added a check to ensure any 'limit' or 'numsamples' value is not negative.