### PR TITLE
Fix redis deployment in Ansible

### DIFF
--- a/ansible/roles/redis/tasks/main.yml
+++ b/ansible/roles/redis/tasks/main.yml
@@ -8,6 +8,7 @@
   kubernetes.core.helm:
     name: redis
     namespace: default
+    kubeconfig: "{{ kubeconfig_file.path }}"
     chart_ref: bitnami/redis
     chart_version: "{{ redis_chart_version }}"
     values: "{{ lookup('template', 'redis.yaml.j2') | from_yaml }}"


### PR DESCRIPTION
Follow-up to b4c3f4cbbbedbfa277bf37bd4c94f4d2304741c3

Missed specifying the kubeconfig to be used for the deployment.
