### PR TITLE
tpe cli, changed app-ver to appvers and app-name to appname to be con…

### DIFF
--- a/mc/mcctl/ormctl/trustpolicyexception.mc2.go
+++ b/mc/mcctl/ormctl/trustpolicyexception.mc2.go
@@ -99,8 +99,8 @@ func init() {
 
 var CreateTrustPolicyExceptionRequiredArgs = []string{
 	"app-org",
-	"app-name",
-	"app-ver",
+	"appname",
+	"appvers",
 	"cloudletpool-org",
 	"cloudletpool-name",
 	"name",
@@ -113,8 +113,8 @@ var CreateTrustPolicyExceptionOptionalArgs = []string{
 }
 var DeleteTrustPolicyExceptionRequiredArgs = []string{
 	"app-org",
-	"app-name",
-	"app-ver",
+	"appname",
+	"appvers",
 	"cloudletpool-org",
 	"cloudletpool-name",
 	"name",
@@ -127,8 +127,8 @@ var DeleteTrustPolicyExceptionOptionalArgs = []string{
 }
 var TrustPolicyExceptionRequiredArgs = []string{
 	"app-org",
-	"app-name",
-	"app-ver",
+	"appname",
+	"appvers",
 	"cloudletpool-org",
 	"cloudletpool-name",
 	"name",
@@ -144,8 +144,8 @@ var TrustPolicyExceptionOptionalArgs = []string{
 var TrustPolicyExceptionAliasArgs = []string{
 	"fields=trustpolicyexception.fields",
 	"app-org=trustpolicyexception.key.appkey.organization",
-	"app-name=trustpolicyexception.key.appkey.name",
-	"app-ver=trustpolicyexception.key.appkey.version",
+	"appname=trustpolicyexception.key.appkey.name",
+	"appvers=trustpolicyexception.key.appkey.version",
 	"cloudletpool-org=trustpolicyexception.key.cloudletpoolkey.organization",
 	"cloudletpool-name=trustpolicyexception.key.cloudletpoolkey.name",
 	"name=trustpolicyexception.key.name",
@@ -159,8 +159,8 @@ var TrustPolicyExceptionAliasArgs = []string{
 var TrustPolicyExceptionComments = map[string]string{
 	"fields":                               "Fields are used for the Update API to specify which fields to apply",
 	"app-org":                              "App developer organization",
-	"app-name":                             "App name",
-	"app-ver":                              "App version",
+	"appname":                              "App name",
+	"appvers":                              "App version",
 	"cloudletpool-org":                     "Name of the organization this pool belongs to",
 	"cloudletpool-name":                    "CloudletPool Name",
 	"name":                                 "TrustPolicyExceptionKey name",


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5974 trustpolicyexception mcctl app args should be consistent with other mcctl commands

### Description
Trust Policy Exception cli, changed app-ver to appvers and app-name to appname to be consistent with other cli.s

### Testing
Did Unit test, ran API test and e2e test.
Please see https://github.com/mobiledgex/edge-cloud/pull/1599
