### PR TITLE
Customise Jenkins builds for staging setup

### DIFF
--- a/jenkins/mexplat.Jenkinsfile
+++ b/jenkins/mexplat.Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
             steps {
                 dir(path: 'ansible') {
                     ansiColor('xterm') {
-                        sh label: 'Run ansible playbook', script: '''$!/bin/bash
+                        sh label: 'Run ansible playbook', script: '''#!/bin/bash
 export GITHUB_USER="${GITHUB_CREDS_USR}"
 export GITHUB_TOKEN="${GITHUB_CREDS_PSW}"
 export AZURE_CLIENT_ID="${AZURE_SERVICE_PRINCIPAL_USR}"


### PR DESCRIPTION
Support for
- Picking a specific build for deployment to the staging setup
- Picking edge-cloud docker images from the "mobiledgex-dev" registry
- Skipping the vault setup step
