### PR TITLE
Implement minimum version checks for teleport

### DIFF
--- a/ansible/roles/teleport/defaults/main.yml
+++ b/ansible/roles/teleport/defaults/main.yml
@@ -1,3 +1,3 @@
-teleport_version: 8.1.0
+teleport_minimum_version: 8.0.7
 teleport_config: /etc/teleport.yaml
 force_config_update: yes

--- a/ansible/roles/teleport/tasks/install.yml
+++ b/ansible/roles/teleport/tasks/install.yml
@@ -15,11 +15,33 @@
 
 - name: Install teleport
   apt:
-    name: "teleport={{ teleport_version }}"
+    name: teleport
     state: present
     update_cache: yes
   become: yes
   notify: Restart teleport
+  tags: setup
+
+- name: Gather package facts
+  package_facts:
+    manager: auto
+  tags: setup
+
+- set_fact:
+    teleport_current_version: "{{ ansible_facts.packages['teleport'][0]['version'] }}"
+  tags: setup
+
+- debug:
+    msg: "Teleport version: {{ teleport_current_version }}"
+  tags: setup
+
+- name: "Ensure teleport version is at least {{ teleport_minimum_version }}"
+  apt:
+    name: teleport
+    state: latest
+  become: yes
+  notify: Restart teleport
+  when: teleport_current_version is version(teleport_minimum_version, '<')
   tags: setup
 
 - name: Install config file


### PR DESCRIPTION
Teleport pulls older versions of their packages from their APT repo when
a newer version is released. This breaks deployments unless we have the
exact latest version number listed in our playbooks.

Switch to ensuring a minimum version of teleport, and if the installed
version is older than that, upgrade to the latest version.
