### PR TITLE
include metallb containers in baseimage

### DIFF
--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.7.0
+VERSION = 4.7.1
 DISTRIBUTION = cirrus
 COMPONENT = main
 

--- a/openstack-tenant/packer/docker-image-cache.txt
+++ b/openstack-tenant/packer/docker-image-cache.txt
@@ -8,3 +8,5 @@ quay.io/prometheus/prometheus:v2.18.2
 squareup/ghostunnel:v1.5.2
 weaveworks/weave-kube:2.8.1
 weaveworks/weave-npc:2.8.1
+quay.io/metallb/controller:v0.10.2
+quay.io/metallb/speaker:v0.10.2

--- a/version/package-version.go
+++ b/version/package-version.go
@@ -1,3 +1,3 @@
 package version
 
-var MobiledgeXPackageVersion = "4.7.0"
+var MobiledgeXPackageVersion = "4.7.1"

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -44,7 +44,7 @@ const MINIMUM_VCPUS uint64 = 2
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.7.0"
+var MEXInfraVersion = "4.7.1"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5544 cache metalLb containers in baseimage

### Description

adds metalLB containers to the base image