### PR TITLE
Teleport ops access

### DIFF
--- a/ansible/roles/teleport/tasks/main.yml
+++ b/ansible/roles/teleport/tasks/main.yml
@@ -83,6 +83,18 @@
   become: yes
   when: audit_role is changed
 
+- name: Set up Ops access role
+  template:
+    src: ops-access-role.yaml.j2
+    dest: "{{ teleport_config_dir.path }}/ops-access-role.yaml"
+  become: yes
+  register: ops_role
+
+- name: Apply Ops access role
+  command: "tctl create -f {{ ops_role.dest }}"
+  become: yes
+  when: ops_role is changed
+
 - name: Set up Telefonica access role
   template:
     src: telefonica-access-role.yaml.j2

--- a/ansible/roles/teleport/templates/github.yaml.j2
+++ b/ansible/roles/teleport/templates/github.yaml.j2
@@ -32,6 +32,11 @@ spec:
         - audit-access
 
     - organization: mobiledgex
+      team: teleport-ops
+      logins:
+        - ops
+
+    - organization: mobiledgex
       team: infra-dev
       logins:
         - infra-dev

--- a/ansible/roles/teleport/templates/ops-access-role.yaml.j2
+++ b/ansible/roles/teleport/templates/ops-access-role.yaml.j2
@@ -1,0 +1,10 @@
+kind: role
+version: v4
+metadata:
+  name: ops
+spec:
+  allow:
+    logins:
+      - ubuntu
+    node_labels:
+      env: ops


### PR DESCRIPTION
Primarily used for audited, session-recorded access to jumphosts right now.

