### PR TITLE
EDGECLOUD-6231 make JWT valid duration configurable

### DIFF
--- a/e2e-tests/data/mc_showaudit_admin.yml
+++ b/e2e-tests/data/mc_showaudit_admin.yml
@@ -14,7 +14,7 @@
   username: mexadmin
   clientip: 127.0.0.1
   status: 200
-  request: '{"AdminPasswordMinCrackTimeSec":63072000,"DisableRateLimit":true,"FailedLoginLockoutThreshold1":3,"FailedLoginLockoutThreshold2":10,"FailedLoginLockoutTimeSec1":60,"FailedLoginLockoutTimeSec2":300,"MaxMetricsDataPoints":10000,"NotifyEmailAddress":"support@mobiledgex.com","PasswordMinCrackTimeSec":2592000,"RateLimitMaxTrackedIps":10000,"RateLimitMaxTrackedUsers":10000,"SkipVerifyEmail":true,"UserApiKeyCreateLimit":10}'
+  request: '{"AdminPasswordMinCrackTimeSec":63072000,"ApiKeyLoginTokenValidDuration":"4h0m0s","DisableRateLimit":true,"FailedLoginLockoutThreshold1":3,"FailedLoginLockoutThreshold2":10,"FailedLoginLockoutTimeSec1":60,"FailedLoginLockoutTimeSec2":300,"MaxMetricsDataPoints":10000,"NotifyEmailAddress":"support@mobiledgex.com","PasswordMinCrackTimeSec":2592000,"RateLimitMaxTrackedIps":10000,"RateLimitMaxTrackedUsers":10000,"SkipVerifyEmail":true,"UserApiKeyCreateLimit":10,"UserLoginTokenValidDuration":"24h0m0s","WebsocketTokenValidDuration":"2m0s"}'
 - operationname: /api/v1/login
   username: mexadmin
   clientip: 127.0.0.1

--- a/e2e-tests/data/mc_showaudit_all.yml
+++ b/e2e-tests/data/mc_showaudit_all.yml
@@ -26,7 +26,7 @@
   username: mexadmin
   clientip: 127.0.0.1
   status: 200
-  request: '{"AdminPasswordMinCrackTimeSec":63072000,"DisableRateLimit":true,"FailedLoginLockoutThreshold1":3,"FailedLoginLockoutThreshold2":10,"FailedLoginLockoutTimeSec1":60,"FailedLoginLockoutTimeSec2":300,"MaxMetricsDataPoints":10000,"NotifyEmailAddress":"support@mobiledgex.com","PasswordMinCrackTimeSec":2592000,"RateLimitMaxTrackedIps":10000,"RateLimitMaxTrackedUsers":10000,"SkipVerifyEmail":true,"UserApiKeyCreateLimit":10}'
+  request: '{"AdminPasswordMinCrackTimeSec":63072000,"ApiKeyLoginTokenValidDuration":"4h0m0s","DisableRateLimit":true,"FailedLoginLockoutThreshold1":3,"FailedLoginLockoutThreshold2":10,"FailedLoginLockoutTimeSec1":60,"FailedLoginLockoutTimeSec2":300,"MaxMetricsDataPoints":10000,"NotifyEmailAddress":"support@mobiledgex.com","PasswordMinCrackTimeSec":2592000,"RateLimitMaxTrackedIps":10000,"RateLimitMaxTrackedUsers":10000,"SkipVerifyEmail":true,"UserApiKeyCreateLimit":10,"UserLoginTokenValidDuration":"24h0m0s","WebsocketTokenValidDuration":"2m0s"}'
 - operationname: /api/v1/login
   username: mexadmin
   clientip: 127.0.0.1

--- a/e2e-tests/data/mcconfig.yml
+++ b/e2e-tests/data/mcconfig.yml
@@ -11,3 +11,6 @@ failedloginlockoutthreshold1: 3
 failedloginlockouttimesec1: 60
 failedloginlockoutthreshold2: 10
 failedloginlockouttimesec2: 300
+userlogintokenvalidduration: 24h0m0s
+apikeylogintokenvalidduration: 4h0m0s
+websockettokenvalidduration: 2m0s

--- a/e2e-tests/data/mcconfig_default.yml
+++ b/e2e-tests/data/mcconfig_default.yml
@@ -9,3 +9,6 @@ failedloginlockoutthreshold1: 3
 failedloginlockouttimesec1: 60
 failedloginlockoutthreshold2: 10
 failedloginlockouttimesec2: 300
+userlogintokenvalidduration: 24h0m0s
+apikeylogintokenvalidduration: 4h0m0s
+websockettokenvalidduration: 2m0s

--- a/e2e-tests/data/mcconfig_ratelimit_show.yml
+++ b/e2e-tests/data/mcconfig_ratelimit_show.yml
@@ -10,3 +10,6 @@ failedloginlockoutthreshold1: 3
 failedloginlockouttimesec1: 60
 failedloginlockoutthreshold2: 10
 failedloginlockouttimesec2: 300
