### PR TITLE
Monitor Jaeger metrics

### DIFF
--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -305,6 +305,9 @@
 
     - import_role:
         name: telegraf
+      vars:
+        telegraf_additional_config:
+          - input/jaeger-metrics.conf.j2
       tags:
         - monitoring
         - setup

--- a/ansible/roles/jaeger/tasks/main.yml
+++ b/ansible/roles/jaeger/tasks/main.yml
@@ -48,6 +48,7 @@
         ports:
           - 127.0.0.1:24268:14268
           - 127.0.0.1:26686:16686
+          - 127.0.0.1:14269:14269
 
   when:
     - es_instance is not defined
@@ -74,6 +75,7 @@
         restart_policy: unless-stopped
         ports:
           - 127.0.0.1:24268:14268
+          - 127.0.0.1:14269:14269
         env:
           SPAN_STORAGE_TYPE: elasticsearch
           ES_SERVER_URLS: "{{ jaeger_es_url }}"
@@ -89,6 +91,7 @@
         restart_policy: unless-stopped
         ports:
           - 127.0.0.1:26686:16686
+          - 127.0.0.1:16687:16687
         env:
           SPAN_STORAGE_TYPE: elasticsearch
           ES_SERVER_URLS: "{{ jaeger_es_url }}"

--- a/ansible/roles/telegraf/templates/input/jaeger-metrics.conf.j2
+++ b/ansible/roles/telegraf/templates/input/jaeger-metrics.conf.j2
@@ -1,0 +1,8 @@
+[[inputs.prometheus]]
+{% if es_instance is defined %}
+  # Metrics endpoints for collector and query
+  urls = [ "http://127.0.0.1:14269/metrics", "http://127.0.0.1:16687/metrics" ]
+{% else %}
+  # Metrics endpoint for all-in-one jaeger
+  urls = [ "http://127.0.0.1:14269/metrics" ]
+{% endif %}


### PR DESCRIPTION
With this change, jaeger metrics will be logged to our internal
InfluxDB. The primary metric we are interested in the number of dropped
spans, which can happen if the backend data (like ElasticSearch) is
slow. Will add alerts for this as a separate commit after monitoring
the data for a few days.
