### PR TITLE
EDGECLOUD-5812 Restrict InfluxDB access to trusted IPs

### DIFF
--- a/ansible/roles/influxdb/tasks/main.yml
+++ b/ansible/roles/influxdb/tasks/main.yml
@@ -108,11 +108,9 @@
     namespace: default
     definition: "{{ lookup('template', 'influxdb.yml.j2') }}"
 
-- name: Deploy InfluxDB LB
-  k8s:
-    kubeconfig: "{{ kubeconfig_file.path }}"
-    namespace: default
-    definition: "{{ lookup('template', 'influxdb-svc.yml.j2') }}"
+- import_role:
+    name: influxdb
+    tasks_from: svc
 
 - k8s_info:
     kubeconfig: "{{ kubeconfig_file.path }}"

--- a/ansible/roles/influxdb/tasks/svc.yml
+++ b/ansible/roles/influxdb/tasks/svc.yml
@@ -1,0 +1,18 @@
+---
+- name: Load list of kubernetes source IPs
+  import_role:
+    name: mexplat_k8s
+    tasks_from: source-ips
+
+- name: Look up console IP
+  set_fact:
+    console_ip: "{{ lookup('dig', console_vm_hostname) }}"
+
+- set_fact:
+    mexplat_k8s_source_ips: "{{ mexplat_k8s_source_ips + [ console_ip ] }}"
+
+- name: Deploy InfluxDB LB
+  k8s:
+    kubeconfig: "{{ kubeconfig_file.path }}"
+    namespace: default
+    definition: "{{ lookup('template', 'influxdb-svc.yml.j2') }}"

--- a/ansible/roles/influxdb/templates/influxdb-svc.yml.j2
+++ b/ansible/roles/influxdb/templates/influxdb-svc.yml.j2
@@ -12,3 +12,7 @@ spec:
     targetPort: 8086
   selector:
     k8s-app: influxdb
+  loadBalancerSourceRanges:
+  {% for lb_source_ip in mexplat_k8s_source_ips | sort %}
+  - {{ lb_source_ip }}/32
+  {% endfor %}

--- a/ansible/roles/mexplat_k8s/tasks/main.yml
+++ b/ansible/roles/mexplat_k8s/tasks/main.yml
@@ -22,3 +22,8 @@
 - import_role: name="autoprov"
 - import_role: name="frm"
 - import_role: name="k8s-telegraf"
+
+- name: Validate InfluxDB source IP access list
+  import_role:
+    name: influxdb
+    tasks_from: svc

--- a/ansible/roles/mexplat_k8s/tasks/source-ips.yml
+++ b/ansible/roles/mexplat_k8s/tasks/source-ips.yml
@@ -1,0 +1,40 @@
+---
+- import_role:
+    name: mexplat_k8s
+    tasks_from: load-kubeconfig
+
+- set_fact:
+    mexplat_k8s_source_ips: []
+
+- name: Fetch kubernetes ingress details
+  k8s_info:
+    kubeconfig: "{{ kubeconfig_file.path }}"
+    namespace: default
+    kind: Ingress
+    api_version: extensions/v1beta1
+  register: ingress
+
+- set_fact:
+    mexplat_k8s_source_ips: "{{ mexplat_k8s_source_ips + [ k8s_ingress.ip ] }}"
+  loop: "{{ ingress.resources[0].status.loadBalancer.ingress }}"
+  loop_control:
+    loop_var: k8s_ingress
+
+- name: Fetch kubernetes service details
+  k8s_info:
+    kubeconfig: "{{ kubeconfig_file.path }}"
+    namespace: default
+    kind: Service
+    api_version: v1
+  register: k8s_services
+
+- set_fact:
+    mexplat_k8s_source_ips: "{{ mexplat_k8s_source_ips + [ k8s_service.status.loadBalancer.ingress[0].ip ] }}"
+  when: '"loadBalancer" in k8s_service.status and "ingress" in k8s_service.status.loadBalancer'
+  loop: "{{ k8s_services.resources }}"
+  loop_control:
+    loop_var: k8s_service
+  no_log: True
+
+- set_fact:
+    mexplat_k8s_source_ips: "{{ mexplat_k8s_source_ips | sort }}"


### PR DESCRIPTION
InfluxDB needs to be accessible from the controller and MC.  But Azure
AKS picks a single frontend at random from the list of available
frontends for all outbound connections, and so connections from the
controller could be from any of the public IPs associated with the
kubernetes cluster.
Adding the following IPs to the access list in the InfluxDB loadbalancer:
- Public IPs of all services in kubernetes cluster
- Public IPs of all ingresses in kubernetes cluster
- Public IP of the console/MC
