### PR TITLE
Consolidate hardcoded changes & fix app related onboarding issues

### DIFF
--- a/crm-platforms/federation/federation_pf.go
+++ b/crm-platforms/federation/federation_pf.go
@@ -359,7 +359,7 @@ func (f *FederationPlatform) CreateAppInst(ctx context.Context, clusterInst *edg
 	}
 
 	// Wait for app provision status to be ready
-	updateCallback(edgeproto.UpdateTask, "Wait for application to be provisioned")
+	updateCallback(edgeproto.UpdateTask, "Waiting for application to be provisioned")
 	start = time.Now()
 	for {
 		time.Sleep(10 * time.Second)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6144: Consolidate temporary changes required for federation app onboarding demo

### Description
* Consolidate temporary changes so that it is easier to identify and remove them later once SingTel implements the required changes. Their current focus is to just get things working for the demo
* They are maintaining different API endpoints for federation management and for app management APIs, which doesn't make sense. They will fix it after the demo and hence for now we just take it as part of the app configs
* Use `DnsLabel` instead of `UniqueLabel` as appID just has to be unique inside the k8s cluster. Also, using `UniqueId` was causing the length limit issues from their end