### PR TITLE
EDGECLOUD-6144: Add federation APIKey read policy for FRM service

### DIFF
--- a/ansible/roles/vault/tasks/policies.yml
+++ b/ansible/roles/vault/tasks/policies.yml
@@ -27,6 +27,7 @@
     - policies/cloudlets.write.v1.hcl.j2
     - policies/edge-cloud-registry.read.v1.hcl.j2
     - policies/federation.write.v1.hcl.j2
+    - policies/federation.read.v1.hcl.j2
     - policies/gcs.read.v1.hcl.j2
     - policies/gcp-auth.read.v1.hcl.j2
     - policies/gcp-bucket-create-key.read.v1.hcl.j2

--- a/ansible/roles/vault/tasks/region-roles.yml
+++ b/ansible/roles/vault/tasks/region-roles.yml
@@ -92,5 +92,6 @@
     name: "{{ region_prefix }}.frm.v1"
     policies:
       - approle.login.v1
+      - federation.read.v1
       - "{{ region_prefix }}.pki-regional.issue.v1"
     token_type: batch

--- a/ansible/roles/vault/templates/policies/federation.read.v1.hcl.j2
+++ b/ansible/roles/vault/templates/policies/federation.read.v1.hcl.j2
@@ -1,0 +1,3 @@
+path "secret/data/federation/*" {
+  capabilities = [ "read" ]
+}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6144: Add federation APIKey read-policy for FRM service

### Description
* FRM service should have permissions to read API key from vault.