### PR TITLE
EDGECLOUD-5765:update fed plat GetConsoleUrl signature

### DIFF
--- a/crm-platforms/federation/federation_pf.go
+++ b/crm-platforms/federation/federation_pf.go
@@ -128,7 +128,7 @@ func (f *FederationPlatform) GetContainerCommand(ctx context.Context, clusterIns
 }
 
 // Get the console URL of the VM app
-func (f *FederationPlatform) GetConsoleUrl(ctx context.Context, app *edgeproto.App) (string, error) {
+func (f *FederationPlatform) GetConsoleUrl(ctx context.Context, app *edgeproto.App, appInst *edgeproto.AppInst) (string, error) {
 	return "", nil
 }
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5765 add cloudlet name to vmApp name

### Description
Update federation platform GetConsoleUrl signature to include appInst. 
