### PR TITLE
revert change to shared lb name

### DIFF
--- a/crm-platforms/k8s-baremetal/k8sbm-lb.go
+++ b/crm-platforms/k8s-baremetal/k8sbm-lb.go
@@ -17,9 +17,8 @@ type LbInfo struct {
 	LbListenDevName string
 }
 
-// GetSharedLBName returns the "dedicated" FQDN of the default cluster
 func (k *K8sBareMetalPlatform) GetSharedLBName(ctx context.Context, cloudletKey *edgeproto.CloudletKey) string {
-	return cloudcommon.GetDedicatedLBFQDN(cloudletKey, &k.GetDefaultCluster(cloudletKey).Key.ClusterKey, k.commonPf.PlatformConfig.AppDNSRoot)
+	return cloudcommon.GetRootLBFQDN(cloudletKey, k.commonPf.PlatformConfig.AppDNSRoot)
 }
 
 func (k *K8sBareMetalPlatform) GetLbName(ctx context.Context, appInst *edgeproto.AppInst) string {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5943 anthos appinst create is not mapping ports to different public ports

### Description

See edgecloud PR for more details, this is the infra change to revert the shared LB name to "shared" for k8s baremetal