### PR TITLE
EDGECLOUD-5326 Automatic scanning of developer docker

### DIFF
--- a/ansible/internal
+++ b/ansible/internal
@@ -28,3 +28,6 @@ monitor.mobiledgex.net
 
 [teleport]
 teleport.mobiledgex.net
+
+[trivy]
+trivy.mobiledgex.net

--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -892,3 +892,24 @@
 
     - import_role:
         name: teleport
+
+- hosts: trivy
+  tasks:
+    - import_role:
+        name: vault
+        tasks_from: vault-ssh
+
+    - import_role:
+        name: telegraf
+      tags:
+        - monitoring
+        - setup
+
+    - import_role:
+        name: docker
+      vars:
+        docker_skip_registry_login: true
+      tags: setup
+
+    - import_role:
+        name: trivy

--- a/ansible/roles/trivy/tasks/main.yml
+++ b/ansible/roles/trivy/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Add trivy GPG key
+  apt_key:
+    url: https://aquasecurity.github.io/trivy-repo/deb/public.key
+    state: present
+  become: yes
+  tags: setup
+
+- name: Add trivy APT repo
+  apt_repository:
+    repo: "deb https://aquasecurity.github.io/trivy-repo/deb {{ ansible_distribution_release }} main"
+    state: present
+  become: yes
+  tags: setup
+
+- name: Install trivy
+  apt:
+    name: "trivy={{ trivy_version }}"
+    state: present
+    update_cache: yes
+  become: yes
+  tags: setup

--- a/ansible/roles/trivy/vars/main.yml
+++ b/ansible/roles/trivy/vars/main.yml
@@ -1,0 +1,1 @@
+trivy_version: 0.22.0

--- a/terraform/internal/main.tf
+++ b/terraform/internal/main.tf
@@ -135,10 +135,10 @@ module "chef" {
 
   instance_name  = var.chef_instance_name
   environ_tag    = var.environ_tag
-  instance_size  = "n1-standard-4"
+  instance_size  = "n1-standard-8"
   zone           = var.chef_zone
   boot_image     = "ubuntu-1604-xenial-v20200407"
-  boot_disk_size = 300
+  boot_disk_size = 1200
   tags           = ["mexplat-internal", "http-server", "https-server"]
   labels = {
     "owner" = "ops"
@@ -227,4 +227,26 @@ module "teleport_dns" {
   source   = "../modules/cloudflare_record"
   hostname = var.teleport_domain_name
   ip       = module.teleport.external_ip
+}
+
+module "trivy" {
+  source = "../modules/vm_gcp"
+
+  instance_name       = var.trivy_instance_name
+  environ_tag         = var.environ_tag
+  zone                = var.trivy_zone
+  boot_image          = "ubuntu-os-cloud/ubuntu-2004-lts"
+  boot_disk_size      = 1024
+  tags                = [
+    "mexplat-internal",
+  ]
+  labels = {
+    "owner" = "ops"
+  }
+}
+
+module "trivy_dns" {
+  source   = "../modules/cloudflare_record"
+  hostname = var.trivy_domain_name
+  ip       = module.trivy.external_ip
 }

--- a/terraform/internal/variables.tf
+++ b/terraform/internal/variables.tf
@@ -146,3 +146,15 @@ variable "teleport_instance_name" {
 variable "teleport_zone" {
   default = "us-central1-a"
 }
+
+variable "trivy_domain_name" {
+  default = "trivy.mobiledgex.net"
+}
+
+variable "trivy_instance_name" {
+  default = "trivy"
+}
+
+variable "trivy_zone" {
+  default = "us-central1-a"
+}


### PR DESCRIPTION
VM to scan developer docker images.

This infrastructure can be dismantled once we replace Gitlab with
Harbor. Harbor can be configured to scan docker images automatically,
but to get the equivalent functionality in Gitlab, we will need to set
up a CI job for this in every project (i.e., every developer org) in
Gitlab. That'd be a nightmare to configure and maintain, and especially
pointless as this will all go away once we get Harbor.

This external test setup is configured to run image scans on demand, and
there are jobs in Roma which track and scan all developer images
periodically.
https://roma.mobiledgex.net/inventory/appimage

(This commit also includes an unrelated change in
`terraform/internal/main.tf` syncing the terraform state of the chef
master VM with its actual state.)