### PR TITLE
EDGECLOUD-5790  App instance health status wrongly shows “Cloudletoffline” status for an online & operational cloudlet

### DIFF
--- a/e2e-tests/testfiles/alerttest.yml
+++ b/e2e-tests/testfiles/alerttest.yml
@@ -370,7 +370,6 @@ tests:
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'
       yaml2: '{{datadir2}}/mcappdata_empty.yml'
-      # mcdata-xind keeps health check status
       filetype: mcalerts
 
   - name: check that the app on the cloudlet is back online
@@ -382,6 +381,7 @@ tests:
     compareyaml:
       yaml1: '{{outputdir}}/show-commands.yml'
       yaml2: '{{datadir2}}/cloudlet_alert_appinst_online_show.yml'
+      # mcdata-xind keeps health check status
       filetype: mcdata-xind
 
   - name: enable resource quotas alerts


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5790  App instance health status wrongly shows “CloudletOffline” status for an online & operational cloudlet

### Description

E2e tests to validate cleanup of appinst cloudlet offline health check.
See https://github.com/mobiledgex/edge-cloud/pull/1551 for actual code changes