### PR TITLE
EDGECLOUD-6146 Gitlab upgrade to 14.5.4

### DIFF
--- a/ansible/roles/gitlab/defaults/main.yml
+++ b/ansible/roles/gitlab/defaults/main.yml
@@ -1,3 +1,3 @@
-gitlab_version: 14.5.3-ee.0
+gitlab_version: 14.5.4-ee.0
 gitlab_force_reconfigure: false
 gitlab_slack_notify_image_version: 2019-07-26


### PR DESCRIPTION
Security fix for [CVE-2022-0427](https://about.gitlab.com/releases/2022/02/03/security-release-gitlab-14-7-1-released/)
