### PR TITLE
fix floating ip count

### DIFF
--- a/crm-platforms/openstack/openstack-cmd.go
+++ b/crm-platforms/openstack/openstack-cmd.go
@@ -876,8 +876,16 @@ func (s *OpenstackPlatform) OSGetLimits(ctx context.Context, info *edgeproto.Clo
 // GetNumberOfFloatingIps returns allocated,used
 func (s *OpenstackPlatform) GetNumberOfFloatingIps(ctx context.Context) (int, int, error) {
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetNumberOfFloatingIps")
-	net := s.VMProperties.GetCloudletExternalNetwork()
-	fipList, err := s.ListFloatingIPs(ctx, net)
+	ns := s.VMProperties.GetCloudletNetworkScheme()
+	nspec, err := vmlayer.ParseNetSpec(ctx, ns)
+	if err != nil {
+		return 0, 0, err
+	}
+	if nspec.FloatingIPExternalNet == "" {
+		log.SpanLog(ctx, log.DebugLevelInfra, "no external floating ip external network")
+		return 0, 0, nil
+	}
+	fipList, err := s.ListFloatingIPs(ctx, nspec.FloatingIPExternalNet)
 	if err != nil {
 		return 0, 0, err
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5955 Floating IPs resource limit is wrong

### Description
Openstack has a bug in which maxTotalFloatingIps is always at 10 regardless of the actual quota and totalFloatingIpsUsed always reads 0. This is preventing WWT from adding any new deployments because even though they have many floating ips free, the controller is disallowing because it thinks the limit is reached. Also, since we assume the floating IPs are pre-allocated the number in the pool is really the restriction, not the quota.