### PR TITLE
Fix Unit Tests 

### DIFF
--- a/shepherd/fake_envoy_exporter/fake_envoy_exporter.go
+++ b/shepherd/fake_envoy_exporter/fake_envoy_exporter.go
@@ -34,7 +34,6 @@ func (i *arrayFlags) Set(value string) error {
 var portFlags arrayFlags
 
 var sockFile = flag.String("sockfile", "", "unix domain socket file to listen on")
-var cluster = flag.String("cluster", "", "cluster name")
 
 var stats []stat
 var measures map[string]*measure
@@ -66,10 +65,7 @@ func run(ch chan bool) {
 		}
 		replaceTags["envoy_cluster_name"] = backendPorts
 	} else {
-		if *cluster == "" {
-			baselog.Fatal("cluster required if ports are not specified")
-		}
-		replaceTags["envoy_cluster_name"] = []string{`"` + *cluster + `"`}
+		baselog.Fatal("at lease one port needs to be specified")
 	}
 	stats = parseSampleStats(sampleOutput, replaceTags)
 

--- a/shepherd/fake_envoy_exporter/fake_envoy_exporter_test.go
+++ b/shepherd/fake_envoy_exporter/fake_envoy_exporter_test.go
@@ -14,34 +14,6 @@ import (
 
 func TestExporter(t *testing.T) {
 	*sockFile = "/tmp/fake_envoy_exporter_unit_test"
-	*cluster = "testclust"
-
-	ch := make(chan bool, 0)
-	run(ch)
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", *sockFile)
-			},
-		},
-	}
-
-	ensureMeas(t, client, `envoy_cluster_upstream_cx_active{envoy_cluster_name="testclust"} 50`)
-
-	// update measure
-	params := url.Values{}
-	params.Set("measure", `envoy_cluster_upstream_cx_active{envoy_cluster_name="testclust"}`)
-	params.Set("val", "11")
-	resp, err := client.PostForm("http://unix/setval", params)
-	require.Nil(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	defer resp.Body.Close()
-
-	ensureMeas(t, client, `envoy_cluster_upstream_cx_active{envoy_cluster_name="testclust"} 11`)
-}
-func TestExporterPortArg(t *testing.T) {
-	*sockFile = "/tmp/fake_envoy_exporter_unit_test"
 	portFlags = append(portFlags, "80")
 
 	ch := make(chan bool, 0)


### PR DESCRIPTION
### Description

The root cause of the failures was that we were trying to run two http servers for the same path in the same process context. 

Remove cluster option from fake_envoy_exporter, since it's no longer being used