### PR TITLE
EDGECLOUD-6020 Encrypt etcd backups

### DIFF
--- a/ansible/roles/controller/tasks/etcd-backup.yml
+++ b/ansible/roles/controller/tasks/etcd-backup.yml
@@ -43,9 +43,22 @@
     changed_when: false
     check_mode: no
 
+  - name: Create temporary file for encryption key
+    tempfile:
+      path: "{{ tempfile_path }}"
+      state: file
+      suffix: .json
+    register: etcd_backup_enc_key_file
+    changed_when: false
+    check_mode: no
+
   - name: Download etcd database
     command: "kubectl --kubeconfig {{ kubeconfig_file.path }} cp {{ mex_etcd_pod }}:{{ etcd_backup_file }} {{ etcd_backup_local_file.path }}"
     changed_when: false
+    register: result
+    retries: 3
+    delay: 10
+    until: result is not failed
 
   - stat:
       path: "{{ etcd_backup_local_file.path }}"
@@ -56,14 +69,80 @@
       that: etcd_backup_local_file_st.stat.size > 0
     when: not ansible_check_mode
 
-  - name: Archive etcd backup in Artifactory
+  - name: Generate encryption key
+    set_fact:
+      etcd_backup_enc_key: "{{ lookup('community.general.random_string', length=80) }}"
+
+  - import_role:
+      name: vault
+      tasks_from: load-token
+
+  - name: Encrypt encryption key
+    vault_api:
+      vault_addr: "{{ vault_address }}"
+      vault_token: "{{ vault_token }}"
+      api: transit/encrypt/etcd-backup
+      method: POST
+      data:
+        plaintext: "{{ etcd_backup_enc_key | b64encode }}"
+    register: enc_enc_key
+
+  - name: Write encrypted encryption key to metadata file
+    copy:
+      dest: "{{ etcd_backup_enc_key_file.path }}"
+      content: "{{ enc_enc_key.meta.response.data | combine({ 'original_sha1sum': etcd_backup_local_file_st.stat.checksum }) }}"
+
+  - name: Stat metadata file
+    stat:
+      path: "{{ etcd_backup_enc_key_file.path }}"
+      get_checksum: true
+      checksum_algorithm: sha1
+    register: enc_key_st
+
+  - name: Encrypt backup
+    command:
+      argv:
+        - gpg
+        - --batch
+        - --passphrase
+        - "{{ etcd_backup_enc_key }}"
+        - --symmetric
+        - "{{ etcd_backup_local_file.path }}"
+
+  - name: Compute name of encrypted backup
+    set_fact:
+      encrypted_backup_path: "{{ etcd_backup_local_file.path }}.gpg"
+
+  - name: Stat encrypted backup
+    stat:
+      path: "{{ encrypted_backup_path }}"
+      get_checksum: true
+      checksum_algorithm: sha1
+    register: enc_bkp_st
+
+  - name: Delete original backup
+    file:
+      path: "{{ etcd_backup_local_file.path }}"
+      state: absent
+
+  - name: Compute upload params
+    set_fact:
+      artf_base: "{{ artifactory_address }}/build-artifacts/etcd-backup/{{ deploy_environ }}/{{ k8s_cluster_name }}/{{ ansible_date_time.year }}-{{ ansible_date_time.month }}"
+      backup_prefix: "etcd-backup-{{ ansible_date_time.iso8601 }}"
+
+  - name: Archive files to Artifactory
     uri:
-      url: "{{ artifactory_address }}/build-artifacts/etcd-backup/{{ deploy_environ }}/{{ k8s_cluster_name }}/{{ ansible_date_time.year }}-{{ ansible_date_time.month }}/etcd-backup-{{ ansible_date_time.iso8601 }}.db"
+      url: "{{ artf_base }}/{{ backup_prefix }}.{{ upload.suffix }}"
+      src: "{{ upload.file.path }}"
       method: PUT
       headers:
         X-JFrog-Art-Api: "{{ artifactory_publish_api_key }}"
-        X-Checksum-Sha1: "{{ etcd_backup_local_file_st.stat.checksum }}"
-      src: "{{ etcd_backup_local_file.path }}"
+        X-Checksum-Sha1: "{{ upload.file.checksum }}"
       status_code: 201
