### PR TITLE
EDGECLOUD-5710  usage with unknown app/cloudlet returns columns only

### DIFF
--- a/mc/orm/cloudletpool_usage.go
+++ b/mc/orm/cloudletpool_usage.go
@@ -150,7 +150,13 @@ func GetCloudletPoolUsageCommon(c echo.Context) error {
 		log.SpanLog(ctx, log.DebugLevelMetrics, "usage args", "cluster", clusterUsage, "app", appUsage, "list", cloudletList)
 
 		usage := ormapi.AllMetrics{
-			Data: []ormapi.MetricData{*clusterUsage, *appUsage},
+			Data: []ormapi.MetricData{},
+		}
+		if len(clusterUsage.Series[0].Values) != 0 {
+			usage.Data = append(usage.Data, *clusterUsage)
+		}
+		if len(appUsage.Series[0].Values) != 0 {
+			usage.Data = append(usage.Data, *appUsage)
 		}
 		return ormutil.SetReply(c, &usage)
 	} else {

--- a/mc/orm/influx_usage.go
+++ b/mc/orm/influx_usage.go
@@ -759,10 +759,11 @@ func GetUsageCommon(c echo.Context) error {
 	} else {
 		return echo.ErrNotFound
 	}
-
-	payload := ormapi.StreamPayload{}
-	payload.Data = &[]ormapi.MetricData{*usage}
-	WriteStream(c, &payload)
-
-	return nil
+	billingusage := ormapi.AllMetrics{
+		Data: []ormapi.MetricData{},
+	}
+	if len(usage.Series[0].Values) != 0 {
+		billingusage.Data = append(billingusage.Data, *usage)
+	}
+	return ormutil.SetReply(c, &billingusage)
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5710  usage with unknown app/cloudlet returns columns only

### Description

Don't send anything back if no data points are found for app/cluster/cloudlet usage instead of just a row of influxDB columns. In addition I fixed app/cluster usage apis to return a complete chunk instead of pretending to be a streaming api.