### PR TITLE
tpe update (by admin) with rules and nonexisting org, should give correct error of key not found

### DIFF
--- a/mc/orm/authz_trustpolicyexception.go
+++ b/mc/orm/authz_trustpolicyexception.go
@@ -101,7 +101,9 @@ func authzUpdateTrustPolicyException(ctx context.Context, region, username strin
 	if err != nil {
 		return err
 	}
-
+	if authz.allowAll {
+		return nil
+	}
 	_, isOper := authz.allowedOperOrgs[tpe.Key.CloudletPoolKey.Organization]
 	_, isDev := authz.allowedDevOrgs[tpe.Key.AppKey.Organization]
 
@@ -109,8 +111,8 @@ func authzUpdateTrustPolicyException(ctx context.Context, region, username strin
 		return nil
 	}
 
-	if isOper || authz.allowAll {
-		// Operator/Admin can only update state
+	if isOper {
+		// Operator can only update state
 		for _, field := range tpe.Fields {
 			if tpe.IsKeyField(field) {
 				continue


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5965
Please see Andy's comment on bug verification.
The bug is fixed except one small issue.
When logged in as an admin, and a nonexistent key is provided but with security rules, it gives a message 
"Operator can update only state field"

### Description
Authz code kicks in first (and in the case that the security rules are also provided) admin is treated like operator and it complains about inputting anything other than state (and thus does not check for a wrong/non-existing key).
Removed this check for admin from authz code so that controller code of UpdateTrustPolicyException() catches this error of nonexistent key, instead of any other errors shown by authz code.



### Unit test

devdatta@Dajgaonkar-MAC:~$ lmc user current
name: mexadmin
email: mexadmin@mobiledgex.net
emailverified: true
familyname: mexadmin
givenname: mexadmin
nickname: mexadmin
createdat: 2022-01-10T14:57:22.483249+05:30
updatedat: 2022-01-10T15:03:25.09953+05:30
passcracktimesec: 1.114279590619691e+16
lastlogin: 2022-01-10T15:03:25.0993+05:30
lastfailedlogin: 0001-01-01T05:53:28+05:53
devdatta@Dajgaonkar-MAC:~$ lmc trustpolicyexception update app-org=OrgDeveloper11 appname="DevOrg_SDK_Demo" region=local name=PoolTPE  appvers="1.0" cloudletpool-org=OrgOperator cloudletpool-name=CloudletPoolA 'outboundsecurityrules:0.protocol=udp outboundsecurityrules:0.portrangemin=1111 outboundsecurityrules:0.remotecidr=11.11.22.22/16'
Error: Bad Request (400), TrustPolicyException key {"app_key":{"organization":"OrgDeveloper11","name":"DevOrg_SDK_Demo","version":"1.0"},"cloudlet_pool_key":{"organization":"OrgOperator","name":"CloudletPoolA"},"name":"PoolTPE"} not found
devdatta@Dajgaonkar-MAC:~$ lmc trustpolicyexception update app-org=OrgDeveloper appname="DevOrg_SDK_Demo" region=local name=PoolTPE  appvers="1.0" cloudletpool-org=OrgOperator222 cloudletpool-name=CloudletPoolA 'outboundsecurityrules:0.protocol=udp outboundsecurityrules:0.portrangemin=1111 outboundsecurityrules:0.remotecidr=11.11.22.22/16'
Error: Bad Request (400), TrustPolicyException key {"app_key":{"organization":"OrgDeveloper","name":"DevOrg_SDK_Demo","version":"1.0"},"cloudlet_pool_key":{"organization":"OrgOperator222","name":"CloudletPoolA"},"name":"PoolTPE"} not found
devdatta@Dajgaonkar-MAC:~$


### API test

devdatta@Dajgaonkar-MAC ~/g/s/g/m/e/controller (master)> go test -run "TestTrustPolicyExceptionApi" ./...
ok      github.com/mobiledgex/edge-cloud/controller     (cached)
ok      github.com/mobiledgex/edge-cloud/controller/influxq_client      (cached) [no tests to run]
?       github.com/mobiledgex/edge-cloud/controller/influxq_client/influxq_testutil     [no test files]
devdatta@Dajgaonkar-MAC ~/g/s/g/m/e/controller (master)>

### e2e test for TPE

devdatta@Dajgaonkar-MAC ~/g/s/g/m/edge-cloud (master)> make test
e2e-tests -testfile ./setup-env/e2e-tests/testfiles/regression_group.yml -setupfile ./setup-env/e2e-tests/setups/local_multi.yml
Creating output dir: /tmp/e2e_test_out/2022-01-10T152212

Testfile                       Test                                                         Result
-----------------------------------------------------------------------------------------------------
regression_group.yml           include: stop_cleanup.yml
 - stop_cleanup.yml            stop services and cleanup                                    PASS
regression_group.yml           include: deploy_start.yml
 - deploy_start.yml            start services                                               PASS
 - deploy_start.yml            verify services are running                                  PASS
regression_group.yml           include: trustpolexception_add_update.yml
 - trustpolexception_add_up... create a trust policy exception                              PASS
 - trustpolexception_add_up... update a trust policy exception portrange                    PASS
 - trustpolexception_add_up... approve a trust policy exception                             PASS
 - trustpolexception_add_up... update remotecidr in an active trust policy exception, should fail PASS
 - trustpolexception_add_up... update Active state to ApprovalRequested, should fail        PASS
 - trustpolexception_add_up... reject a trust policy exception                              PASS
 - trustpolexception_add_up... delete trust policy exception, verify it is empty            PASS
regression_group.yml           include: stop_cleanup.yml
 - stop_cleanup.yml            stop services and cleanup                                    PASS

