### PR TITLE
EDGECLOUD-6107  cloudletusage metrics should check cloudlet exists for flavorusage

### DIFF
--- a/mc/orm/metrics.go
+++ b/mc/orm/metrics.go
@@ -423,12 +423,10 @@ func (m *cloudletUsageMetrics) InitObject(ctx context.Context, rc *InfluxDBConte
 	if err != nil {
 		return err
 	}
-	// Platform type is required for cloudlet resource usage
-	if m.Selector == "resourceusage" {
-		m.platformTypes, err = getCloudletPlatformTypes(ctx, rc.claims.Username, m.Region, m.Cloudlets)
-		if err != nil {
-			return err
-		}
+	// Platform type is required for cloudlet resource usage, but for consistency check for all selectors
+	m.platformTypes, err = getCloudletPlatformTypes(ctx, rc.claims.Username, m.Region, m.Cloudlets)
+	if err != nil {
+		return err
 	}
 	return m.cloudletMetrics.InitObject(ctx, rc)
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6107  cloudletusage metrics should check cloudlet exists for flavorusage

### Description

Added a cloudlet check for any selector when using cloudletusage api for consistency. Optimized `getCloudletPlatformTypes` function to only call `ShowCloudletStream` once instead of calling it for every cloudlet passed in.