### PR TITLE
EDGECLOUD-5712  appinst alerts are not triggering for cpu mem and disk

### DIFF
--- a/ansible/roles/cluster-svc/templates/deploy.yml.j2
+++ b/ansible/roles/cluster-svc/templates/deploy.yml.j2
@@ -42,6 +42,7 @@ spec:
          - "infra,notify,api"
          - "--scrapeInterval"
          - "5s"
+         - "pluginRequired"
         env:
          - name: JAEGER_ENDPOINT
            value: "{{ jaeger_endpoint }}"


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5712  appinst alerts are not triggering for cpu mem and disk

### Description
Made plugin presence mandatory for cluster-svc deployments. This was missing and we didn't notice that `platforms.so` was missing from cluster-svc dockerfile.