### PR TITLE
Fix entrypoint in debug docker baseimages

### DIFF
--- a/ansible/roles/alertmanager/templates/docker-compose.yml.j2
+++ b/ansible/roles/alertmanager/templates/docker-compose.yml.j2
@@ -19,8 +19,8 @@ services:
     container_name: {{ sidecar_container }}
     image: {{ edge_cloud_image }}-alertmgr-sidecar:{{ edge_cloud_version }}
     restart: always
+    entrypoint: alertmgr-sidecar
     command:
-      - "alertmgr-sidecar"
       - "--httpAddr"
       - "0.0.0.0:9094"
       - "--alertmgrAddr"

--- a/ansible/roles/mc/tasks/main.yml
+++ b/ansible/roles/mc/tasks/main.yml
@@ -30,7 +30,6 @@
 - name: Compute mc command line
   set_fact:
     mc_args:
-      - mc
       - "-commonName"
       - "{{ inventory_hostname }}"
       - "-addr"
@@ -75,6 +74,7 @@
     name: "{{ mc_name }}"
     image: "{{ edge_cloud_image }}-mc:{{ edge_cloud_version }}"
     restart_policy: unless-stopped
+    entrypoint: mc
     command: "{{ mc_args }}"
     ports:
       - "127.0.0.1:{{ mc_api_port }}:{{ mc_api_port }}"

--- a/ansible/roles/notifyroot/tasks/main.yml
+++ b/ansible/roles/notifyroot/tasks/main.yml
@@ -8,8 +8,8 @@
     image: "{{ edge_cloud_image }}-notifyroot:{{ edge_cloud_version }}"
     restart_policy: unless-stopped
     network_mode: host
+    entrypoint: notifyroot
     command:
-      - notifyroot
       - "--commonName"
       - "{{ inventory_hostname }}"
       - "--notifyAddr"


### PR DESCRIPTION
Debug distroless baseimages have busybox as the default entrypoint. This
does not affect kubernetes, but when run using docker, the entrypoint
needs to be set explicitly.
