### PR TITLE
Bump up teleport proxy to version 7.3.3

### DIFF
--- a/ansible/roles/teleport/defaults/main.yml
+++ b/ansible/roles/teleport/defaults/main.yml
@@ -1,1 +1,2 @@
+teleport_version: 7.3.3
 teleport_config: /etc/teleport.yaml

--- a/ansible/roles/teleport/tasks/main.yml
+++ b/ansible/roles/teleport/tasks/main.yml
@@ -13,10 +13,11 @@
 
 - name: Install teleport
   apt:
-    name: teleport
+    name: "teleport={{ teleport_version }}"
     state: present
     update_cache: yes
   become: yes
+  notify: Restart teleport
 
 - name: Install config file
   template:


### PR DESCRIPTION
Fixes a bug which broke "kubectl exec" to teleport-managed clusters.
https://github.com/gravitational/teleport/pull/8601

With this update, "kubectl exec" sessions are recorded and available in
the audit view:
https://teleport.mobiledgex.net/web/cluster/teleport.mobiledgex.net/recordings
