### PR TITLE
fix fake platform update clusterinst resources

### DIFF
--- a/e2e-tests/data/autoscale_cluster_nodes2.yml
+++ b/e2e-tests/data/autoscale_cluster_nodes2.yml
@@ -30,11 +30,11 @@ regiondata:
           type: cluster-k8s-node
           status: ACTIVE
           infraflavor: x1.small
-        - name: smallcluster.tmus-cloud-1.tmus.fake.net
-          type: rootlb
-          status: ACTIVE
-          infraflavor: x1.small
         - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
           type: cluster-k8s-node
+          status: ACTIVE
+          infraflavor: x1.small
+        - name: smallcluster.tmus-cloud-1.tmus.fake.net
+          type: rootlb
           status: ACTIVE
           infraflavor: x1.small

--- a/e2e-tests/data/autoscale_cluster_nodes3.yml
+++ b/e2e-tests/data/autoscale_cluster_nodes3.yml
@@ -30,15 +30,15 @@ regiondata:
           type: cluster-k8s-node
           status: ACTIVE
           infraflavor: x1.small
-        - name: smallcluster.tmus-cloud-1.tmus.fake.net
-          type: rootlb
-          status: ACTIVE
-          infraflavor: x1.small
         - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
           type: cluster-k8s-node
           status: ACTIVE
           infraflavor: x1.small
         - name: fake-node-3-tmus-cloud-1-smallcluster-acmeappco
           type: cluster-k8s-node
+          status: ACTIVE
+          infraflavor: x1.small
+        - name: smallcluster.tmus-cloud-1.tmus.fake.net
+          type: rootlb
           status: ACTIVE
           infraflavor: x1.small

--- a/e2e-tests/data/autoscale_cluster_nodes4.yml
+++ b/e2e-tests/data/autoscale_cluster_nodes4.yml
@@ -30,10 +30,6 @@ regiondata:
           type: cluster-k8s-node
           status: ACTIVE
           infraflavor: x1.small
-        - name: smallcluster.tmus-cloud-1.tmus.fake.net
-          type: rootlb
-          status: ACTIVE
-          infraflavor: x1.small
         - name: fake-node-2-tmus-cloud-1-smallcluster-acmeappco
           type: cluster-k8s-node
           status: ACTIVE
@@ -44,5 +40,9 @@ regiondata:
           infraflavor: x1.small
         - name: fake-node-4-tmus-cloud-1-smallcluster-acmeappco
           type: cluster-k8s-node
+          status: ACTIVE
+          infraflavor: x1.small
+        - name: smallcluster.tmus-cloud-1.tmus.fake.net
+          type: rootlb
           status: ACTIVE
           infraflavor: x1.small

--- a/e2e-tests/testfiles/autoscale.yml
+++ b/e2e-tests/testfiles/autoscale.yml
@@ -98,17 +98,16 @@ tests:
     yaml2: '{{datadir2}}/autoscale_prom_check_active_exp300'
     filetype: raw
 
-# TODO: fix incorrect clusterinst resources
-#- name: check that autoscaled cluster has numnodes 3
-#  actions: [mcapi-showfiltered]
-#  apifile: '{{datadir2}}/autoscale_cluster.yml'
-#  curuserfile: '{{datadir2}}/mc_user2.yml'
-#  retrycount: 12
-#  retryintervalsec: 0.5
-#  compareyaml:
-#    yaml1: '{{outputdir}}/show-commands.yml'
-#    yaml2: '{{datadir2}}/autoscale_cluster_nodes3.yml'
-#    filetype: mcdata
+- name: check that autoscaled cluster has numnodes 3
+  actions: [mcapi-showfiltered]
+  apifile: '{{datadir2}}/autoscale_cluster.yml'
+  curuserfile: '{{datadir2}}/mc_user2.yml'
+  retrycount: 12
+  retryintervalsec: 0.5
+  compareyaml:
+    yaml1: '{{outputdir}}/show-commands.yml'
+    yaml2: '{{datadir2}}/autoscale_cluster_nodes3.yml'
+    filetype: mcdata
 
 - name: finished - set active connections back to 50
   actions: [cmds]
@@ -126,20 +125,19 @@ tests:
     yaml2: '{{datadir2}}/autoscale_prom_check_active_exp50'
     filetype: raw
 
-# TODO: fix incorrect clusterinst resources
-#- name: check that autoscaled cluster has numnodes 1
-#  actions: [mcapi-showfiltered]
-#  apifile: '{{datadir2}}/autoscale_cluster.yml'
-#  curuserfile: '{{datadir2}}/mc_user2.yml'
-#  retrycount: 12
-#  retryintervalsec: 0.5
-#  compareyaml:
-#    yaml1: '{{outputdir}}/show-commands.yml'
-#    yaml2: '{{datadir2}}/autoscale_cluster_nodes1.yml'
-#    filetype: mcdata
+- name: check that autoscaled cluster has numnodes 1
+  actions: [mcapi-showfiltered]
+  apifile: '{{datadir2}}/autoscale_cluster.yml'
+  curuserfile: '{{datadir2}}/mc_user2.yml'
+  retrycount: 12
+  retryintervalsec: 0.5
+  compareyaml:
+    yaml1: '{{outputdir}}/show-commands.yml'
+    yaml2: '{{datadir2}}/autoscale_cluster_nodes1.yml'
+    filetype: mcdata
 
-#- name: enable resource quotas
-#  actions: [mcapi-update, mcapi-show]
-#  apifile: '{{datadir2}}/mc_cloudlet_resource_quotas.yml'
-#  curuserfile: '{{datadir2}}/mc_user1.yml'
+- name: enable resource quotas
+  actions: [mcapi-update, mcapi-show]
+  apifile: '{{datadir2}}/mc_cloudlet_resource_quotas.yml'
+  curuserfile: '{{datadir2}}/mc_user1.yml'
 


### PR DESCRIPTION
My change to include more data in the e2e comparison revealed a bug in the fake platform code for calculating ClusterInst node resources on Update. This fixes the fake platform code to remove nodes when a cluster is scaled down to fewer worker nodes. See https://github.com/mobiledgex/edge-cloud/pull/1590.