### PR TITLE
crmserver restaring on VCD when create cloudlet has a trust policy

### DIFF
--- a/infracommon/common-iptables.go
+++ b/infracommon/common-iptables.go
@@ -177,13 +177,14 @@ func getIpTablesEntriesForRule(ctx context.Context, direction string, label stri
 	if rule.PortRange != "" && rule.PortRange != "0" {
 		portStr = "--" + string(rule.PortEndpoint) + " " + rule.PortRange
 	}
+	protostr := ""
+	if rule.Protocol != "" {
+		rule.Protocol = strings.ToLower(rule.Protocol)
+		protostr = fmt.Sprintf("-p %s -m %s", rule.Protocol, rule.Protocol)
+	}
 	icmpType := ""
 	if rule.Protocol == "icmp" {
 		icmpType = " --icmp-type any"
-	}
-	protostr := ""
-	if rule.Protocol != "" {
-		protostr = fmt.Sprintf("-p %s -m %s", rule.Protocol, rule.Protocol)
 	}
 	ifstr := ""
 	if rule.InterfaceIn != "" {

--- a/vmlayer/iptables.go
+++ b/vmlayer/iptables.go
@@ -77,14 +77,24 @@ func (v *VMPlatform) setupForwardingIptables(ctx context.Context, client ssh.Cli
 	return nil
 }
 
+// iptable is case sensitive and does not like upper case for some options
+// convert protocol to lower case
+func fixupSecurityRules(ctx context.Context, rules []edgeproto.SecurityRule) {
+	for i, o := range rules {
+		rules[i].Protocol = strings.ToLower(o.Protocol)
+	}
+}
+
 // isTrustPolicy true means cloudlet level trustPolicy and false implies TrustPolicyException
 func (v *VMProperties) SetupIptablesRulesForRootLB(ctx context.Context, client ssh.Client, sshCidrsAllowed []string, isTrustPolicy bool, secGrpName string, rules []edgeproto.SecurityRule, commonSharedAccess bool) error {
 
 	if isTrustPolicy == true {
 		// The label used for TrustPolicy
 		secGrpName = infracommon.TrustPolicySecGrpNameLabel
+	} else {
+		// For TrustPolicyException, use input parameter secGrpName as the label
 	}
-	// For TrustPolicyException, use parameter secGrpName as the label
+	fixupSecurityRules(ctx, rules)
 
 	var netRules infracommon.FirewallRules
 	var ppRules infracommon.FirewallRules


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6196 crmserver restaring on VCD when create cloudlet has a trust policy

### Description
iptables -m option (explicit match) was broken by my commit
[EDGECLOUD-6156: requiredoutboundconnections and outboundsecurityrules should allow uppercase protocol](https://mobiledgex.atlassian.net/browse/EDGECLOUD-6156)

Fixing it in two places,

a) fix in lower most level 
This is in getIpTablesEntriesForRule()

b) fix it in the last common function that deals with  edgeproto.SecurityRule before converting it to FirewallRule and a string format for client.Output(cmd)
This happens to be in SetupIptablesRulesForRootLB()

This is blocking Andy from doing TPE testing on VCD.

### Unit-test
Jim and I both unit tested on a real VCD. 
Tested Create/Update cloudlet with TrustPolicy.
With and without diffs.

Many thanks @jlmorris3827 for helping with testing as well