### PR TITLE
EDGECLOUD-6226 sanitize runcommand at MC

### DIFF
--- a/e2e-tests/data/kind_user1_data_show.yml
+++ b/e2e-tests/data/kind_user1_data_show.yml
@@ -111,9 +111,6 @@ regiondata:
         disk: 1
       containerversion: "2019-10-24"
       controllercachereceived: true
-      resourcessnapshot:
-        platformvms:
-        - name: local-mac
       trustpolicystate: NotPresent
 - region: locala
   appdata:

--- a/mc/ctrlclient/custom.go
+++ b/mc/ctrlclient/custom.go
@@ -1,0 +1,20 @@
+package ctrlclient
+
+import (
+	"context"
+
+	"github.com/mobiledgex/edge-cloud-infra/mc/ormutil"
+	edgeproto "github.com/mobiledgex/edge-cloud/edgeproto"
+	"github.com/mobiledgex/edge-cloud/util"
+)
+
+func RunCommandValidateInput(ctx context.Context, rc *ormutil.RegionContext, obj *edgeproto.ExecRequest) error {
+	if obj.Cmd != nil {
+		sanitizedCmd, err := util.RunCommandSanitize(obj.Cmd.Command)
+		if err != nil {
+			return err
+		}
+		obj.Cmd.Command = sanitizedCmd
+	}
+	return nil
+}

--- a/mc/ctrlclient/exec.ctrl.go
+++ b/mc/ctrlclient/exec.ctrl.go
@@ -23,6 +23,9 @@ var _ = math.Inf
 // Auto-generated code: DO NOT EDIT
 
 func RunCommandObj(ctx context.Context, rc *ormutil.RegionContext, obj *edgeproto.ExecRequest, connObj ClientConnMgr) (*edgeproto.ExecRequest, error) {
+	if err := RunCommandValidateInput(ctx, rc, obj); err != nil {
+		return nil, err
+	}
 	conn, err := connObj.GetRegionConn(ctx, rc.Region)
 	if err != nil {
 		return nil, err

--- a/protoc-gen-mc2/genmc2.go
+++ b/protoc-gen-mc2/genmc2.go
@@ -366,6 +366,7 @@ func (g *GenMC2) getMethodArgs(service string, method *descriptor.MethodDescript
 		HasMethodArgs:        gensupport.HasMethodArgs(method),
 		HasFields:            gensupport.HasGrpcFields(in.DescriptorProto),
 		NotifyRoot:           GetMc2ApiNotifyroot(method),
+		CustomValidateInput:  GetMc2CustomValidateInput(method),
 	}
 	if gensupport.GetMessageKey(in.DescriptorProto) != nil || gensupport.GetObjAndKey(in.DescriptorProto) {
 		args.HasKey = true
@@ -527,6 +528,7 @@ type tmplArgs struct {
 	CliUse               string
 	CliShort             string
 	CliGroup             string
+	CustomValidateInput  bool
 }
 
 var tmplApi = `
@@ -716,6 +718,11 @@ func {{.MethodName}}Obj(ctx context.Context, rc *ormutil.RegionContext, obj *edg
 {{- else}}
 func {{.MethodName}}Obj(ctx context.Context, rc *ormutil.RegionContext, obj *edgeproto.{{.InName}}, connObj ClientConnMgr) (*edgeproto.{{.OutName}}, error) {
 {{- end}}
+{{- end}}
+{{- if .CustomValidateInput}}
+	if err := {{.MethodName}}ValidateInput(ctx, rc, obj); err != nil {
+		return {{.ReturnErrArg}}err
+	}
 {{- end}}
 {{- if .NotifyRoot}}
         conn, err := connObj.GetNotifyRootConn(ctx)
@@ -1167,6 +1174,10 @@ func GetMc2CustomAuthz(method *descriptor.MethodDescriptorProto) bool {
 
 func GetMc2ApiNotifyroot(method *descriptor.MethodDescriptorProto) bool {
 	return proto.GetBoolExtension(method.Options, protogen.E_Mc2ApiNotifyroot, false)
+}
+
+func GetMc2CustomValidateInput(method *descriptor.MethodDescriptorProto) bool {
+	return proto.GetBoolExtension(method.Options, protogen.E_Mc2CustomValidateInput, false)
 }
 
 func GetCliCmd(method *descriptor.MethodDescriptorProto) string {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6226 Runcommand allows running commands in parent VM

### Description

This adds an additional redundant fix to the run command exploit. In addition to sanitizing the command at the place it is run (in the CRM), we also sanitize it at the MC. This is redundant but serves two advantages: 1) we don't need to send the command all the way down to the CRM just for it to fail, 2) as a hot fix we won't need to redeploy the CRMs for the fix to take affect, we only need to redeploy the MCs which is much easier.

We leave the sanitization at the CRM as well in case the architecture changes in the future and commands are issue from another client instead of the MC.