### PR TITLE
renaming CreateDeveloperDefinedNamespaces

### DIFF
--- a/crm-platforms/edgebox/edgebox-appinst.go
+++ b/crm-platforms/edgebox/edgebox-appinst.go
@@ -67,7 +67,7 @@ func (e *EdgeboxPlatform) CreateAppInst(ctx context.Context, clusterInst *edgepr
 			if err != nil {
 				return err
 			}
-			err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
+			err = k8smgmt.CreateAllNamespaces(ctx, client, names)
 			if err != nil {
 				return err
 			}
@@ -154,7 +154,7 @@ func (e *EdgeboxPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgepr
 			if err != nil {
 				return err
 			}
-			err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
+			err = k8smgmt.CreateAllNamespaces(ctx, client, names)
 			if err != nil {
 				return err
 			}

--- a/crm-platforms/k8s-baremetal/k8sbm-appinst.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-appinst.go
@@ -45,7 +45,7 @@ func (k *K8sBareMetalPlatform) CreateAppInst(ctx context.Context, clusterInst *e
 
 		updateCallback(edgeproto.UpdateTask, "Setting up registry secret")
 		for _, imagePath := range names.ImagePaths {
-			err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
+			err = k8smgmt.CreateAllNamespaces(ctx, client, names)
 			if err != nil {
 				return err
 			}

--- a/vmlayer/appinst.go
+++ b/vmlayer/appinst.go
@@ -218,7 +218,7 @@ func (v *VMPlatform) CreateAppInst(ctx context.Context, clusterInst *edgeproto.C
 		if err != nil {
 			return err
 		}
-		err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
+		err = k8smgmt.CreateAllNamespaces(ctx, client, names)
 		if err != nil {
 			return err
 		}
@@ -756,7 +756,7 @@ func (v *VMPlatform) UpdateAppInst(ctx context.Context, clusterInst *edgeproto.C
 			if err != nil {
 				return err
 			}
-			err = k8smgmt.CreateDeveloperDefinedNamespaces(ctx, client, names)
+			err = k8smgmt.CreateAllNamespaces(ctx, client, names)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5776 unable to deploy an appinst on anthos

### Description

see edge-cloud PR for details, this is just to do the renaming of CreateDeveloperDefinedNamespaces within infra