+userlogintokenvalidduration: 24h0m0s
+apikeylogintokenvalidduration: 4h0m0s
+websockettokenvalidduration: 2m0s

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -2812,7 +2812,7 @@ func testUserApiKeys(t *testing.T, ctx context.Context, ds *testutil.DummyServer
 	_, err = Jwks.VerifyCookie(apiKeyLoginToken, &claims)
 	require.Nil(t, err, "parse token")
 	delta := claims.ExpiresAt - claims.IssuedAt
-	require.Equal(t, delta, int64(JWTShortDuration.Seconds()), "match short expiration time")
+	require.Equal(t, delta, int64((4 * time.Hour).Seconds()), "match short expiration time")
 
 	// user should not be able to create/delete/show apikey
 	userApiKeyObj.Permissions = []ormapi.RolePerm{

--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -75,11 +75,15 @@ func GenerateWSAuthToken(c echo.Context) error {
 		return err
 	}
 	ctx := ormutil.GetContext(c)
+	config, err := getConfig(ctx)
+	if err != nil {
+		return err
+	}
 
 	claims.StandardClaims.IssuedAt = time.Now().Unix()
 	// Set short expiry as it is intended to be used immediately
 	// by the client for connection to Websocket API endpoint
-	claims.StandardClaims.ExpiresAt = time.Now().Add(JWTWSAuthDuration).Unix()
+	claims.StandardClaims.ExpiresAt = time.Now().Add(config.WebsocketTokenValidDuration.TimeDuration()).Unix()
 	cookie, err := Jwks.GenerateCookie(claims)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelApi, "failed to generate cookie", "err", err)
@@ -245,7 +249,7 @@ func Login(c echo.Context) error {
 		}
 	}
 
-	cookie, err := GenerateCookie(&user, login.ApiKeyId, serverConfig.DomainName)
+	cookie, err := GenerateCookie(&user, login.ApiKeyId, serverConfig.DomainName, config)
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelApi, "failed to generate cookie", "err", err)
 		return fmt.Errorf("Failed to generate cookie")

--- a/mc/orm/userauth.go
+++ b/mc/orm/userauth.go
@@ -24,9 +24,6 @@ var PasswordMaxLength = 4096
 
 var BruteForceGuessesPerSecond = 1000000
 
-var JWTShortDuration = 4 * time.Hour
-var JWTWSAuthDuration = 2 * time.Minute
-
 var Jwks vault.JWKS
 var NoUserClaims *UserClaims = nil
 
@@ -91,12 +88,12 @@ func NewHTTPAuthCookie(token string, expires int64, domain string) *http.Cookie 
 	}
 }
 
-func GenerateCookie(user *ormapi.User, apiKeyId, domain string) (*http.Cookie, error) {
+func GenerateCookie(user *ormapi.User, apiKeyId, domain string, config *ormapi.Config) (*http.Cookie, error) {
 	claims := UserClaims{
 		StandardClaims: jwt.StandardClaims{
 			IssuedAt: time.Now().Unix(),
 			// 1 day expiration for now
-			ExpiresAt: time.Now().AddDate(0, 0, 1).Unix(),
+			ExpiresAt: time.Now().Add(config.UserLoginTokenValidDuration.TimeDuration()).Unix(),
 		},
 		Username: user.Name,
 		Email:    user.Email,
@@ -109,7 +106,7 @@ func GenerateCookie(user *ormapi.User, apiKeyId, domain string) (*http.Cookie, e
 		// rather than on user name
 		claims.Username = apiKeyId
 		// shorter expiration time if apiKeyId is specified
-		claims.ExpiresAt = time.Now().Add(JWTShortDuration).Unix()
+		claims.ExpiresAt = time.Now().Add(config.ApiKeyLoginTokenValidDuration.TimeDuration()).Unix()
 		claims.AuthType = ApiKeyAuth
 		claims.ApiKeyUsername = user.Name
 	} else {

--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -240,6 +240,12 @@ type Config struct {
 	FailedLoginLockoutThreshold2 int
 	// Number of seconds to lock account from logging in after threshold 2 is hit (default 300)
 	FailedLoginLockoutTimeSec2 int
+	// User login token valid duration (in format 2h30m10s, default 24h)
+	UserLoginTokenValidDuration edgeproto.Duration
+	// API key login token valid duration (in format 2h30m10s, default 4h)
+	ApiKeyLoginTokenValidDuration edgeproto.Duration
+	// Websocket auth token valid duration (in format 2h30m10s, default 2m)
+	WebsocketTokenValidDuration edgeproto.Duration
 }
 
 type McRateLimitFlowSettings struct {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6231 Make MC JWT session key valid time configurable

### Description

Security audit recommended to reduce the JWT token valid duration to 30 to 60 minutes. That seems a bit short for requiring users to have to log in again. Since there will never be one correct answer for all cases, this change makes it configurable.