### PR TITLE
add standalone redis for e2e

### DIFF
--- a/e2e-tests/setups/local_multi.yml
+++ b/e2e-tests/setups/local_multi.yml
@@ -152,6 +152,11 @@ rediscaches:
   type: master
   port: 36384
   hostname: "127.0.0.1"
+# redis standalone for crm
+- name: redis-standalone
+  type: master
+  port: 6379
+  hostname: "127.0.0.1"
 
 controllers:
 - name: ctrl1


### PR DESCRIPTION
### Issues Fixed

Fix infra e2e tests which were failing because CRM was not able to connect to redis 
### Description
