### PR TITLE
new chef policy for k8s platform workers

### DIFF
--- a/chef/policyfiles/k8s_worker_crm.lock.json
+++ b/chef/policyfiles/k8s_worker_crm.lock.json
@@ -1,0 +1,121 @@
+{
+  "revision_id": "4dd70876a9fb39a82d9d8f1a815a049c65fd4c0330c28f86274b995c599e7351",
+  "name": "k8s_worker_crm",
+  "run_list": [
+    "recipe[chef_client_updater::default]",
+    "recipe[runstatus_handler::default]",
+    "recipe[setup_infra::default]",
+    "recipe[preflight_crm_checks::default]",
+    "recipe[chef_client_updater::default]",
+    "recipe[set_security_policies::default]"
+  ],
+  "included_policy_locks": [
+
+  ],
+  "cookbook_locks": {
+    "chef_client_updater": {
+      "version": "3.11.0",
+      "identifier": "419a5b1204f7145afdabce5e81889d7a925bd21b",
+      "dotted_decimal_identifier": "18465589421209364.25611662247494024.173149767062043",
+      "cache_key": "chef_client_updater-3.11.0",
+      "origin": "https://chef.mobiledgex.net/organizations/mobiledgex",
+      "source_options": {
+        "chef_server": "https://chef.mobiledgex.net/organizations/mobiledgex",
+        "version": "3.11.0"
+      }
+    },
+    "preflight_crm_checks": {
+      "version": "1.0.0",
+      "identifier": "2e3458d2ab0f35f4885fdc601925deee7ad54912",
+      "dotted_decimal_identifier": "13005405024882485.68829839617956133.245115844380946",
+      "cache_key": "preflight_crm_checks-1.0.0",
+      "origin": "https://chef.mobiledgex.net/organizations/mobiledgex",
+      "source_options": {
+        "chef_server": "https://chef.mobiledgex.net/organizations/mobiledgex",
+        "version": "1.0.0"
+      }
+    },
+    "runstatus_handler": {
+      "version": "1.0.0",
+      "identifier": "779bf5d49799fcf3e2e455abc0232abd5a792470",
+      "dotted_decimal_identifier": "33667002364566012.68647889658429475.46992755074160",
+      "cache_key": "runstatus_handler-1.0.0",
+      "origin": "https://chef.mobiledgex.net/organizations/mobiledgex",
+      "source_options": {
+        "chef_server": "https://chef.mobiledgex.net/organizations/mobiledgex",
+        "version": "1.0.0"
+      }
+    },
+    "set_security_policies": {
+      "version": "1.0.0",
+      "identifier": "0f2add5a7ac0b7d5e981770be4f1209096dd6d44",
+      "dotted_decimal_identifier": "4269254844793015.60210912296690929.35805378473284",
+      "cache_key": "set_security_policies-1.0.0",
+      "origin": "https://chef.mobiledgex.net/organizations/mobiledgex",
+      "source_options": {
+        "chef_server": "https://chef.mobiledgex.net/organizations/mobiledgex",
+        "version": "1.0.0"
+      }
+    },
+    "setup_infra": {
+      "version": "1.0.0",
+      "identifier": "7ea0f6481eab8d2fd7a2193fb3fc9ddf807788a4",
+      "dotted_decimal_identifier": "35642826697911181.13466415113679868.173583258585252",
+      "cache_key": "setup_infra-1.0.0",
+      "origin": "https://chef.mobiledgex.net/organizations/mobiledgex",
+      "source_options": {
+        "chef_server": "https://chef.mobiledgex.net/organizations/mobiledgex",
+        "version": "1.0.0"
+      }
+    }
+  },
+  "default_attributes": {
+    "chef_client_updater": {
+      "version": "17.2.29"
+    }
+  },
+  "override_attributes": {
+
+  },
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "chef_client_updater",
+        "= 3.11.0"
+      ],
+      [
+        "preflight_crm_checks",
+        "= 1.0.0"
+      ],
+      [
+        "runstatus_handler",
+        "= 1.0.0"
+      ],
+      [
+        "set_security_policies",
+        "= 1.0.0"
+      ],
+      [
+        "setup_infra",
+        "= 1.0.0"
+      ]
+    ],
+    "dependencies": {
+      "chef_client_updater (3.11.0)": [
+
+      ],
+      "preflight_crm_checks (1.0.0)": [
+
+      ],
+      "runstatus_handler (1.0.0)": [
+
+      ],
+      "set_security_policies (1.0.0)": [
+
+      ],
+      "setup_infra (1.0.0)": [
+
+      ]
+    }
+  }
+}

--- a/chef/policyfiles/k8s_worker_crm.rb
+++ b/chef/policyfiles/k8s_worker_crm.rb
@@ -1,0 +1,20 @@
+# worker nodes for k8s containers to setup cloudlet services
+
+# A name that describes what the system you're building with Chef does.
+name 'k8s_worker_crm'
+
+# Where to find external cookbooks:
+default_source :chef_server, "https://chef.mobiledgex.net/organizations/mobiledgex"
+
+# run_list: chef-client will run these recipes in the order specified.
+run_list 'chef_client_updater::default', 'recipe[runstatus_handler]', 'recipe[setup_infra]', 'recipe[preflight_crm_checks]', 'recipe[chef_client_updater]', 'recipe[set_security_policies]' 
+
+# Specify a custom source for a single cookbook:
+cookbook 'runstatus_handler', '= 1.0.0'
+cookbook 'setup_infra', '= 1.0.0'
+cookbook 'preflight_crm_checks', '= 1.0.0'
+cookbook 'chef_client_updater', '= 3.11.0'
+cookbook 'set_security_policies', '= 1.0.0'
+
+# Set chef-client version
+default['chef_client_updater']['version'] = '17.2.29'

--- a/chefmgmt/chef.go
+++ b/chefmgmt/chef.go
@@ -22,10 +22,10 @@ import (
 
 const (
 	// Chef Policies
-	ChefPolicyBase   = "base"
-	ChefPolicyDocker = "docker_crm"
-	ChefPolicyK8s    = "k8s_crm"
-
+	ChefPolicyBase        = "base"
+	ChefPolicyDocker      = "docker_crm"
+	ChefPolicyK8s         = "k8s_crm"
+	ChefPolicyK8sWorker   = "k8s_worker_crm"
 	DefaultChefServerPath = "https://chef.mobiledgex.net/organizations/mobiledgex"
 	DefaultCacheDir       = "/root/crm_cache"
 )


### PR DESCRIPTION
### Issues Fixed

EDGECLOUD-6117 TDG endpoints need to have the route added for the worker nodes during creation of cloudlet

### Description

Most of the TDG cloudlets except Bonn require that an additional IP route be made to reach the OpenStack API endpoint. For this purpose, we have the chef recipe "setup_infra" which adds the route. Currently however only the master k8s node runs anything besides the ChefPolicyBase recipe and this is not done. This is because all the work in the k8s case is done on the master node only. But because the k8s worker nodes actually run CRM, they do need this route added.  

A new chef policy is defined k8s_worker_crm which does not do the full onboarding (setup_services) but it does add the route via setup_infra.