### PR TITLE
EDGECLOUD-5502 Removing extra period

### DIFF
--- a/e2e-tests/data/mc_ratelimitflow_showapp_fail_show.yml
+++ b/e2e-tests/data/mc_ratelimitflow_showapp_fail_show.yml
@@ -1,2 +1,2 @@
 - desc: AppApi[0]
-  msg: '/api/v1/auth/ctrl/ShowApp is rejected, please retry later. Error is: Exceeded rate of 1.000000 requests per second..'
+  msg: '/api/v1/auth/ctrl/ShowApp is rejected, please retry later. Error is: Exceeded rate of 1.000000 requests per second.'


### PR DESCRIPTION
### Issues Fixed

EDGECLOUD-5502 rate limit error from DME has incorrect punctuation

### Description
Removing extra period from show file to match this change made in edge-cloud: https://github.com/mobiledgex/edge-cloud/pull/1522