### PR TITLE
Gitlab security upgrade to 14.5.3

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1,3 +1,3 @@
-gitlab_version: 14.5.2-ee.0
+gitlab_version: 14.5.3-ee.0
 gitlab_force_reconfigure: false
 gitlab_slack_notify_image_version: 2019-07-26


### PR DESCRIPTION
https://about.gitlab.com/releases/2022/01/11/security-release-gitlab-14-6-2-released/
