### PR TITLE
Reduce number of shards used by Jaeger indexes

### DIFF
--- a/ansible/roles/jaeger/tasks/main.yml
+++ b/ansible/roles/jaeger/tasks/main.yml
@@ -83,6 +83,7 @@
           ES_USERNAME: "{{ jaeger_es_user }}"
           ES_PASSWORD: "{{ jaeger_es_pass }}"
           ES_MAX_SPAN_AGE: "720h"
+          ES_NUM_SHARDS: 2
 
     - name: Deploy jaeger query
       docker_container:
@@ -99,6 +100,7 @@
           ES_USERNAME: "{{ jaeger_es_user }}"
           ES_PASSWORD: "{{ jaeger_es_pass }}"
           ES_MAX_SPAN_AGE: "720h"
+          ES_NUM_SHARDS: 2
 
     - name: Install dependencies
       apt:


### PR DESCRIPTION
Elasticsearch is heavily over-sharded. Jaeger creates ten shards per day
by default--5 for spans and 5 for service. Reducing the number of shards
for each to 2.