### PR TITLE
tweak k8s install scripts to use only master IP from metadata

### DIFF
--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.7.1
+VERSION = 4.7.2
 DISTRIBUTION = cirrus
 COMPONENT = main
 

--- a/openstack-tenant/packages/mobiledgex/install-k8s-master.sh
+++ b/openstack-tenant/packages/mobiledgex/install-k8s-master.sh
@@ -2,17 +2,13 @@
 # must run as root
 # on the master
 set -x
-if [ $# -lt 3 ]; then
+if [ $# -lt 1 ]; then
 	echo "Insufficient arguments"
-	echo "Need interface-name master-ip my-ip"
+	echo "master-ip"
 	exit 1
 fi
-INTF=$1
-MASTERIP=$2
-MYIP=$3
-echo "Interface $INTF"
+MASTERIP=$1
 echo "Master IP $MASTERIP"
-echo "My IP Address: $MYIP"
 
 systemctl is-active --quiet kubelet
 if [ $? -ne 0 ]; then
@@ -25,9 +21,7 @@ if [ $? -ne 0 ]; then
     echo missing kubeadm
     exit 1
 fi
-#nohup consul agent -server -bootstrap-expect=1 -data-dir=/tmp/consul -node=`hostname` -bind=$MYIP -syslog -config-dir=/etc/consul/conf.d  &
-#kubeadm init --apiserver-advertise-address=$MYIP --pod-network-cidr=10.244.0.0/16 --ignore-preflight-errors=all
-kubeadm init --apiserver-advertise-address=$MYIP --pod-network-cidr=192.168.0.0/16 --ignore-preflight-errors=all
+kubeadm init --apiserver-advertise-address=$MASTERIP --pod-network-cidr=192.168.0.0/16 --ignore-preflight-errors=all
 if [ $? -ne 0 ]; then
     echo  kubeadm exited with error
     exit 1

--- a/openstack-tenant/packages/mobiledgex/install-k8s-node.sh
+++ b/openstack-tenant/packages/mobiledgex/install-k8s-node.sh
@@ -2,17 +2,13 @@
 # must be run as root
 #  on all nodes
 set -x
-if [ $# -lt 3 ]; then
+if [ $# -lt 1 ]; then
 	echo "Insufficient arguments"
-	echo "Need interface-name master-ip my-ip"
+	echo "Need master-ip"
 	exit 1
 fi
-INTF=$1
-MASTERIP=$2
-MYIP=$3
-echo "Interface $INTF"
+MASTERIP=$1
 echo "Master IP $MASTERIP"
-echo "My IP Address: $MYIP"
 
 systemctl is-active --quiet kubelet
 if [ $? -ne 0 ]; then
@@ -20,25 +16,6 @@ if [ $? -ne 0 ]; then
   systemctl enable kubelet
 fi
 
-#nohup consul agent -data-dir=/tmp/consul -node=`hostname` -syslog -config-dir=/etc/consul/conf.d -bind=$MYIP &
-#consul info
-#while [ $? -ne 0 ] ; do
-#	echo Waiting for local consul
-#	sleep 7
-#	consul info
-#done
-#consul join $MASTERIP
-#if [ $? -ne 0 ]; then
-#	echo consul join to $MASTERIP failed
-#	exit 1
-#fi
-#consul members
-#JOIN=`consul kv get join-cmd`
-#while [ $? -ne 0 ]; do
-#	echo waiting for join-cmd
-#	sleep 7
-#	JOIN=`consul kv get join-cmd`
-#done
 echo installing k8s node, wait...
 cd /tmp
 

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -43,7 +43,7 @@ const MINIMUM_VCPUS uint64 = 2
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.7.1"
+var MEXInfraVersion = "4.7.2"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION


### Issues Fixed

* EDGECLOUD-5999 CRM H/A part 3 (prep work)

### Description

For CRM-HA we will use k8s to run the platform. When instantiating these clusters, the nodes need to be connected to an external network (which may or may not be the default cloudlet external net). In testing this I found that we end up using the external IP to expose the APIs, which is a security issue. 

This change tweaks the init scripts to get rid of the INTF and MYIP parameters, both of which the script basically tried to guess at and it is not deterministic. Sometimes is passes blank values which is not caught because they are passed as empty quoted strings.  Neither of these parameters is needed as we will always have the Master IP address within the metadata which is much more deterministic.   I removed some unused code as part of this in the scripts.