### PR TITLE
Turn on ntpd or timesyncd on all VMs

### DIFF
--- a/ansible/internal.yml
+++ b/ansible/internal.yml
@@ -15,6 +15,10 @@
   tasks:
 
     - import_role:
+        name: ntp
+      tags: setup
+
+    - import_role:
         name: vault
         tasks_from: vault-ssh
 
@@ -295,6 +299,9 @@
     vouch_data_dir: "/var/vouch"
   tasks:
     - import_role:
+        name: ntp
+      tags: setup
+    - import_role:
         name: vault
         tasks_from: vault-ssh
     - import_role:
@@ -364,6 +371,9 @@
     kibana_conf: /etc/kibana.yml
 
   tasks:
+    - import_role:
+        name: ntp
+      tags: setup
     - import_role:
         name: vault
         tasks_from: vault-ssh
@@ -567,6 +577,10 @@
   tasks:
 
     - import_role:
+        name: ntp
+      tags: setup
+
+    - import_role:
         name: vault
         tasks_from: vault-ssh
 
@@ -656,6 +670,10 @@
     backup_log: /var/log/backup.log
 
   tasks:
+
+    - import_role:
+        name: ntp
+      tags: setup
 
     - import_role:
         name: vault
@@ -795,6 +813,9 @@
 
   tasks:
     - import_role:
+        name: ntp
+      tags: setup
+    - import_role:
         name: vault
         tasks_from: vault-ssh
     - import_role:
@@ -811,6 +832,10 @@
     grafana_google_creds_path: "secret/ansible/{{ deploy_environ }}/accounts/grafana_google"
 
   tasks:
+
+    - import_role:
+        name: ntp
+      tags: setup
 
     - import_role:
         name: vault
@@ -881,6 +906,10 @@
 
   tasks:
     - import_role:
+        name: ntp
+      tags: setup
+
+    - import_role:
         name: vault
         tasks_from: vault-ssh
 
@@ -895,6 +924,10 @@
 
 - hosts: trivy
   tasks:
+    - import_role:
+        name: ntp
+      tags: setup
+
     - import_role:
         name: vault
         tasks_from: vault-ssh

--- a/ansible/mexplat.yml
+++ b/ansible/mexplat.yml
@@ -143,6 +143,9 @@
 - hosts: gitlab
   tasks:
     - import_role:
+        name: ntp
+      tags: setup
+    - import_role:
         name: vault
         tasks_from: vault-ssh
     - import_role:
@@ -166,6 +169,9 @@
 - hosts: postgres
   tasks:
     - import_role:
+        name: ntp
+      tags: setup
+    - import_role:
         name: vault
         tasks_from: vault-ssh
     - import_role:
@@ -184,6 +190,9 @@
 
 - hosts: crms
   tasks:
+    - import_role:
+        name: ntp
+      tags: setup
     - import_role:
         name: vault
         tasks_from: vault-ssh
@@ -214,6 +223,9 @@
 - hosts: stun
   tasks:
     - import_role:
+        name: ntp
+      tags: setup
+    - import_role:
         name: vault
         tasks_from: vault-ssh
     - import_role:
@@ -227,6 +239,9 @@
 
 - hosts: alertmanager
   tasks:
+    - import_role:
+        name: ntp
+      tags: setup
     - import_role:
         name: vault
         tasks_from: vault-ssh
@@ -242,6 +257,9 @@
 
 - hosts: console
   tasks:
+    - import_role:
+        name: ntp
+      tags: setup
     - import_role:
         name: vault
         tasks_from: vault-ssh
@@ -284,6 +302,9 @@
 - hosts: notifyroot
   tasks:
     - import_role:
+        name: ntp
+      tags: setup
+    - import_role:
         name: vault
         tasks_from: vault-ssh
     - import_role:
@@ -301,6 +322,9 @@
 
 - hosts: registry_replicas
   tasks:
+    - import_role:
+        name: ntp
+      tags: setup
     - import_role:
         name: vault
         tasks_from: vault-ssh
@@ -323,6 +347,10 @@
 
 - hosts: jaeger
   tasks:
+    - import_role:
+        name: ntp
+      tags: setup
+
     - import_role:
         name: vault
         tasks_from: vault-ssh
@@ -350,6 +378,10 @@
 - hosts: esproxy
   tasks:
     - import_role:
+        name: ntp
+      tags: setup
+
+    - import_role:
         name: vault
         tasks_from: vault-ssh
 
@@ -368,6 +400,10 @@
 
 - hosts: kafka
   tasks:
+    - import_role:
+        name: ntp
+      tags: setup
+
     - import_role:
         name: vault
         tasks_from: vault-ssh

--- a/ansible/roles/ntp/defaults/main.yml
+++ b/ansible/roles/ntp/defaults/main.yml
@@ -1,0 +1,1 @@
+use_ntpd: no

--- a/ansible/roles/ntp/tasks/main.yml
+++ b/ansible/roles/ntp/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
-- name: Turn off timesyncd
-  command: "timedatectl set-ntp no"
-  become: yes
-  changed_when: false
+- import_role:
+    name: ntp
+    tasks_from: ntpd
+  when: use_ntpd|bool
 
-- name: Install ntp
-  apt:
-    name:
-      - ntp
-    update_cache: yes
-  become: yes
+- import_role:
+    name: ntp
+    tasks_from: timesyncd
+  when: not use_ntpd|bool

--- a/ansible/roles/ntp/tasks/ntpd.yml
+++ b/ansible/roles/ntp/tasks/ntpd.yml
@@ -1,0 +1,12 @@
+---
+- name: Turn off timesyncd
+  command: "timedatectl set-ntp no"
+  become: yes
+  changed_when: false
+
+- name: Install ntp
+  apt:
+    name:
+      - ntp
+    update_cache: yes
+  become: yes

--- a/ansible/roles/ntp/tasks/timesyncd.yml
+++ b/ansible/roles/ntp/tasks/timesyncd.yml
@@ -1,0 +1,5 @@
+---
+- name: Turn on timesyncd
+  command: "timedatectl set-ntp yes"
+  become: yes
+  changed_when: false

--- a/ansible/vault.yml
+++ b/ansible/vault.yml
@@ -1,4 +1,7 @@
 - hosts: vault
+  vars:
+    use_ntpd: yes
+
   tasks:
 
     - import_role:


### PR DESCRIPTION
Turns out older Ubuntu boxes (18.04) do not enable timesyncd
automatically. Making sure it is explicitly enabled.

Previously, only the vault VMs had ntpd (not timesyncd) enabled.
Refactored the "ntp" role to set up timesyncd or ntpd, with timesyncd
being the default unless the "use_ntpd" parameter is set.
