### PR TITLE
Support all Telefonica orgs in teleport

### DIFF
--- a/ansible/roles/teleport/tasks/main.yml
+++ b/ansible/roles/teleport/tasks/main.yml
@@ -5,6 +5,10 @@
     tasks_from: install
   vars:
     teleport_config_template: teleport.yaml.j2
+    telefonica_divisions:
+      - Brazil
+      - GCTIO
+      - Germany
 
 - name: Create teleport config dir
   file:
@@ -81,6 +85,13 @@
   when: telefonica_role is changed
   tags: config
 
+- include_role:
+    name: teleport
+    tasks_from: telefonica-division.yml
+  loop: "{{ telefonica_divisions|map('lower') }}"
+  loop_control:
+    loop_var: division
+
 - name: Set up tefmgr access role
   template:
     src: tefmgr-access-role.yaml.j2
@@ -141,8 +152,8 @@
   become: yes
 
 - name: Set up Telefonica user management script
-  copy:
-    src: tef-user-mgr
+  template:
+    src: tef-user-mgr.j2
     dest: "{{ tef_user_mgr }}"
     mode: "0500"
   become: yes

--- a/ansible/roles/teleport/tasks/telefonica-division.yml
+++ b/ansible/roles/teleport/tasks/telefonica-division.yml
@@ -1,0 +1,14 @@
+---
+- name: "Set up Telefonica {{ division }} access role"
+  template:
+    src: telefonica-division-access-role.yaml.j2
+    dest: "{{ teleport_config_dir.path }}/telefonica-{{ division }}-access-role.yaml"
+  become: yes
+  register: telefonica_division_role
+  tags: config
+
+- name: "Apply Telefonica {{ division }} access role"
+  command: "tctl create -f {{ telefonica_division_role.dest }}"
+  become: yes
+  when: telefonica_division_role is changed
+  tags: config

--- a/ansible/roles/teleport/templates/tef-user-mgr.j2
+++ b/ansible/roles/teleport/templates/tef-user-mgr.j2
@@ -3,18 +3,27 @@ PATH='/usr/bin:/bin:/usr/local/bin'; export PATH
 
 USAGE="usage: $( basename $0 ) <command>
 
-  add <user>  Add Telefonica user account
-  ls          List Telefonica user accounts
-  rm <user>   Remove Telefonica user account
+  add <user> <division> Add Telefonica user account
+  ls                    List Telefonica user accounts
+  rm <user>             Remove Telefonica user account
 "
 
 add_user() {
     username="$1"
-    if [[ -z "$username" ]]; then
-        echo "usage: $( basename $0 ) $COMM <user>" >&2
+    division="$( echo $2 | tr 'A-Z' 'a-z' | sed 's/^telefonica-//' )"
+    if [[ -z "$username" || -z "$division" ]]; then
+        echo "usage: $( basename $0 ) $COMM <user> <division>" >&2
         exit 1
     fi
-    tctl users add "$1" --roles=telefonica
+    case "$division" in
+        telefonica|{{ telefonica_divisions|map('lower')|join('|') }}) true ;;
+        *) echo "error: unknown division: $2" >&2; exit 1 ;;
+    esac
+
+    rolename="$division"
+    [[ "$rolename" != telefonica ]] && rolename="telefonica-${rolename}"
+
+    tctl users add "$1" --roles="$rolename"
 }
 
 ls_users() {
@@ -41,7 +50,7 @@ rm_user() {
 
 COMM="$1"; shift
 case "$COMM" in
-    add|create)         add_user "$1" ;;
+    add|create)         add_user "$1" "$2";;
     rm|remove|delete)   rm_user "$1" ;;
     ls|list)            ls_users ;;
     *)                  echo "$USAGE" >&2; exit 1 ;;

--- a/ansible/roles/teleport/templates/telefonica-division-access-role.yaml.j2
+++ b/ansible/roles/teleport/templates/telefonica-division-access-role.yaml.j2
@@ -1,0 +1,10 @@
+kind: role
+version: v4
+metadata:
+  name: telefonica-{{ division }}
+spec:
+  allow:
+    logins:
+      - ubuntu
+    node_labels:
+      operator: telefonica-{{ division }}


### PR DESCRIPTION
Telefonica's org is being split into multiple sub-orgs. This change adds
support in teleport for access control by sub-org.