+    loop:
+      - { "file": "{{ enc_key_st.stat }}", "suffix": "json" }
+      - { "file": "{{ enc_bkp_st.stat }}", "suffix": "db.gpg" }
+    loop_control:
+      loop_var: upload
 
   when: mex_etcd_pod|length > 0

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -61,6 +61,9 @@ vault_user_roles:
     - gcp-bucket-create-key.read.v1
     - gcp-firewall-manage-key.read.v1
     - gcp-role-create-key.read.v1
+    - transit-etcd-backup.decrypt.v1
+    - transit-etcd-backup.encrypt.v1
+    - transit-keys.list.v1
 
   editor: &vault_user_role_editor
     - *vault_user_role_deployer

--- a/ansible/roles/vault/tasks/policies.yml
+++ b/ansible/roles/vault/tasks/policies.yml
@@ -75,6 +75,9 @@
     - policies/sys-policies.write.v1.hcl.j2
     - policies/sys-storage-raft-snapshot.read.v1.hcl.j2
     - policies/teleport-node-token.write.v1.hcl.j2
+    - policies/transit-etcd-backup.decrypt.v1.hcl.j2
+    - policies/transit-etcd-backup.encrypt.v1.hcl.j2
+    - policies/transit-keys.list.v1.hcl.j2
     - policies/ui-access.v1.hcl.j2
 
 - include_role:

--- a/ansible/roles/vault/tasks/roles.yml
+++ b/ansible/roles/vault/tasks/roles.yml
@@ -25,6 +25,7 @@
       - influxdb.read.v1
       - influxdb-internal.read.v1
       - mexenv.read.v1
+      - noreplyemail.read.v1
       - pki-global-config.read.v1
       - pki-global-roles.read.v1
       - pki-regional-cloudlet-config.read.v1
@@ -44,7 +45,8 @@
       - sys-plugins-catalog.read.v1
       - sys-plugins-certs-config.read.v1
       - sys-policies.read.v1
-      - noreplyemail.read.v1
+      - transit-etcd-backup.encrypt.v1
+      - transit-keys.list.v1
     token_type: batch
     token_ttl: 5400   # seconds = 90 minutes
 

--- a/ansible/roles/vault/templates/policies/transit-etcd-backup.decrypt.v1.hcl.j2
+++ b/ansible/roles/vault/templates/policies/transit-etcd-backup.decrypt.v1.hcl.j2
@@ -1,0 +1,3 @@
+path "transit/decrypt/etcd-backup" {
+  capabilities = [ "create", "update" ]
+}

--- a/ansible/roles/vault/templates/policies/transit-etcd-backup.encrypt.v1.hcl.j2
+++ b/ansible/roles/vault/templates/policies/transit-etcd-backup.encrypt.v1.hcl.j2
@@ -1,0 +1,3 @@
+path "transit/encrypt/etcd-backup" {
+  capabilities = [ "create", "update" ]
+}

--- a/ansible/roles/vault/templates/policies/transit-keys.list.v1.hcl.j2
+++ b/ansible/roles/vault/templates/policies/transit-keys.list.v1.hcl.j2
@@ -1,0 +1,3 @@
+path "transit/keys" {
+  capabilities = [ "list" ]
+}

--- a/ansible/vault-setup.yml
+++ b/ansible/vault-setup.yml
@@ -73,6 +73,32 @@
       when: '"totp/" not in secret_engines.meta.response'
       notify: Vault TOTP setup prompt
 
+    - name: Enable the transit secrets engine
+      vault_api:
+        api: sys/mounts/transit
+        method: POST
+        data:
+          type: transit
+        success_code: 204
+      when: '"transit/" not in secret_engines.meta.response'
+
+    - name: Fetch list of transit keys
+      vault_api:
+        api: transit/keys
+        method: LIST
+        success_code: [200, 404]
+      register: keys_resp
+
+    - set_fact:
+        transit_engine_keys: "{{ keys_resp.meta.response.data['keys'] | default([]) }}"
+
+    - name: Create etcd-backup transit key
+      vault_api:
+        api: transit/keys/etcd-backup
+        method: POST
+        success_code: 204
+      when: '"etcd-backup" not in transit_engine_keys'
+
     - name: Enable the GCP secrets engine
       vault_api:
         api: sys/mounts/gcp

