### PR TITLE
Have ansible deployments optionally bypass teleport

### DIFF
--- a/ansible/roles/load-vault-creds/tasks/kubeconfig.yml
+++ b/ansible/roles/load-vault-creds/tasks/kubeconfig.yml
@@ -1,8 +1,20 @@
-- name: "Retrieve {{ region }} kubeconfig from vault"
-  set_fact:
-    vault_lookup: "{{ lookup('vault', kubeconfig_path) }}"
-  vars:
-    kubeconfig_path: "secret/ansible/common/kubeconfigs/{{ region | lower }}:kubeconfig"
+- block:
+
+    # Attempt to load static kubeconfig
+    - name: "Retrieve static kubeconfig for {{ region }}"
+      set_fact:
+        vault_lookup: "{{ lookup('vault', kubeconfig_path) }}"
+      vars:
+        kubeconfig_path: "secret/ansible/common/kubeconfigs/static/{{ region | lower }}:kubeconfig"
+
+  rescue:
+
+    # Fall back to using teleport kubeconfig
+    - name: "Retrieve teleport kubeconfig for {{ region }}"
+      set_fact:
+        vault_lookup: "{{ lookup('vault', kubeconfig_path) }}"
+      vars:
+        kubeconfig_path: "secret/ansible/common/kubeconfigs/{{ region | lower }}:kubeconfig"
 
 - set_fact:
     kubeconfig: "{{ vault_lookup.kubeconfig.data.value | b64decode }}"


### PR DESCRIPTION
Teleport can cause ansible kubernetes deployments to be a bit flaky with
occasional API requests failing with 500 errors.  This change adds
support for storing direct access kubeconfigs in vault and have ansible
fall back to teleport if they are not present.