### PR TITLE
EDGECLOUD-6103 EDGECLOUD-5921 Fix help string for locationTile and add input validation for usage apis

### DIFF
--- a/mc/mcctl/ormctl/metrics.go
+++ b/mc/mcctl/ormctl/metrics.go
@@ -404,7 +404,7 @@ func getClientTypeUsageMetricComments(typ string) map[string]string {
 
 	switch typ {
 	case "app":
-		locationtileSelectorPermission = fmt.Sprintf(baseSelectorPermission, "latency")
+		locationtileSelectorPermission = fmt.Sprintf(baseSelectorPermission, "latency, deviceinfo")
 		deviceosSelectorPermission = fmt.Sprintf(baseSelectorPermission, "deviceinfo")
 		devicemodelSelectorPermission = fmt.Sprintf(baseSelectorPermission, "deviceinfo")
 		devicecarrierSelectorPermission = fmt.Sprintf(baseSelectorPermission, "deviceinfo")

--- a/mc/orm/influx_usage.go
+++ b/mc/orm/influx_usage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	"github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/mobiledgex/edge-cloud/log"
+	"github.com/mobiledgex/edge-cloud/util"
 )
 
 var AppCheckpointFields = []string{
@@ -700,6 +701,10 @@ func GetUsageCommon(c echo.Context) error {
 		if err != nil {
 			return err
 		}
+		// validate all the passed in arguments
+		if err = util.ValidateNames(in.AppInst.GetTags()); err != nil {
+			return err
+		}
 
 		// start and end times must be specified
 		if in.StartTime.IsZero() || in.EndTime.IsZero() {
@@ -729,6 +734,10 @@ func GetUsageCommon(c echo.Context) error {
 		in := ormapi.RegionClusterInstUsage{}
 		_, err := ReadConn(c, &in)
 		if err != nil {
+			return err
+		}
+		// validate all the passed in arguments
+		if err = util.ValidateNames(in.ClusterInst.GetTags()); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6103  "usage app" and "metrics app" give inconsistent error for sql injection attempt
* EDGECLOUD-5921  mcctl usage for metrics clientappusage locationtile needs update for support of deviceinfo

### Description
Fix help string for locationTile and add input validation for usage apis