--- a/mgmt/etcd/decrypt-etcd-backup.sh
+++ b/mgmt/etcd/decrypt-etcd-backup.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -e
+
+ARTF_URL="$1"
+if [[ -z "$ARTF_URL" ]]; then
+    echo "usage: $( basename $0 ) <artf-etcd-backup-url>" >&2
+    exit 1
+fi
+
+ARTF_BASE="${ARTF_URL%/*}"
+ENCDB=$( basename "$ARTF_URL" )
+ENCBASE=$( basename "$ENCDB" .db.gpg )
+META="${ENCBASE}.json"
+
+if [[ "$ENCDB" == "$ENCBASE" ]]; then
+    # Not an entrypted etcd DB
+    echo "URL of encrypted etcd DB should end in '.db.gpg'" >&2
+    exit 2
+fi
+
+if [[ -z "$VAULT_ADDR" ]]; then
+    export VAULT_ADDR="https://vault-main.mobiledgex.net"
+    echo "VAULT_ADDR not set; assuming $VAULT_ADDR"
+fi
+
+if ! vault token lookup >/dev/null; then
+    echo "Not logged in to vault" >&2
+    exit 2
+fi
+
+read -p "Artifactory username: " ARTF_USER
+read -s -p "Artifactory password: " ARTF_PASS; echo
+
+log() {
+    echo
+    echo "== $* =="
+}
+
+TMPDIR=$( mktemp -d )
+trap 'cd /tmp; rm -rf "$TMPDIR"' EXIT
+
+cd "$TMPDIR"
+
+log "Downloading $ENCDB"
+curl -sf -u "${ARTF_USER}:${ARTF_PASS}" -O "${ARTF_BASE}/${ENCDB}"
+
+log "Downloading $META"
+curl -sf -u "${ARTF_USER}:${ARTF_PASS}" -O "${ARTF_BASE}/${META}"
+
+log "Decrypting encryption key"
+CIPHERTEXT=$( jq -r .ciphertext "$META" )
+ENCKEY=$( vault write -field=plaintext transit/decrypt/etcd-backup \
+        ciphertext="$CIPHERTEXT" \
+        | base64 --decode )
+
+log "Decrypting $ENCDB"
+BKP="${ENCBASE}.db"
+gpg --batch --passphrase "$ENCKEY" --decrypt "$ENCDB" >"$BKP"
+
+log "Validating checksum"
+SHA1SUM=$( openssl sha1 "$BKP" | awk '{print $NF}' )
+ORIG_SHA1SUM=$( jq -r .original_sha1sum "$META" )
+if [[ "$SHA1SUM" != "$ORIG_SHA1SUM" ]]; then
+    echo "Checksum mismatch!" >&2
+    exit 2
+fi
+
+ARTF_UPLOAD="${ARTF_BASE}/${BKP}"
+log "Uploading unencrypted backup to Artifactory"
+curl -f -u "${ARTF_USER}:${ARTF_PASS}" -XPUT -H "X-Checksum-Sha1: $SHA1SUM" \
+    "$ARTF_UPLOAD" -T "$BKP"
+echo
+
+log "Upload complete"
+echo "$ARTF_UPLOAD"


### PR DESCRIPTION
Approach:
- Generate a random string to server as the symmetric encryption key
- Encrypt etcd backup using this key
- Encrypt encryption key using vault's transit engine
- Store encrypted encryption key in Artifactory alongside the encrypted
  etcd backup

Restoring etcd still needs an unencrypted backup bundle in Artifactory.
The "mgmt/etcd/decrypt-etcd-backup.sh" script can be used to decrypt an
encrypted etcd backup bundle and upload it back to Artifactory.

https://mobiledgex.atlassian.net/wiki/spaces/SWDEV/pages/400752664/Restore+etcd+from+backup#Decrypt-etcd-backup
