### PR TITLE
Bundle weave manifest in mobiledgex package

### DIFF
--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.6.0
+VERSION = 4.6.1
 DISTRIBUTION = cirrus
 COMPONENT = main
 
@@ -33,6 +33,7 @@ setup_files: \
 	$(PKGDIR)/etc/mobiledgex/get-flavor.sh \
 	$(PKGDIR)/etc/mobiledgex/setup-chef.sh \
 	$(PKGDIR)/etc/mobiledgex/install-gpu-driver.sh \
+	$(PKGDIR)/etc/mobiledgex/weave-2.8.1.yml \
 	$(PKGDIR)/etc/systemd/system/mobiledgex.service \
 	$(PKGDIR)/usr/local/bin/mobiledgex-init.sh
 

--- a/openstack-tenant/packages/mobiledgex/install-k8s-master.sh
+++ b/openstack-tenant/packages/mobiledgex/install-k8s-master.sh
@@ -50,42 +50,8 @@ while [ $? -ne 0 ] ; do
     sleep 7
     kubectl version
 done
-#kubectl apply -f https://raw.githubusercontent.com/projectcalico/canal/master/k8s-install/1.7/rbac.yaml
-#if [ $? -ne 0 ]; then
-#    echo kubectl exited with error installing rbac
-#    exit 1
-#fi
-#kubectl apply -f https://raw.githubusercontent.com/projectcalico/canal/master/k8s-install/1.7/canal.yaml
-# use fixed version. the original will fail validation
-#kubectl apply -f https://mobiledgex:sandhill@registry.mobiledgex.net:8000/mobiledgex/canal.yaml
-#curl https://docs.projectcalico.org/v3.4/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml -O
-#POD_CIDR="10.244.0.0/16" sed -i -e "s?192.168.0.0/16?$POD_CIDR?g" calico.yaml
-#kubectl apply -f calico.yaml
-#if [ $? -ne 0 ]; then
-#    #    echo kubectl exited with error installing canal
-#    echo kubectl exited with error installing canal
-#    exit 1
-#fi
-# the pod network plugin has to be done for coredns to come up
 
-
-echo Checking Weave CNI download URL is available
-TIMEOUT=$((SECONDS+300))
-nc cloud.weave.works 443 -v -z -w 5 
-while [ $? -ne 0 ] ; do
-    # retry until timeout
-    if [ $SECONDS -gt $TIMEOUT ] ; then
-        echo Timed out waiting for Weave CNI
-        exit 1
-    fi
-    echo Waiting to check Weave URL available - now $SECONDS timeout $TIMEOUT
-    sleep 5
-    nc cloud.weave.works 443 -v -z -w 5
-done
-
-echo Weave URL is reachable, install CNI
-
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+kubectl apply -f "/etc/mobiledgex/weave-2.8.1.yml"
 if [ $? -ne 0 ] ; then
     echo Failed to install Weave
     exit 1

