### PR TITLE
Support for deploying custom builds from `mobiledgex-dev` project in harbor

### DIFF
--- a/ansible/deploy.sh
+++ b/ansible/deploy.sh
@@ -10,6 +10,7 @@ USAGE="usage: $0 [options] <environment> [<target>]
   -c		confirm before running playbook
   -C <version>	console version to deploy (default: pick latest git tag)
   -d		enable debug mode
+  -D		pick edge-cloud images from the \"mobiledgex-dev\" docker registry
   -e <var=val>	pass environment variables to playbook run
   -G		skip github login
   -i		interactive mode; pause before each region upgrade
@@ -67,11 +68,12 @@ SKIP_VAULT_SSH_KEY_SIGNING=false
 VAULT_ADDR=
 VERBOSITY=
 ENVVARS=()
-while getopts ':cC:de:Ghilnp:qs:St:vV:xX:y' OPT; do
+while getopts ':cC:dDe:Ghilnp:qs:St:vV:xX:y' OPT; do
 	case "$OPT" in
 	c)	CONFIRM=true ;;
 	C)	CONSOLE_VERSION="$OPTARG" ;;
 	d)	DEBUG=true ;;
+	D)	ENVVARS+=( -e "mex_registry_project=mobiledgex-dev" ) ;;
 	e)	ENVVARS+=( -e "$OPTARG" ) ;;
 	G)	SKIP_GITHUB=true ;;
 	i)	INTERACTIVE=true ;;

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -5,8 +5,9 @@ platform_k8s_pool_size: 3
 platform_k8s_pool_size_max: 5
 platform_k8s_vm_size: Standard_D2s_v3
 mex_docker_registry: harbor.mobiledgex.net
-edge_cloud_image: "{{ mex_docker_registry }}/mobiledgex/edge-cloud"
-monitor_image: "{{ mex_docker_registry }}/mobiledgex/monitor"
+mex_registry_project: mobiledgex
+edge_cloud_image: "{{ mex_docker_registry }}/{{ mex_registry_project }}/edge-cloud"
+monitor_image: "{{ mex_docker_registry }}/{{ mex_registry_project }}/monitor"
 mex_ops_email: mobiledgex.ops@mobiledgex.com
 cloudflare_zone: mobiledgex.net
 global_dme_suffix: ".global.dme.{{ cloudflare_zone }}"

--- a/ansible/roles/mexplat_k8s/tasks/main.yml
+++ b/ansible/roles/mexplat_k8s/tasks/main.yml
@@ -4,7 +4,7 @@
     tasks_from: load-kubeconfig
 
 - debug:
-    msg: "Deploying edge-cloud version '{{ edge_cloud_version }}' to cluster '{{ k8s_cluster_name }}' (region: '{{ region }}')"
+    msg: "Deploying edge-cloud '{{ edge_cloud_image }}:{{ edge_cloud_version }}' to cluster '{{ k8s_cluster_name }}' (region: '{{ region }}')"
 
 - name: "Confirm {{ region }} region upgrade"
   pause:


### PR DESCRIPTION
Once we run out of letters in the Latin alphabet for command line options in `deploy.sh`, we'll switch to the Cyrillic alphabet.
