### PR TITLE
Per DT, removing DEFAULT profile names. Fixing LOW_LATENCY

### DIFF
--- a/operator-api-gw/tdg/tdg.go
+++ b/operator-api-gw/tdg/tdg.go
@@ -132,6 +132,8 @@ func (o *OperatorApiGw) DeletePrioritySession(ctx context.Context, priorityType 
 
 func (o *OperatorApiGw) LookupQosParm(qos string) string {
 	switch qos {
+	case "QOS_NO_PRIORITY":
+		return "QOS_NO_PRIORITY"
 	case "QOS_LOW_LATENCY":
 		return "LOW_LATENCY"
 	case "QOS_THROUGHPUT_DOWN_S":


### PR DESCRIPTION
### Description
DT has removed the DEFAULT profile names from their API, so removing them from the DME. Also fixing LOW_LATENCY which was wrongly entered as LATENCY_LOW.