### PR TITLE
EDGECLOUD-6133 check specific SingleKubernetesClusterOwner org exists

### DIFF
--- a/mc/orm/authz_cloudlet.go
+++ b/mc/orm/authz_cloudlet.go
@@ -261,6 +261,9 @@ func authzCreateCloudlet(ctx context.Context, region, username string, obj *edge
 		}
 		ops = append(ops, withReferenceOrg(org, OrgTypeOperator))
 	}
+	if obj.SingleKubernetesClusterOwner != "" {
+		ops = append(ops, withReferenceOrg(obj.SingleKubernetesClusterOwner, OrgTypeAny))
+	}
 	if obj.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_EDGEBOX {
 		ops = append(ops, withNoEdgeboxOnly())
 	}

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -24,6 +24,7 @@ import (
 var OrgTypeAdmin = "admin"
 var OrgTypeDeveloper = "developer"
 var OrgTypeOperator = "operator"
+var OrgTypeAny = ""
 
 type UpdateType int
 

--- a/mc/orm/userauth.go
+++ b/mc/orm/userauth.go
@@ -261,7 +261,7 @@ func authorized(ctx context.Context, sub, org, obj, act string, ops ...authOp) e
 // If not present, hides not found error with Forbidden to prevent
 // fishing for org names.
 func checkRequiresOrg(ctx context.Context, org, resource string, admin, noEdgeboxOnly bool) error {
-	orgType := ""
+	orgType := OrgTypeAny
 	if _, ok := DeveloperResourcesMap[resource]; ok {
 		orgType = OrgTypeDeveloper
 	} else if _, ok := OperatorResourcesMap[resource]; ok {
@@ -309,7 +309,7 @@ func checkReferenceOrg(ctx context.Context, org, orgType string) (*ormapi.Organi
 		return lookup, fmt.Errorf("Operation not allowed for org %s with delete in progress", org)
 	}
 	// see if resource is only for a specific type of org
-	if orgType != "" && lookup.Type != orgType {
+	if orgType != OrgTypeAny && lookup.Type != orgType {
 		return lookup, fmt.Errorf("Operation only allowed for organizations of type %s", orgType)
 	}
 	return lookup, nil


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6133 "cloudlet create" with singlekubernetesclusterowner should validate the org name

### Description

When SingleKubernetesClusterOwner org is specified, check that it exists.