### PR TITLE
EDGECLOUD-6144: Show other details as part of federator create output

### DIFF
--- a/mc/orm/federation_mc.go
+++ b/mc/orm/federation_mc.go
@@ -260,8 +260,11 @@ func CreateSelfFederator(c echo.Context) error {
 	}
 
 	opFedOut := ormapi.Federator{
-		FederationId: opFed.FederationId,
-		ApiKey:       apiKey,
+		OperatorId:     opFed.OperatorId,
+		CountryCode:    opFed.CountryCode,
+		FederationId:   opFed.FederationId,
+		FederationAddr: opFed.FederationAddr,
+		ApiKey:         apiKey,
 	}
 	return c.JSON(http.StatusOK, &opFedOut)
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6144: Show other details as part of federator create output

### Description
* These details are required for UI and also they can just be copied and sent to partner operator directly rather than making a show API call 