### PR TITLE
EDGECLOUD-6235 Redact unneccessary info from MC API controller show

### DIFF
--- a/e2e-tests/data/mc_flavors.yml
+++ b/e2e-tests/data/mc_flavors.yml
@@ -1,15 +1,6 @@
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
-  influxdb: http://127.0.0.1:8086
-  thanosmetrics: http://127.0.0.1:29090
-  dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
-  influxdb: http://127.0.0.1:8087
-  dnsregion: locala
 regiondata:
 - region: local
   appdata:

--- a/e2e-tests/data/mc_user1_data_show.yml
+++ b/e2e-tests/data/mc_user1_data_show.yml
@@ -1,15 +1,6 @@
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
-  influxdb: http://127.0.0.1:8086
-  thanosmetrics: http://127.0.0.1:29090
-  dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
-  influxdb: http://127.0.0.1:8087
-  dnsregion: locala
 orgs:
 - name: azure
   type: operator

--- a/e2e-tests/data/mc_user1_federated_data_show.yml
+++ b/e2e-tests/data/mc_user1_federated_data_show.yml
@@ -1,15 +1,6 @@
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
-  influxdb: http://127.0.0.1:8086
-  thanosmetrics: http://127.0.0.1:29090
-  dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
-  influxdb: http://127.0.0.1:8087
-  dnsregion: locala
 orgs:
 - name: azure
   type: operator

--- a/e2e-tests/data/mc_user2_data_show.yml
+++ b/e2e-tests/data/mc_user2_data_show.yml
@@ -1,15 +1,6 @@
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
-  influxdb: http://127.0.0.1:8086
-  thanosmetrics: http://127.0.0.1:29090
-  dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
-  influxdb: http://127.0.0.1:8087
-  dnsregion: locala
 billingorgs:
 - name: AcmeAppCo
   type: self

--- a/e2e-tests/data/mc_user3_data_show.yml
+++ b/e2e-tests/data/mc_user3_data_show.yml
@@ -1,15 +1,6 @@
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
-  influxdb: http://127.0.0.1:8086
-  thanosmetrics: http://127.0.0.1:29090
-  dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
-  influxdb: http://127.0.0.1:8087
-  dnsregion: locala
 billingorgs:
 - name: user3org
   type: self

--- a/e2e-tests/data/mc_user3_empty_show.yml
+++ b/e2e-tests/data/mc_user3_empty_show.yml
@@ -1,15 +1,6 @@
 controllers:
 - region: local
-  address: 127.0.0.1:55001
-  notifyaddr: 127.0.0.1:37001
-  influxdb: http://127.0.0.1:8086
-  thanosmetrics: http://127.0.0.1:29090
-  dnsregion: local
 - region: locala
-  address: 127.0.0.1:55011
-  notifyaddr: 127.0.0.1:37011
-  influxdb: http://127.0.0.1:8087
-  dnsregion: locala
 billingorgs:
 - name: user3org
   type: self

--- a/mc/mcctl/ormctl/controller.go
+++ b/mc/mcctl/ormctl/controller.go
@@ -37,7 +37,7 @@ func init() {
 		Name:         "ShowController",
 		Use:          "show",
 		Short:        "Show regional controllers",
-		OptionalArgs: "region address notifyaddr influxdb",
+		OptionalArgs: "region",
 		Comments:     ormapi.ControllerComments,
 		ReqData:      &ormapi.Controller{},
 		ReplyData:    &[]ormapi.Controller{},

--- a/mc/orm/ctrl.go
+++ b/mc/orm/ctrl.go
@@ -344,6 +344,13 @@ func ShowController(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+	if err := authorized(ctx, claims.Username, "", ResourceControllers, ActionView); err != nil {
+		// non-admins can only see the region
+		for ii, ctrl := range ctrls {
+			ctrls[ii] = ormapi.Controller{}
+			ctrls[ii].Region = ctrl.Region
+		}
+	}
 	return ormutil.SetReply(c, ctrls)
 }
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6235 Redact unneccessary info from MC API controller show

### Description

ShowController can be run by any authenticated user, because it is used by the UI to get the available regions. However, the other information in ShowController is for internal use only and should not be exposed to regular users. So it is only shown to admins, and redacted for regular users.