### PR TITLE
EDGECLOUD-5846: Shepherd keeps restarting after upgrade to HF4

### DIFF
--- a/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
+++ b/shepherd/shepherd_platform/shepherd_vmprovider/shepherd_vmprovider.go
@@ -54,6 +54,7 @@ func (s *ShepherdPlatform) Init(ctx context.Context, pc *platform.PlatformConfig
 		return err
 	}
 
+	s.VMPlatform.Caches = platformCaches
 	s.VMPlatform.VMProvider.InitData(ctx, platformCaches)
 	// Override cloudlet internal updated callback so CloudletAccessToken updates from the CRM can be stored
 	platformCaches.CloudletInternalCache.SetUpdatedCb(s.vmProviderCloudletCb)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5846: Shepherd keeps restarting after upgrade to HF4

### Description

* Shepherd was crashing at this line:
```
        appInst := edgeproto.AppInst{}
        if !s.VMPlatform.Caches.AppInstCache.Get(key, &appInst) { # <----- CRASH
                return appMetrics, key.NotFoundError()
        }
```
* This was happening because as part of `InitData` we were not initializing `Caches` obj