### PR TITLE
Harbor cert renewal fix

### DIFF
--- a/ansible/roles/harbor/tasks/main.yml
+++ b/ansible/roles/harbor/tasks/main.yml
@@ -8,15 +8,14 @@
       - hook_name: harbor_reload_hook
         hook_content: |
           #!/bin/bash
-          cd /home/ansible/harbor
-          docker-compose down -v
+          docker stop nginx
     post_renewal_hooks:
       - hook_name: harbor_reload_hook
         hook_content: |
           #!/bin/bash
-          cd /home/ansible/harbor
-          ./prepare --with-trivy --with-chartmuseum
-          docker-compose up -d
+          cp -f /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem /data/secret/cert/server.crt
+          cp -f /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem /data/secret/cert/server.key
+          docker start nginx
   tags: setup
 
 - name: Configure the docker daemon


### PR DESCRIPTION
The "recommended" way of updating TLS certs on renewal messed up harbor's
docker network and ended up needing a reboot to fix.  Switching to updating
just the nginx service of harbor instead of a complete reconfigure for cert
renewals.
