### PR TITLE
Workflow to upload THIRD-PARTY-NOTICES file to Artifactory

### DIFF
--- a/.github/workflows/upload-third-party-notices.yml
+++ b/.github/workflows/upload-third-party-notices.yml
@@ -1,6 +1,8 @@
 name: Upload third party notices list to Artifactory
 on:
   push:
+    branches:
+      - master
     paths:
       - THIRD-PARTY-NOTICES
 


### PR DESCRIPTION
Workflow triggers whenever a new THIRD-PARTY-NOTICES file is pushed to the master branch.