### PR TITLE
access cloudlet support

### DIFF
--- a/crm-platforms/k8s-baremetal/k8sbm.go
+++ b/crm-platforms/k8s-baremetal/k8sbm.go
@@ -187,7 +187,7 @@ func (k *K8sBareMetalPlatform) ListCloudletMgmtNodes(ctx context.Context, cluste
 	log.SpanLog(ctx, log.DebugLevelInfra, "ListCloudletMgmtNodes", "clusterInsts", clusterInsts, "vmAppInsts", vmAppInsts)
 	mgmt_nodes := []edgeproto.CloudletMgmtNode{
 		{
-			Type: "masterhost",
+			Type: "platformhost",
 			Name: k.commonPf.PlatformConfig.CloudletKey.String(),
 		},
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5777 accesscloudlet does not work on anthos

### Description

AccessCloudlet does not work because ListCloudletMgmtNodes is not implemented. 