--- a/openstack-tenant/packages/mobiledgex/weave-2.8.1.yml
+++ b/openstack-tenant/packages/mobiledgex/weave-2.8.1.yml
@@ -1,0 +1,275 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "original-request": {
+              "url": "/k8s/v1.16/net.yaml?k8s-version=Q2xpZW50IFZlcnNpb246IHZlcnNpb24uSW5mb3tNYWpvcjoiMSIsIE1pbm9yOiIxOCIsIEdpdFZlcnNpb246InYxLjE4LjIwIiwgR2l0Q29tbWl0OiIxZjNlMTliN2JlYjFjYzAxMTAyNTU2NjhjNDIzOGVkNjNkYWRiN2FkIiwgR2l0VHJlZVN0YXRlOiJjbGVhbiIsIEJ1aWxkRGF0ZToiMjAyMS0wNi0xNlQxMjo1ODo1MVoiLCBHb1ZlcnNpb246ImdvMS4xMy4xNSIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9ClNlcnZlciBWZXJzaW9uOiB2ZXJzaW9uLkluZm97TWFqb3I6IjEiLCBNaW5vcjoiMTgiLCBHaXRWZXJzaW9uOiJ2MS4xOC4yMCIsIEdpdENvbW1pdDoiMWYzZTE5YjdiZWIxY2MwMTEwMjU1NjY4YzQyMzhlZDYzZGFkYjdhZCIsIEdpdFRyZWVTdGF0ZToiY2xlYW4iLCBCdWlsZERhdGU6IjIwMjEtMDYtMTZUMTI6NTE6MTdaIiwgR29WZXJzaW9uOiJnbzEuMTMuMTUiLCBDb21waWxlcjoiZ2MiLCBQbGF0Zm9ybToibGludXgvYW1kNjQifQo=",
+              "date": "Wed Nov 17 2021 12:21:10 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+      labels:
+        name: weave-net
+      namespace: kube-system
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "original-request": {
+              "url": "/k8s/v1.16/net.yaml?k8s-version=Q2xpZW50IFZlcnNpb246IHZlcnNpb24uSW5mb3tNYWpvcjoiMSIsIE1pbm9yOiIxOCIsIEdpdFZlcnNpb246InYxLjE4LjIwIiwgR2l0Q29tbWl0OiIxZjNlMTliN2JlYjFjYzAxMTAyNTU2NjhjNDIzOGVkNjNkYWRiN2FkIiwgR2l0VHJlZVN0YXRlOiJjbGVhbiIsIEJ1aWxkRGF0ZToiMjAyMS0wNi0xNlQxMjo1ODo1MVoiLCBHb1ZlcnNpb246ImdvMS4xMy4xNSIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9ClNlcnZlciBWZXJzaW9uOiB2ZXJzaW9uLkluZm97TWFqb3I6IjEiLCBNaW5vcjoiMTgiLCBHaXRWZXJzaW9uOiJ2MS4xOC4yMCIsIEdpdENvbW1pdDoiMWYzZTE5YjdiZWIxY2MwMTEwMjU1NjY4YzQyMzhlZDYzZGFkYjdhZCIsIEdpdFRyZWVTdGF0ZToiY2xlYW4iLCBCdWlsZERhdGU6IjIwMjEtMDYtMTZUMTI6NTE6MTdaIiwgR29WZXJzaW9uOiJnbzEuMTMuMTUiLCBDb21waWxlcjoiZ2MiLCBQbGF0Zm9ybToibGludXgvYW1kNjQifQo=",
+              "date": "Wed Nov 17 2021 12:21:10 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+      labels:
+        name: weave-net
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+          - namespaces
+          - nodes
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ''
+        resources:
+          - nodes/status
+        verbs:
+          - patch
+          - update
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "original-request": {
+              "url": "/k8s/v1.16/net.yaml?k8s-version=Q2xpZW50IFZlcnNpb246IHZlcnNpb24uSW5mb3tNYWpvcjoiMSIsIE1pbm9yOiIxOCIsIEdpdFZlcnNpb246InYxLjE4LjIwIiwgR2l0Q29tbWl0OiIxZjNlMTliN2JlYjFjYzAxMTAyNTU2NjhjNDIzOGVkNjNkYWRiN2FkIiwgR2l0VHJlZVN0YXRlOiJjbGVhbiIsIEJ1aWxkRGF0ZToiMjAyMS0wNi0xNlQxMjo1ODo1MVoiLCBHb1ZlcnNpb246ImdvMS4xMy4xNSIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9ClNlcnZlciBWZXJzaW9uOiB2ZXJzaW9uLkluZm97TWFqb3I6IjEiLCBNaW5vcjoiMTgiLCBHaXRWZXJzaW9uOiJ2MS4xOC4yMCIsIEdpdENvbW1pdDoiMWYzZTE5YjdiZWIxY2MwMTEwMjU1NjY4YzQyMzhlZDYzZGFkYjdhZCIsIEdpdFRyZWVTdGF0ZToiY2xlYW4iLCBCdWlsZERhdGU6IjIwMjEtMDYtMTZUMTI6NTE6MTdaIiwgR29WZXJzaW9uOiJnbzEuMTMuMTUiLCBDb21waWxlcjoiZ2MiLCBQbGF0Zm9ybToibGludXgvYW1kNjQifQo=",
+              "date": "Wed Nov 17 2021 12:21:10 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+      labels:
+        name: weave-net
+    roleRef:
+      kind: ClusterRole
+      name: weave-net
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "original-request": {
+              "url": "/k8s/v1.16/net.yaml?k8s-version=Q2xpZW50IFZlcnNpb246IHZlcnNpb24uSW5mb3tNYWpvcjoiMSIsIE1pbm9yOiIxOCIsIEdpdFZlcnNpb246InYxLjE4LjIwIiwgR2l0Q29tbWl0OiIxZjNlMTliN2JlYjFjYzAxMTAyNTU2NjhjNDIzOGVkNjNkYWRiN2FkIiwgR2l0VHJlZVN0YXRlOiJjbGVhbiIsIEJ1aWxkRGF0ZToiMjAyMS0wNi0xNlQxMjo1ODo1MVoiLCBHb1ZlcnNpb246ImdvMS4xMy4xNSIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9ClNlcnZlciBWZXJzaW9uOiB2ZXJzaW9uLkluZm97TWFqb3I6IjEiLCBNaW5vcjoiMTgiLCBHaXRWZXJzaW9uOiJ2MS4xOC4yMCIsIEdpdENvbW1pdDoiMWYzZTE5YjdiZWIxY2MwMTEwMjU1NjY4YzQyMzhlZDYzZGFkYjdhZCIsIEdpdFRyZWVTdGF0ZToiY2xlYW4iLCBCdWlsZERhdGU6IjIwMjEtMDYtMTZUMTI6NTE6MTdaIiwgR29WZXJzaW9uOiJnbzEuMTMuMTUiLCBDb21waWxlcjoiZ2MiLCBQbGF0Zm9ybToibGludXgvYW1kNjQifQo=",
+              "date": "Wed Nov 17 2021 12:21:10 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+      labels:
+        name: weave-net
+      namespace: kube-system
+    rules:
+      - apiGroups:
+          - ''
+        resourceNames:
+          - weave-net
+        resources:
+          - configmaps
+        verbs:
+          - get
+          - update
+      - apiGroups:
+          - ''
+        resources:
+          - configmaps
+        verbs:
+          - create
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "original-request": {
+              "url": "/k8s/v1.16/net.yaml?k8s-version=Q2xpZW50IFZlcnNpb246IHZlcnNpb24uSW5mb3tNYWpvcjoiMSIsIE1pbm9yOiIxOCIsIEdpdFZlcnNpb246InYxLjE4LjIwIiwgR2l0Q29tbWl0OiIxZjNlMTliN2JlYjFjYzAxMTAyNTU2NjhjNDIzOGVkNjNkYWRiN2FkIiwgR2l0VHJlZVN0YXRlOiJjbGVhbiIsIEJ1aWxkRGF0ZToiMjAyMS0wNi0xNlQxMjo1ODo1MVoiLCBHb1ZlcnNpb246ImdvMS4xMy4xNSIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9ClNlcnZlciBWZXJzaW9uOiB2ZXJzaW9uLkluZm97TWFqb3I6IjEiLCBNaW5vcjoiMTgiLCBHaXRWZXJzaW9uOiJ2MS4xOC4yMCIsIEdpdENvbW1pdDoiMWYzZTE5YjdiZWIxY2MwMTEwMjU1NjY4YzQyMzhlZDYzZGFkYjdhZCIsIEdpdFRyZWVTdGF0ZToiY2xlYW4iLCBCdWlsZERhdGU6IjIwMjEtMDYtMTZUMTI6NTE6MTdaIiwgR29WZXJzaW9uOiJnbzEuMTMuMTUiLCBDb21waWxlcjoiZ2MiLCBQbGF0Zm9ybToibGludXgvYW1kNjQifQo=",
+              "date": "Wed Nov 17 2021 12:21:10 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+      labels:
+        name: weave-net
+      namespace: kube-system
+    roleRef:
+      kind: Role
+      name: weave-net
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: weave-net
+        namespace: kube-system
+  - apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: weave-net
+      annotations:
+        cloud.weave.works/launcher-info: |-
+          {
+            "original-request": {
+              "url": "/k8s/v1.16/net.yaml?k8s-version=Q2xpZW50IFZlcnNpb246IHZlcnNpb24uSW5mb3tNYWpvcjoiMSIsIE1pbm9yOiIxOCIsIEdpdFZlcnNpb246InYxLjE4LjIwIiwgR2l0Q29tbWl0OiIxZjNlMTliN2JlYjFjYzAxMTAyNTU2NjhjNDIzOGVkNjNkYWRiN2FkIiwgR2l0VHJlZVN0YXRlOiJjbGVhbiIsIEJ1aWxkRGF0ZToiMjAyMS0wNi0xNlQxMjo1ODo1MVoiLCBHb1ZlcnNpb246ImdvMS4xMy4xNSIsIENvbXBpbGVyOiJnYyIsIFBsYXRmb3JtOiJsaW51eC9hbWQ2NCJ9ClNlcnZlciBWZXJzaW9uOiB2ZXJzaW9uLkluZm97TWFqb3I6IjEiLCBNaW5vcjoiMTgiLCBHaXRWZXJzaW9uOiJ2MS4xOC4yMCIsIEdpdENvbW1pdDoiMWYzZTE5YjdiZWIxY2MwMTEwMjU1NjY4YzQyMzhlZDYzZGFkYjdhZCIsIEdpdFRyZWVTdGF0ZToiY2xlYW4iLCBCdWlsZERhdGU6IjIwMjEtMDYtMTZUMTI6NTE6MTdaIiwgR29WZXJzaW9uOiJnbzEuMTMuMTUiLCBDb21waWxlcjoiZ2MiLCBQbGF0Zm9ybToibGludXgvYW1kNjQifQo=",
+              "date": "Wed Nov 17 2021 12:21:10 GMT+0000 (UTC)"
+            },
+            "email-address": "support@weave.works"
+          }
+      labels:
+        name: weave-net
+      namespace: kube-system
+    spec:
+      minReadySeconds: 5
+      selector:
+        matchLabels:
+          name: weave-net
+      template:
+        metadata:
+          labels:
+            name: weave-net
+        spec:
+          containers:
+            - name: weave
+              command:
+                - /home/weave/launch.sh
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+                - name: INIT_CONTAINER
+                  value: 'true'
+              image: 'docker.mobiledgex.net/mobiledgex/mobiledgex_public/weaveworks/weave-kube:2.8.1'
+              readinessProbe:
+                httpGet:
+                  host: 127.0.0.1
+                  path: /status
+                  port: 6784
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 100Mi
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: weavedb
+                  mountPath: /weavedb
+                - name: dbus
+                  mountPath: /host/var/lib/dbus
+                - name: machine-id
+                  mountPath: /host/etc/machine-id
+                  readOnly: true
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+            - name: weave-npc
+              env:
+                - name: HOSTNAME
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: spec.nodeName
+              image: 'docker.mobiledgex.net/mobiledgex/mobiledgex_public/weaveworks/weave-npc:2.8.1'
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 100Mi
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          initContainers:
+            - name: weave-init
+              command:
+                - /home/weave/init.sh
+              image: 'docker.mobiledgex.net/mobiledgex/mobiledgex_public/weaveworks/weave-kube:2.8.1'
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: cni-bin
+                  mountPath: /host/opt
+                - name: cni-bin2
+                  mountPath: /host/home
+                - name: cni-conf
+                  mountPath: /host/etc
+                - name: lib-modules
+                  mountPath: /lib/modules
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+          priorityClassName: system-node-critical
+          restartPolicy: Always
+          securityContext:
+            seLinuxOptions: {}
+          serviceAccountName: weave-net
+          tolerations:
+            - effect: NoSchedule
+              operator: Exists
+            - effect: NoExecute
+              operator: Exists
+          volumes:
+            - name: weavedb
+              hostPath:
+                path: /var/lib/weave
+            - name: cni-bin
+              hostPath:
+                path: /opt
+            - name: cni-bin2
+              hostPath:
+                path: /home
+            - name: cni-conf
+              hostPath:
+                path: /etc
+            - name: dbus
+              hostPath:
+                path: /var/lib/dbus
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+            - name: machine-id
+              hostPath:
+                path: /etc/machine-id
+                type: FileOrCreate
+            - name: xtables-lock
+              hostPath:
+                path: /run/xtables.lock
+                type: FileOrCreate
+      updateStrategy:
+        type: RollingUpdate

--- a/openstack-tenant/packer/setup.sh
+++ b/openstack-tenant/packer/setup.sh
@@ -119,6 +119,10 @@ machine artifactory.mobiledgex.net login ${APT_USER} password ${APT_PASS}
 machine apt.mobiledgex.net login ${APT_USER} password ${APT_PASS}
 EOT
 
+sudo tee /etc/apt/apt.conf.d/10cert-validation <<EOT
+Acquire::https::Verify-Peer "false";
+EOT
+
 log "Set up the APT keys"
 curl -s https://${APT_USER}:${APT_PASS}@artifactory.mobiledgex.net/artifactory/api/gpg/key/public | sudo apt-key add -
 curl -s https://${APT_USER}:${APT_PASS}@apt.mobiledgex.net/gpg.key | sudo apt-key add -

--- a/version/package-version.go
+++ b/version/package-version.go
@@ -1,3 +1,3 @@
 package version
 
-var MobiledgeXPackageVersion = "4.6.0"
+var MobiledgeXPackageVersion = "4.6.1"

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -42,7 +42,7 @@ const MINIMUM_VCPUS uint64 = 2
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.6.0"
+var MEXInfraVersion = "4.6.1"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
The upstream weave manifest was broken and referred to an image tag which didn't exist, breaking all our kubernetes app deployments.

The problem has since been fixed and the docker image is available again, but it might be good to try and keep our dependencies within our control.

This change bundles the weave manifest into the `mobiledgex` package, and replaces all references to the external `ghcr.io` registry with our internal `mobiledgex_public` registry. The weave 2.8.1 images have been republished there.