### PR TITLE
fix intel k8s baremetal issues

### DIFF
--- a/crm-platforms/k8s-baremetal/k8sbm-appinst.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-appinst.go
@@ -17,8 +17,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var DockerUser = "1000"
-
 func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.ClusterInst, app *edgeproto.App, appInst *edgeproto.AppInst, appInstFlavor *edgeproto.Flavor, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "CreateAppInst", "appInst", appInst)
 

--- a/crm-platforms/k8s-baremetal/k8sbm.go
+++ b/crm-platforms/k8s-baremetal/k8sbm.go
@@ -3,6 +3,7 @@ package k8sbm
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
@@ -16,6 +17,8 @@ import (
 )
 
 var k8sControlHostNodeType = "k8sbmcontrolhost"
+
+var DockerUser string
 
 type K8sBareMetalPlatform struct {
 	commonPf           infracommon.CommonPlatform
@@ -42,6 +45,23 @@ func (k *K8sBareMetalPlatform) IsCloudletServicesLocal() bool {
 	return false
 }
 
+func UpdateDockerUser(ctx context.Context, client ssh.Client) error {
+	log.SpanLog(ctx, log.DebugLevelInfra, "update docker user")
+	cmd := "id -u"
+	out, err := client.Output(cmd)
+	if err != nil {
+		return fmt.Errorf("Fail to get docker user id: %s - %v", out, err)
+	}
+	// we keep id as a string but make sure it parses as an int
+	_, err = strconv.ParseUint(out, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Fail to parse docker user id: %s - %v", out, err)
+	}
+	DockerUser = out
+	log.SpanLog(ctx, log.DebugLevelInfra, "set docker user", "DockerUser", DockerUser)
+	return nil
+}
+
 func (k *K8sBareMetalPlatform) Init(ctx context.Context, platformConfig *platform.PlatformConfig, caches *platform.Caches, updateCallback edgeproto.CacheUpdateCallback) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "Init start")
 	k.caches = caches
@@ -65,6 +85,10 @@ func (k *K8sBareMetalPlatform) Init(ctx context.Context, platformConfig *platfor
 	}
 
 	client, err := k.GetNodePlatformClient(ctx, &edgeproto.CloudletMgmtNode{Name: platformConfig.CloudletKey.String(), Type: k8sControlHostNodeType})
+	if err != nil {
+		return err
+	}
+	err = UpdateDockerUser(ctx, client)
 	if err != nil {
 		return err
 	}

--- a/infracommon/kubectl.go
+++ b/infracommon/kubectl.go
@@ -104,7 +104,7 @@ func CreateDockerRegistrySecret(ctx context.Context, client ssh.Client, kconf st
 		log.SpanLog(ctx, log.DebugLevelInfra, "CreateDockerRegistrySecret", "secretName", secretName, "namespace", namespace)
 		out, err = client.Output(cmd)
 		if err != nil {
-			if !strings.Contains(out, "AlreadyExists") {
+			if !strings.Contains(out, "already exists") {
 				return fmt.Errorf("can't add docker registry secret, %s, %v", out, err)
 			} else {
 				log.SpanLog(ctx, log.DebugLevelInfra, "warning, docker registry secret already exists.")
@@ -132,7 +132,7 @@ func CreateClusterConfigMap(ctx context.Context, client ssh.Client, clusterInst 
 
 	out, err := client.Output(cmd)
 	if err != nil {
-		if !strings.Contains(out, "AlreadyExists") {
+		if !strings.Contains(out, "already exists") {
 			return fmt.Errorf("can't add cluster ConfigMap cmd %s, %s, %v", cmd, out, err)
 		} else {
 			log.SpanLog(ctx, log.DebugLevelInfra, "warning, Cluster ConfigMap already exists.")


### PR DESCRIPTION
### Issues Fixed

* kubernetes version 1.21+ error message handling for already-existing secret 
* ubuntu userid for docker 

### Description

Addresses the following issues that Bibin experienced in trying to run our k8s baremetal platform for the Intel PoC. This is not Anthos, but Intel's bare metal platform. 

1) Intel is running version 1.21 of kubernetes. In this version the error that is returned when an already-existing secret is added changes from:
      Error from server (AlreadyExists): secrets "docker.mobiledgex.com" already exists
to:
     failed to create secret secrets "docker.mobiledgex.com" already exists

So the "already exists" part is common to the older and newer versions but "AlreadyExists" is no longer valid

2) the linux uid for the "ubuntu" user in his setup is 1001 and not 1000, presumably because there is some other user present. This caused an envoy issue because in k8s baremetal we were hardcoding the userid to run docker to 1000. This fix reads the user id from the system rather than hardcoding it