### PR TITLE
EDGECLOUD-5917 add custom descriptions for swagger fix; fix login args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ doc:
 	make -f proto.make
 	go install ./doc/swaggerfix
 	swagger generate spec -i ./doc/init.json -o ./doc/apidocs.swagger.json --scan-models
-	swaggerfix ./doc/apidocs.swagger.json
+	swaggerfix --custom ./doc/custom.yaml ./doc/apidocs.swagger.json
 
 doc-local-server:
 	docker run --rm -p 1081:80 \

--- a/doc/custom.yaml
+++ b/doc/custom.yaml
@@ -1,0 +1,8 @@
+paths:
+  /login:
+    description: |
+      Log in to the MC to acquire a temporary bearer token for access to other APIs.
+      Authentication can be via a username and password, or an API key ID and API key if created. If two-factor authentication (2FA) is enabled on the account, an additional temporary one-time password (TOTP) from a mobile authenticator will also be required.
+  /dummy-path:
+    description: |
+      Custom dummy description using Github flavored markdown.

--- a/mc/mcctl/ormctl/user.go
+++ b/mc/mcctl/ormctl/user.go
@@ -143,7 +143,8 @@ func init() {
 	cmd = &ApiCommand{
 		Name:         "Login",
 		Short:        "Login using account credentials",
-		OptionalArgs: "name totp apikeyid apikey",
+		OptionalArgs: "name password totp apikeyid apikey",
+		AliasArgs:    "name=username",
 		Comments:     LoginComments,
 		ReqData:      &ormapi.UserLogin{},
 		ReplyData:    &map[string]interface{}{},
@@ -154,6 +155,7 @@ func init() {
 
 var LoginComments = map[string]string{
 	"name":     "User's name",
+	"password": "User's password",
 	"totp":     "Temporary one-time password, if 2-factor auth is enabled",
 	"apikeyid": "API key ID if authenticating via API key instead of user name",
 	"apikey":   "API key value if authenticating via API key instead of user name",

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -353,13 +353,10 @@ type UserLogin struct {
 	// required: true
 	Password string `form:"password" json:"password"`
 	// Temporary one-time password if 2-factor authentication is enabled
-	// read only: true
 	TOTP string `form:"totp" json:"totp"`
 	// API key ID if logging in using API key
-	// read only: true
 	ApiKeyId string `form:"apikeyid" json:"apikeyid"`
 	// API key if logging in using API key
-	// read only: true
 	ApiKey string `form:"apikey" json:"apikey"`
 }
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5917 [Docs] Clarification Regarding Tokens and 2FA for Login APIs

### Description

The bug requests clarification on the login API. There were two issues:
1. The login API description was not descriptive enough
2. The totp/apikey fields were incorrectly marked "read only", so were not displayed on the API docs

For #2, I removed the offending "read only" tags in api.go.
For #1, I've added a custom.yaml file where doc maintainers (Brett, Loann) can add customized, more descriptive descriptions to override the terse ones littered throughout the code. This is easier to manage than adding verbose descriptions in the code, and it's easier to deal with text formatting in yaml than in commented-out go code.

Finally, I fixed another issue I noticed, where a field which is an object had all its sub-fields removed, but itself was left behind as an empty field in the swagger doc. These also should be removed. To fix, I just reordered some of the code in validateSchema().