### PR TITLE
EDGECLOUD-5674 mcctl cloudlet showflavorsfor should have cloudlet and cloudlet-org as optional

### DIFF
--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -415,8 +415,8 @@ var ShowFlavorsForCloudletCmd = &ApiCommand{
 	Name:                 "ShowFlavorsForCloudlet",
 	Use:                  "showflavorsfor",
 	Short:                "Find all meta flavors viable on cloudlet",
-	RequiredArgs:         "region " + strings.Join(CloudletKeyRequiredArgs, " "),
-	OptionalArgs:         strings.Join(CloudletKeyOptionalArgs, " "),
+	RequiredArgs:         "region " + strings.Join(ShowFlavorsForCloudletRequiredArgs, " "),
+	OptionalArgs:         strings.Join(ShowFlavorsForCloudletOptionalArgs, " "),
 	AliasArgs:            strings.Join(CloudletKeyAliasArgs, " "),
 	SpecialArgs:          &CloudletKeySpecialArgs,
 	Comments:             addRegionComment(CloudletKeyComments),
@@ -720,6 +720,12 @@ var GetCloudletResourceUsageRequiredArgs = []string{
 var GetCloudletResourceUsageOptionalArgs = []string{
 	"federated-org",
 	"infrausage",
+}
+var ShowFlavorsForCloudletRequiredArgs = []string{}
+var ShowFlavorsForCloudletOptionalArgs = []string{
+	"cloudlet-org",
+	"cloudlet",
+	"federator-org",
 }
 
 var ShowCloudletInfoCmd = &ApiCommand{


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5674 mcctl cloudlet showflavorsfor should have cloudlet and cloudlet-org as optional

### Description

Infra changes for https://github.com/mobiledgex/edge-cloud/pull/1603