### PR TITLE
fix k8s baremetal DNS

### DIFF
--- a/crm-platforms/k8s-baremetal/k8sbm-lb.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-lb.go
@@ -22,10 +22,9 @@ type LbInfo struct {
 	LbListenDevName string
 }
 
-func (k *K8sBareMetalPlatform) GetSharedLBName(ctx context.Context, key *edgeproto.CloudletKey) string {
-	log.SpanLog(ctx, log.DebugLevelInfra, "GetSharedLBName", "key", key)
-	name := cloudcommon.GetRootLBFQDN(key, k.commonPf.PlatformConfig.AppDNSRoot)
-	return name
+// GetSharedLBName returns the "dedicated" FQDN of the default cluster
+func (k *K8sBareMetalPlatform) GetSharedLBName(ctx context.Context, cloudletKey *edgeproto.CloudletKey) string {
+	return cloudcommon.GetDedicatedLBFQDN(cloudletKey, &k.GetDefaultCluster(cloudletKey).Key.ClusterKey, k.commonPf.PlatformConfig.AppDNSRoot)
 }
 
 func (k *K8sBareMetalPlatform) GetLbName(ctx context.Context, appInst *edgeproto.AppInst) string {

--- a/crm-platforms/k8s-baremetal/k8sbm.go
+++ b/crm-platforms/k8s-baremetal/k8sbm.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/mobiledgex/edge-cloud-infra/infracommon"
+	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/k8smgmt"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform"
 	"github.com/mobiledgex/edge-cloud/cloud-resource-manager/platform/pc"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
@@ -33,8 +34,21 @@ type K8sBareMetalPlatform struct {
 	externalIps        []string
 }
 
+func (k *K8sBareMetalPlatform) GetDefaultCluster(cloudletKey *edgeproto.CloudletKey) *edgeproto.ClusterInst {
+	defCluster := edgeproto.ClusterInst{
+		Key: edgeproto.ClusterInstKey{
+			CloudletKey: *cloudletKey,
+			ClusterKey: edgeproto.ClusterKey{
+				Name: cloudcommon.DefaultClust,
+			},
+		},
+	}
+	return &defCluster
+}
+
+// GetCloudletKubeConfig returns the kconf for the default cluster
 func (k *K8sBareMetalPlatform) GetCloudletKubeConfig(cloudletKey *edgeproto.CloudletKey) string {
-	return fmt.Sprintf("%s-%s", cloudletKey.Name, "cloudlet-kubeconfig")
+	return k8smgmt.GetKconfName(k.GetDefaultCluster(cloudletKey))
 }
 
 func (o *K8sBareMetalPlatform) GetFeatures() *platform.Features {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5844 DNS not correct for shared app instance on anthos

### Description

Fix DNS entry for k8s baremetal. Previously the DNS entry was similar to non-MT in that it began with "shared" but with the new scheme it uses the default cluster name. Also fix the cloudlet k8s config file, as there were 2 different conventions being used which was leading to 2 files being needed for the same thing. 