### PR TITLE
User API key bug fixes

### DIFF
--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -2747,10 +2747,6 @@ func testUserApiKeys(t *testing.T, ctx context.Context, ds *testutil.DummyServer
 	testAddUserRole(t, mcClient, uri, token, operOrg.Name, "OperatorManager", user1.Name, Success)
 	userApiKeyObj.Permissions = []ormapi.RolePerm{
 		ormapi.RolePerm{
-			Action:   "view",
-			Resource: "cloudlets",
-		},
-		ormapi.RolePerm{
 			Action:   "manage",
 			Resource: "cloudlets",
 		},
@@ -2923,12 +2919,33 @@ func testUserApiKeys(t *testing.T, ctx context.Context, ds *testutil.DummyServer
 	require.Equal(t, http.StatusOK, status, "show apikey")
 	require.Equal(t, len(apiKeys), defaultConfig.UserApiKeyCreateLimit, "match api key count")
 
+	// show api key with invalid id should fail
+	_, status, err = mcClient.ShowUserApiKey(uri, token1, &ormapi.CreateUserApiKey{
+		UserApiKey: ormapi.UserApiKey{
+			Id: "invalidID",
+		},
+	})
+	require.NotNil(t, err, "show invalid apikey id")
+	require.Contains(t, err.Error(), "API key ID not found")
+
+	// delete invalid api key id
+	status, err = mcClient.DeleteUserApiKey(uri, token1, &ormapi.CreateUserApiKey{})
+	require.NotNil(t, err, "delete invalid user api key id")
+	require.Contains(t, err.Error(), "Missing API key ID")
+
 	// delete all the api keys
 	for _, apiKeyObj := range apiKeys {
 		status, err = mcClient.DeleteUserApiKey(uri, token1, &apiKeyObj)
 		require.Nil(t, err, "delete user api key")
 		require.Equal(t, http.StatusOK, status)
 	}
+
+	// show api key should now be empty
+	apiKeys, status, err = mcClient.ShowUserApiKey(uri, token1, nil)
+	require.Nil(t, err, "show apikey")
+	require.Equal(t, http.StatusOK, status, "show apikey")
+	require.Equal(t, 0, len(apiKeys), "match api key count")
+
 	// cleanup orgs
 	testDeleteOrg(t, mcClient, uri, token, devOrg.Name)
 	testDeleteOrg(t, mcClient, uri, token, operOrg.Name)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6139: Getting 'Bad Request (400), Database error, record not found' on showuserapikey with a bad key
* EDGECLOUD-6164: Able to delete apikeys without specifying the apikeyid
* EDGECLOUD-6175: Apikey permission Manage should include View permission for the given resource