### PR TITLE
Match externally exposed federation port with container port

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -18,7 +18,6 @@ mc_api_port: 9900
 mc_ldap_port: 9389
 mc_vnc_port: 6080
 mc_notify_srv_port: 52001
-mc_federation_port_internal: 20001
 mc_federation_port: 30001
 notifyroot_port: 53001
 controller_notify_port: 37001

--- a/ansible/roles/mc/tasks/main.yml
+++ b/ansible/roles/mc/tasks/main.yml
@@ -81,10 +81,10 @@
 
     - name: Add federation address
       set_fact:
-        mc_args: "{{ mc_args + [ '-federationAddr', '0.0.0.0:' + mc_federation_port_internal|string ] }}"
+        mc_args: "{{ mc_args + [ '-federationAddr', '0.0.0.0:' + mc_federation_port|string ] }}"
 
     - set_fact:
-        fed_api_port_map: "127.0.0.1:{{ mc_federation_port_internal }}:{{ mc_federation_port_internal }}"
+        fed_api_port_map: "127.0.0.1:{{ mc_federation_port }}:{{ mc_federation_port }}"
 
     - name: Set up port map for federation API
       set_fact:

--- a/ansible/roles/web/tasks/main.yml
+++ b/ansible/roles/web/tasks/main.yml
@@ -8,6 +8,13 @@
 - set_fact:
     nginx_installed: true
 
+- name: Fetch default interface IP
+  shell: "ip route get 1.1.1.1 | sed -n 's/.* src \\([^ ]*\\).*$/\\1/p'"
+  register: def_intf_ip_cmd
+
+- set_fact:
+    default_interface_ip: "{{ def_intf_ip_cmd.stdout }}"
+
 - name: Install nginx config
   template:
     src: "{{ nginx_config_template }}"
@@ -55,3 +62,5 @@
 
 - import_tasks: certs.yml
   when: cert_domains is defined and cert_domains|length > 0
+
+- meta: flush_handlers

--- a/ansible/templates/mexplat/console-nginx-config.j2
+++ b/ansible/templates/mexplat/console-nginx-config.j2
@@ -137,7 +137,7 @@ server {
 {% if federated_mc|default(false)|bool %}
 
 server {
-	listen {{ mc_federation_port }} ssl;
+	listen {{ default_interface_ip }}:{{ mc_federation_port }} ssl;
 	listen [::]:{{ mc_federation_port }} ssl;
 
 	server_name {{ inventory_hostname }};
@@ -151,7 +151,7 @@ server {
 	ssl_ciphers '{{ nginx_ssl_ciphers }}';
 
 	location / {
-		proxy_pass http://127.0.0.1:{{ mc_federation_port_internal }};
+		proxy_pass http://127.0.0.1:{{ mc_federation_port }};
 		proxy_set_header Host $host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
MC container listens on port 30001 on 127.0.0.1, while the nginx reverse
proxy listens on the same port, but only on the default interface IP.
