### PR TITLE
EDGECLOUD-6160 disallow operator org for singlekubernetesclusterowner org

### DIFF
--- a/mc/orm/authz_cloudlet.go
+++ b/mc/orm/authz_cloudlet.go
@@ -248,6 +248,8 @@ func (s *AuthzCloudletKey) populate(ctx context.Context, region, username, orgfi
 	return err
 }
 
+const allianceDesc = "alliance"
+
 func authzCreateCloudlet(ctx context.Context, region, username string, obj *edgeproto.Cloudlet, resource, action string) error {
 	ops := []authOp{withRequiresOrg(obj.Key.Organization)}
 	for _, org := range obj.AllianceOrgs {
@@ -255,10 +257,10 @@ func authzCreateCloudlet(ctx context.Context, region, username string, obj *edge
 			// validation is not required as it is a partner operator
 			continue
 		}
-		ops = append(ops, withReferenceOrg(org, OrgTypeOperator))
+		ops = append(ops, withReferenceOrg(org, allianceDesc, OrgTypeOperator))
 	}
 	if obj.SingleKubernetesClusterOwner != "" {
-		ops = append(ops, withReferenceOrg(obj.SingleKubernetesClusterOwner, OrgTypeAny))
+		ops = append(ops, withReferenceOrg(obj.SingleKubernetesClusterOwner, "single kubernetes cluster owner", OrgTypeDeveloper))
 	}
 	if obj.PlatformType != edgeproto.PlatformType_PLATFORM_TYPE_EDGEBOX {
 		ops = append(ops, withNoEdgeboxOnly())
@@ -273,13 +275,13 @@ func authzUpdateCloudlet(ctx context.Context, region, username string, obj *edge
 			// validation is not required as it is a partner operator
 			continue
 		}
-		ops = append(ops, withReferenceOrg(org, OrgTypeOperator))
+		ops = append(ops, withReferenceOrg(org, allianceDesc, OrgTypeOperator))
 	}
 	return authorized(ctx, username, obj.Key.Organization, resource, action, ops...)
 }
 
 func authzAddCloudletAllianceOrg(ctx context.Context, region, username string, obj *edgeproto.CloudletAllianceOrg, resource, action string) error {
-	ops := []authOp{withReferenceOrg(obj.Organization, OrgTypeOperator)}
+	ops := []authOp{withReferenceOrg(obj.Organization, allianceDesc, OrgTypeOperator)}
 	return authorized(ctx, username, obj.Key.Organization, resource, action, ops...)
 }
 

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -1853,13 +1853,18 @@ func badPermTestReferenceOrg(t *testing.T, mcClient *mctestclient.Client, uri, t
 	regCloudlet.Cloudlet.AllianceOrgs = []string{"no-such-org"}
 	_, _, err := mcClient.CreateCloudlet(uri, token, &regCloudlet)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Org no-such-org not found")
+	require.Contains(t, err.Error(), "Alliance org no-such-org not found")
 
 	regCloudlet.Cloudlet.AllianceOrgs = nil
 	regCloudlet.Cloudlet.SingleKubernetesClusterOwner = "no-such-org"
 	_, _, err = mcClient.CreateCloudlet(uri, token, &regCloudlet)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "Org no-such-org not found")
+	require.Contains(t, err.Error(), "Single kubernetes cluster owner org no-such-org not found")
+
+	regCloudlet.Cloudlet.SingleKubernetesClusterOwner = operOrg
+	_, _, err = mcClient.CreateCloudlet(uri, token, &regCloudlet)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Operation for single kubernetes cluster owner org org3 only allowed for orgs of type developer")
 }
 
 func badPermTestAutoProvPolicy400(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.AutoProvPolicy)) {

--- a/mc/orm/userauth.go
+++ b/mc/orm/userauth.go
@@ -249,7 +249,7 @@ func authorized(ctx context.Context, sub, org, obj, act string, ops ...authOp) e
 			if refOrg.org == "" {
 				continue
 			}
-			if _, err := checkReferenceOrg(ctx, refOrg.org, refOrg.orgType); err != nil {
+			if _, err := checkReferenceOrg(ctx, refOrg.org, refOrg.orgDesc, refOrg.orgType); err != nil {
 				return err
 			}
 		}
@@ -267,7 +267,7 @@ func checkRequiresOrg(ctx context.Context, org, resource string, admin, noEdgebo
 	} else if _, ok := OperatorResourcesMap[resource]; ok {
 		orgType = OrgTypeOperator
 	}
-	lookup, err := checkReferenceOrg(ctx, org, orgType)
+	lookup, err := checkReferenceOrg(ctx, org, "", orgType)
 	if err != nil {
 		if _, ok := err.(OrgLookupError); ok && !admin {
 			// prevent bad actors from fishing for org names
@@ -291,14 +291,19 @@ func (e OrgLookupError) Error() string {
 }
 
 // Returns error if referenced org is not found or invalid.
-func checkReferenceOrg(ctx context.Context, org, orgType string) (*ormapi.Organization, error) {
+func checkReferenceOrg(ctx context.Context, org, orgDesc, orgType string) (*ormapi.Organization, error) {
 	// make sure org actually exists, and is not in the
 	// process of being deleted.
 	lookup, err := orgExists(ctx, org)
+	if orgDesc != "" {
+		orgDesc += " "
+	}
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelApi, "org exists check failed", "err", err)
 		if !strings.Contains(err.Error(), "not found") {
-			err = fmt.Errorf("Org %s lookup failed: %v", org, err)
+			err = fmt.Errorf("%sorg %s lookup failed: %v", orgDesc, org, err)
+		} else {
+			err = fmt.Errorf("%sorg %s not found", orgDesc, org)
 		}
 		lookupErr := OrgLookupError{
 			Err: err,
@@ -306,11 +311,11 @@ func checkReferenceOrg(ctx context.Context, org, orgType string) (*ormapi.Organi
 		return nil, lookupErr
 	}
 	if lookup.DeleteInProgress {
-		return lookup, fmt.Errorf("Operation not allowed for org %s with delete in progress", org)
+		return lookup, fmt.Errorf("Operation not allowed for %sorg %s with delete in progress", orgDesc, org)
 	}
 	// see if resource is only for a specific type of org
 	if orgType != OrgTypeAny && lookup.Type != orgType {
-		return lookup, fmt.Errorf("Operation only allowed for organizations of type %s", orgType)
+		return lookup, fmt.Errorf("Operation for %sorg %s only allowed for orgs of type %s", orgDesc, org, orgType)
 	}
 	return lookup, nil
 }
@@ -327,6 +332,7 @@ type authOptions struct {
 type refOrg struct {
 	org     string
 	orgType string
+	orgDesc string
 }
 
 type authOp func(opts *authOptions)
@@ -339,11 +345,12 @@ func withRequiresOrg(org string) authOp {
 	return func(opts *authOptions) { opts.requiresOrg = org }
 }
 
-func withReferenceOrg(org, orgType string) authOp {
+func withReferenceOrg(org, orgDesc, orgType string) authOp {
 	return func(opts *authOptions) {
 		ro := refOrg{
 			org:     org,
 			orgType: orgType,
+			orgDesc: orgDesc,
 		}
 		opts.refOrgs = append(opts.refOrgs, ro)
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6160 cloudlet create should not allow operator org for singlekubernetesclusterowner

### Description

Check for and disallow operator orgs for the single kubernetes cluster owner org, because developers will not be able to deploy to the k8s cluster if it's owned by an operator. The cluster should be owned by the target developer.

Also improved the error messages to indicate which org is at fault.