### PR TITLE
k8s cluster-inst node resource info

### DIFF
--- a/crm-platforms/k8s-baremetal/k8sbm-cloudlet.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-cloudlet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
 	"github.com/mobiledgex/edge-cloud/util"
 
@@ -272,4 +273,13 @@ func (k *K8sBareMetalPlatform) GetFlavorList(ctx context.Context) ([]*edgeproto.
 		}
 	}
 	return flavors, nil
+}
+
+func (k *K8sBareMetalPlatform) GetNodeInfos(ctx context.Context) ([]*edgeproto.NodeInfo, error) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "GetNodeInfos")
+	client, err := k.GetNodePlatformClient(ctx, &edgeproto.CloudletMgmtNode{Name: k.commonPf.PlatformConfig.CloudletKey.String(), Type: k8sControlHostNodeType})
+	if err != nil {
+		return nil, err
+	}
+	return k8smgmt.GetNodeInfos(ctx, client, "KUBECONFIG="+k.cloudletKubeConfig)
 }

--- a/crm-platforms/k8s-baremetal/k8sbm.go
+++ b/crm-platforms/k8s-baremetal/k8sbm.go
@@ -103,6 +103,10 @@ func (k *K8sBareMetalPlatform) GatherCloudletInfo(ctx context.Context, info *edg
 	log.SpanLog(ctx, log.DebugLevelInfra, "GatherCloudletInfo")
 	var err error
 	info.Flavors, err = k.GetFlavorList(ctx)
+	if err != nil {
+		return err
+	}
+	info.NodeInfos, err = k.GetNodeInfos(ctx)
 	return err
 }
 


### PR DESCRIPTION
More support code for multi-tenant kubernetes. This grabs node info for k8s-bare-metal and includes it in CloudletInfo. See https://github.com/mobiledgex/edge-cloud/pull/1535