### PR TITLE
EDGECLOUD-6007 failed login attempt delay time should show whole seconds

### DIFF
--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -273,7 +273,7 @@ func checkLoginLocked(user *ormapi.User, config *ormapi.Config) error {
 
 	if elapsed < lockoutDur {
 		remaining := lockoutDur - elapsed
-		return fmt.Errorf("Login temporarily disabled due to %d failed login attempts, please try again in %s", user.FailedLogins, remaining.String())
+		return fmt.Errorf("Login temporarily disabled due to %d failed login attempts, please try again in %s", user.FailedLogins, remaining.Round(time.Second).String())
 	}
 	return nil
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6007 failed login attempt delay time should show whole seconds

### Description

Change duration in error message to whole seconds.