### PR TITLE
add internal ip to hosts to ensure weave initializes properly

### DIFF
--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.8.0
+VERSION = 4.8.1
 DISTRIBUTION = cirrus
 COMPONENT = main
 

--- a/openstack-tenant/packages/mobiledgex/install-k8s-master.sh
+++ b/openstack-tenant/packages/mobiledgex/install-k8s-master.sh
@@ -9,6 +9,12 @@ if [ $# -lt 1 ]; then
 fi
 MASTERIP=$1
 echo "Master IP $MASTERIP"
+HOSTNAME=`hostname`
+# replace 127.0.0.1 with the internal IP address in /etc/hosts. This is needed
+# if there are multiple networks on the node. 
+sed -i s/"127.0.0.1 $HOSTNAME"/"$MASTERIP $HOSTNAME"/g /etc/hosts 
+echo "replaced localhost with $MASTERIP in /etc/hosts"
+
 
 systemctl is-active --quiet kubelet
 if [ $? -ne 0 ]; then

--- a/version/package-version.go
+++ b/version/package-version.go
@@ -1,3 +1,3 @@
 package version
 
-var MobiledgeXPackageVersion = "4.8.0"
+var MobiledgeXPackageVersion = "4.8.1"

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -43,7 +43,7 @@ const MINIMUM_VCPUS uint64 = 2
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.8.0"
+var MEXInfraVersion = "4.8.1"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6091 CRM HA : Kubelet fails to create pod while bringing up openstack cloudlet

### Description

When testing CRM H/A in OpenStack, it was found that the pods may not come up because the CNI does not properly initialize  The problem is that the node IP may be set to the external network and not the internal one. For whatever reason this does not happen on VCD, maybe due to some init order difference.

To ensure that the CNI knows what address to use, the internal 10.101.x.x. IP for the node is put into the hosts file which is something I discovered googling this issue.  This is done in the init scripts. For the master, we already have the IP and that is used. For nodes, we find the address on the same subnet on the master. This is baseimage change.