### PR TITLE
Disallow users with no orgs from seeing events

### DIFF
--- a/mc/orm/authz_alert.go
+++ b/mc/orm/authz_alert.go
@@ -3,6 +3,7 @@ package orm
 import (
 	"context"
 
+	"github.com/labstack/echo"
 	"github.com/mobiledgex/edge-cloud/cloudcommon"
 	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
 )
@@ -16,6 +17,9 @@ func newShowAlertAuthz(ctx context.Context, region, username, resource, action s
 	orgs, err := enforcer.GetAuthorizedOrgs(ctx, username, resource, action)
 	if err != nil {
 		return nil, err
+	}
+	if len(orgs) == 0 {
+		return nil, echo.ErrForbidden
 	}
 	authz := AuthzAlert{
 		orgs: orgs,

--- a/mc/orm/billing_organization.go
+++ b/mc/orm/billing_organization.go
@@ -519,6 +519,9 @@ func ShowBillingOrgObj(ctx context.Context, claims *UserClaims) ([]ormapi.Billin
 	if err != nil {
 		return nil, err
 	}
+	if len(authOrgs) == 0 {
+		return nil, echo.ErrForbidden
+	}
 	_, isAdmin := authOrgs[""]
 	if isAdmin {
 		// super user, show all orgs
@@ -570,6 +573,9 @@ func ShowAccountInfoObj(ctx context.Context, claims *UserClaims) ([]ormapi.Accou
 	authOrgs, err := enforcer.GetAuthorizedOrgs(ctx, claims.Username, ResourceBilling, ActionManage)
 	if err != nil {
 		return nil, err
+	}
+	if len(authOrgs) == 0 {
+		return nil, echo.ErrForbidden
 	}
 	_, isAdmin := authOrgs[""]
 	if isAdmin {

--- a/mc/orm/eventsapi.go
+++ b/mc/orm/eventsapi.go
@@ -78,6 +78,9 @@ func EventTerms(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	if len(allowedOrgs) == 0 {
+		return echo.ErrForbidden
+	}
 	if _, found := allowedOrgs[""]; !found {
 		// non-admin, enforce allowed orgs in search
 		for k, _ := range allowedOrgs {

--- a/mc/orm/reporter.go
+++ b/mc/orm/reporter.go
@@ -609,6 +609,9 @@ func ShowReporter(c echo.Context) error {
 	if err != nil {
 		return ormutil.DbErr(err)
 	}
+	if len(authOrgs) == 0 {
+		return echo.ErrForbidden
+	}
 	_, admin := authOrgs[""]
 	_, orgFound := authOrgs[filter.Org]
 	if filter.Org != "" && !admin && !orgFound {

--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -632,6 +632,9 @@ func ShowUser(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	if len(authOrgs) == 0 {
+		return echo.ErrForbidden
+	}
 	_, admin := authOrgs[""]
 	_, orgFound := authOrgs[filterOrg]
 	if filterOrg != "" && !admin && !orgFound {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6223 User with no organization can see audit/event logs from other organizations

### Description

The ShowEvents API passes the filter of allowed orgs to ElasticSearch to do the filtering. Unlike our usual show commands, which checks if a record's org is part of the allowed orgs, ElasticSearch allows all records if allowed orgs are empty. This allowed a user to see events from organizations that they should not have.

To fix, we return Forbidden in eventsapi.go if the allowed orgs is empty. To make the behavior consistent, I also added Forbidden returns in other places where no authorized orgs are present (even though in those other cases, no unauthorized data is leaked, since an empty list is returned).