### PR TITLE
EDGECLOUD-5318 add tty and stdin options to mcctl exec commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/shirou/gopsutil v2.20.4+incompatible
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/test-go/testify v1.1.4
 	github.com/tmc/scp v0.0.0-20170824174625-f7b48647feef

--- a/mc/mcctl/mccli/execreq.go
+++ b/mc/mcctl/mccli/execreq.go
@@ -10,15 +10,17 @@ import (
 	edgecli "github.com/mobiledgex/edge-cloud/edgectl/cli"
 	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // We don't use the auto-generated Command because the client
 // must use websocket connection
 
-func (s *RootCommand) getExecCmd(name string) *cobra.Command {
+func (s *RootCommand) getExecCmd(name string, addFlagsFunc func(*pflag.FlagSet)) *cobra.Command {
 	apiCmd := ormctl.MustGetCommand(name)
 	cliCmd := s.ConvertCmd(apiCmd)
 	cliCmd.Run = s.runExecRequest(apiCmd.Path)
+	cliCmd.AddFlagsFunc = addFlagsFunc
 	return cliCmd.GenCmd()
 }
 
@@ -48,6 +50,10 @@ func (s *RootCommand) runExecRequest(path string) func(c *cli.Command, args []st
 			}
 			return &reply, nil
 		}
-		return edgecli.RunEdgeTurn(&req.ExecRequest, exchangeFunc)
+		options := &edgecli.ExecOptions{
+			Stdin: cli.Interactive,
+			Tty:   cli.Tty,
+		}
+		return edgecli.RunEdgeTurn(&req.ExecRequest, options, exchangeFunc)
 	}
 }

--- a/mc/mcctl/mccli/rootcmd.go
+++ b/mc/mcctl/mccli/rootcmd.go
@@ -79,9 +79,9 @@ func GetRootCommand() *RootCommand {
 		rc.getCmdGroup(ormctl.AppInstRefsGroup),
 		rc.getCmdGroup(ormctl.AppInstLatencyGroup),
 		rc.getCmdGroup(ormctl.TrustPolicyExceptionGroup),
-		rc.getExecCmd("RunCommandCli"),
-		rc.getExecCmd("RunConsole"),
-		rc.getExecCmd("ShowLogsCli"),
+		rc.getExecCmd("RunCommandCli", cli.AddTtyFlags),
+		rc.getExecCmd("RunConsole", cli.NoFlags),
+		rc.getExecCmd("ShowLogsCli", cli.NoFlags),
 	}
 	adminCommands := []*cobra.Command{
 		rc.getCmdGroup(ormctl.ControllerGroup),
@@ -94,7 +94,7 @@ func GetRootCommand() *RootCommand {
 		rc.getCmdGroup(ormctl.DeviceGroup),
 		rc.getCmdGroup(ormctl.ClusterRefsGroup),
 		rc.getCmdGroup(ormctl.RepositoryGroup),
-		rc.getExecCmd("AccessCloudletCli"),
+		rc.getExecCmd("AccessCloudletCli", cli.AddTtyFlags),
 		rc.getCmdGroup(ormctl.SpansGroup),
 		rc.getCmd("RestrictedUpdateUser"),
 		rc.getCmd("RestrictedUpdateOrg"),


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5318 mcctl error when redirecting runcommand/showlogs output

### Description

Same as https://github.com/mobiledgex/edge-cloud/pull/1645, but for mcctl.