### PR TITLE
EDGECLOUD-5906 Gitlab security upgrade to version 14.x

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1,3 +1,3 @@
-gitlab_version: 13.12.12-ee.0
+gitlab_version: 14.5.2-ee.0
 gitlab_force_reconfigure: false
 gitlab_slack_notify_image_version: 2019-07-26


### PR DESCRIPTION
Update Gitlab version in Ansible to 14.5.2.

Note that this just acts as a check during deployment and aborts if the current Gitlab current does not match this version. The actual Gitlab upgrade from 13.x to 14.x is a multi-stage manual process.