### PR TITLE
EDGECLOUD-6234: MC /artifactory/summary leaks user and org information

### DIFF
--- a/mc/orm/artifactory_sync.go
+++ b/mc/orm/artifactory_sync.go
@@ -274,7 +274,7 @@ func (s *AppStoreSync) syncGroupUsers(ctx context.Context, allOrgs map[string]*o
 }
 
 func ArtifactoryResync(c echo.Context) error {
-	err := SyncAccessCheck(c)
+	err := AdminAccessCheck(c)
 	if err != nil {
 		return err
 	}
@@ -284,6 +284,10 @@ func ArtifactoryResync(c echo.Context) error {
 }
 
 func ArtifactorySummary(c echo.Context) error {
+	err := AdminAccessCheck(c)
+	if err != nil {
+		return err
+	}
 	var summary AppStoreSummary
 
 	// Get MC users

--- a/mc/orm/gitlab_sync.go
+++ b/mc/orm/gitlab_sync.go
@@ -255,7 +255,7 @@ func (s *AppStoreSync) syncGroupMembers(ctx context.Context, allOrgs map[string]
 }
 
 func GitlabResync(c echo.Context) error {
-	err := SyncAccessCheck(c)
+	err := AdminAccessCheck(c)
 	if err != nil {
 		return err
 	}

--- a/mc/orm/role.go
+++ b/mc/orm/role.go
@@ -641,7 +641,7 @@ func ShowUserRoleObj(ctx context.Context, username string, filter map[string]int
 	return roles, nil
 }
 
-func SyncAccessCheck(c echo.Context) error {
+func AdminAccessCheck(c echo.Context) error {
 	claims, err := getClaims(c)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6234: MC /artifactory/summary leaks user and org information

### Description
* Only allow admin to access artifactory summary