### PR TITLE
EDGECLOUD-6102: VMPool k8s cluster creation fails as install-k8s scripts args have changed

### DIFF
--- a/crm-platforms/vmpool/vmpool-provider.go
+++ b/crm-platforms/vmpool/vmpool-provider.go
@@ -240,7 +240,7 @@ func (o *VMPoolPlatform) createVMsInternal(ctx context.Context, markedVMs map[st
 		if role == vmlayer.RoleMaster {
 			updateCallback(edgeproto.UpdateTask, fmt.Sprintf("Setting up kubernetes master node"))
 			log.SpanLog(ctx, log.DebugLevelInfra, "CreateVMs, setup kubernetes master node", "masterAddr", masterAddr)
-			cmd := fmt.Sprintf("sudo sh -x /etc/mobiledgex/install-k8s-master.sh \"ens3\" \"%s\" \"%s\"", masterAddr, masterAddr)
+			cmd := fmt.Sprintf("sudo sh -x /etc/mobiledgex/install-k8s-master.sh \"%s\"", masterAddr)
 			out, err := client.Output(cmd)
 			if err != nil {
 				log.SpanLog(ctx, log.DebugLevelInfra, "failed to setup k8s master", "masterAddr", masterAddr, "nodename", vm.InternalName, "out", out, "err", err)
@@ -283,7 +283,7 @@ func (o *VMPoolPlatform) createVMsInternal(ctx context.Context, markedVMs map[st
 			wg.Add(1)
 			go func(clientIn ssh.Client, nodeName string, wg *sync.WaitGroup) {
 				log.SpanLog(ctx, log.DebugLevelInfra, "CreateVMs, setup kubernetes worker node", "masterAddr", masterAddr, "nodename", nodeName)
-				cmd := fmt.Sprintf("sudo sh -x /etc/mobiledgex/install-k8s-node.sh \"ens3\" \"%s\" \"%s\"", masterAddr, masterAddr)
+				cmd := fmt.Sprintf("sudo sh -x /etc/mobiledgex/install-k8s-node.sh \"%s\"", masterAddr)
 				out, err := clientIn.Output(cmd)
 				if err != nil {
 					log.SpanLog(ctx, log.DebugLevelInfra, "failed to setup k8s node", "masterAddr", masterAddr, "nodename", nodeName, "out", out, "err", err)


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-6102: VMPool k8s cluster creation fails as install-k8s scripts args have changed

### Description
* `install-k8s-node.sh` & `install-k8s-master.sh` script args have changed. This broke VMPool k8s cluster creation. I have fixed the code now