### PR TITLE
fix crash due to wrong slice being used

### DIFF
--- a/vmlayer/ip.go
+++ b/vmlayer/ip.go
@@ -256,15 +256,15 @@ func GetLastHostAddressForCidr(cidr string) (string, error) {
 	mask := cs[1]
 	switch mask {
 	case "8":
-		cs[1] = "255"
+		nets[1] = "255"
 		fallthrough
 	case "16":
-		cs[2] = "255"
+		nets[2] = "255"
 		fallthrough
 	case "24":
-		cs[3] = "254"
+		nets[3] = "254"
 	default:
 		return "", fmt.Errorf("invalid mask bit len - %s", mask)
 	}
-	return strings.Join(cs, "."), nil
+	return strings.Join(nets, "."), nil
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-4979 VCD deployment: Options to increment number of shared clusters per cloudlet (crash in original PR)

### Description
GetLastHostAddressForCidr is using the wrong slice to build the resulting address which causes a crash. How I didn't see this after 2 days of testing I don't know..