### PR TITLE
EDGECLOUD-6236  Users can delete AlertReceviers from other orgs

### DIFF
--- a/mc/orm/alertmgr_api.go
+++ b/mc/orm/alertmgr_api.go
@@ -163,6 +163,12 @@ func DeleteAlertReceiver(c echo.Context) error {
 			ResourceUsers, ActionManage); err != nil {
 			return err
 		}
+
+		// also check that the user specified is is part of the org
+		if err := authorized(ctx, in.User, org, ResourceAlert, ActionView); err != nil {
+			return err
+		}
+
 	} else {
 		in.User = claims.Username
 	}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6236  Users can delete AlertReceviers from other orgs

### Description

Add a check for provided username against the org specified in the api. Added unit-test for this case as well.