### PR TITLE
remove cloudlet-wide egress rules for VCD

### DIFF
--- a/crm-platforms/vcd/vcd-security.go
+++ b/crm-platforms/vcd/vcd-security.go
@@ -542,7 +542,7 @@ func (v *VcdPlatform) ConfigureCloudletSecurityRules(ctx context.Context, egress
 		isTrustPolicy = true
 	}
 	secGrpName := v.vmProperties.CloudletSecgrpName
-	log.SpanLog(ctx, log.DebugLevelInfra, "ConfigureCloudletSecurityRules", "egressRestricted", egressRestricted, "TrustPolicy", TrustPolicy, "action", action)
+	log.SpanLog(ctx, log.DebugLevelInfra, "ConfigureCloudletSecurityRules", "egressRestricted", egressRestricted, "TrustPolicy", TrustPolicy, "action", action, "secGrpName", secGrpName)
 
 	return v.configureVCDSecurityRulesCommon(ctx, egressRestricted, isTrustPolicy, secGrpName, TrustPolicy.OutboundSecurityRules, rootlbClients, action, updateCallback)
 }

--- a/infracommon/common-iptables.go
+++ b/infracommon/common-iptables.go
@@ -191,14 +191,14 @@ func getIpTablesEntriesForRule(ctx context.Context, direction string, label stri
 func (c *CommonPlatform) DeleteIptableRulesForCloudletWideLabel(ctx context.Context, client ssh.Client) error {
 	label := "cloudlet-wide"
 	cloudletWideRules, err := getCurrentIptableRulesForLabel(ctx, client, label)
-	if err == nil {
+	if err == nil && len(cloudletWideRules) != 0 {
 		log.SpanLog(ctx, log.DebugLevelInfra, "DeleteIptableRulesForCloudletWideLabel", "Found cloudletWideRules", cloudletWideRules)
 		c.DeleteCloudletFirewallRules(ctx, client)
 	}
 	return err
 }
 
-// CreateCloudletFirewallRules adds cloudlet-wide egress rules based on properties
+// DeleteCloudletFirewallRules deletes cloudlet-wide rules based on properties
 func (c *CommonPlatform) DeleteCloudletFirewallRules(ctx context.Context, client ssh.Client) error {
 	log.SpanLog(ctx, log.DebugLevelInfra, "DeleteCloudletFirewallRules")
 

--- a/vmlayer/iptables.go
+++ b/vmlayer/iptables.go
@@ -85,10 +85,22 @@ func fixupSecurityRules(ctx context.Context, rules []edgeproto.SecurityRule) {
 	}
 }
 
+func (v *VMProperties) cleanupRules(ctx context.Context, client ssh.Client) {
+	log.SpanLog(ctx, log.DebugLevelInfra, "cleanupRules", "secGrpName", v.CloudletSecgrpName)
+
+	// Delete cloudlet-wide rules if any
+	err := v.CommonPf.DeleteIptableRulesForCloudletWideLabel(ctx, client)
+	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfra, "DeleteIptableRulesForCloudletWideLabel() failed", "err", err)
+	}
+
+	infracommon.RemoveTrustPolicyIfExists(ctx, client, false, v.CloudletSecgrpName)
+}
+
 // isTrustPolicy true means cloudlet level trustPolicy and false implies TrustPolicyException
 func (v *VMProperties) SetupIptablesRulesForRootLB(ctx context.Context, client ssh.Client, sshCidrsAllowed []string, isTrustPolicy bool, secGrpName string, rules []edgeproto.SecurityRule, commonSharedAccess bool) error {
 
-	if isTrustPolicy == true {
+	if isTrustPolicy {
 		// The label used for TrustPolicy
 		secGrpName = infracommon.TrustPolicySecGrpNameLabel
 	} else {
@@ -100,13 +112,9 @@ func (v *VMProperties) SetupIptablesRulesForRootLB(ctx context.Context, client s
 	var ppRules infracommon.FirewallRules
 
 	//First create the global rules on this LB
-	log.SpanLog(ctx, log.DebugLevelInfra, "SetupIptablesRulesForRootLB", "isTrustPolicy", isTrustPolicy)
+	log.SpanLog(ctx, log.DebugLevelInfra, "SetupIptablesRulesForRootLB", "isTrustPolicy", isTrustPolicy, "secGrpName", secGrpName)
 	if isTrustPolicy {
-		// Delete cloudlet-wide rules if any
-		err := v.CommonPf.DeleteIptableRulesForCloudletWideLabel(ctx, client)
-		if err != nil {
-			log.SpanLog(ctx, log.DebugLevelInfra, "DeleteIptableRulesForCloudletWideLabel() failed", "err", err)
-		}
+		v.cleanupRules(ctx, client)
 		// Allow SSH from provided cidrs
 		for _, netCidr := range sshCidrsAllowed {
 			sshIngress := infracommon.FirewallRule{
@@ -144,7 +152,7 @@ func (v *VMProperties) SetupIptablesRulesForRootLB(ctx context.Context, client s
 	if err != nil {
 		log.SpanLog(ctx, log.DebugLevelInfra, "SetupIpTablesRulesForRootLB removeTrustPolicyIfExists fail", "error", err)
 	}
-	if len(rules) == 0 {
+	if isTrustPolicy == false && len(rules) == 0 {
 		// a privacy policy with no rules means we need to open all egress traffic
 		log.SpanLog(ctx, log.DebugLevelInfra, "SetupIpTablesRulesForRootLB empty OutboundSecRules removeIfExist")
 		allowEgressAll = true


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6220 TrustPolicy on VCD not blocking egress ports correctly

### Description

removed legacy cloudlet-wide egress rules for VCD which are no longer needed.

These properties MEX_CLOUDLET_FIREWALL_WHITELIST_EGRESS and  MEX_CLOUDLET_FIREWALL_WHITELIST_INGRESS are no longer needed. 

Many thanks to @jlmorris3827 for the guidance.

### Unit-test

On a real VCD.

2022-03-08T18:56:03.912+0530	INFO	7c59b258e6c23514	vmlayer/server.go:86	GetIPFromServerDetails	{"server": "[devdattacloudletvcdaaa.packet.mobiledgex.net](http://devdattacloudletvcdaaa.packet.mobiledgex.net/)", "networkName": "ext-net", "portName": "", "serverDetail": {"Addresses":[{"MacAddress":"00:50:56:01:57:ef","InternalAddr":"10.201.0.1","ExternalAddr":"10.201.0.1","Network":"mex-k8s-net-1","PortName":"[devdattacloudletvcdaaa.packet.mobiledgex.net](http://devdattacloudletvcdaaa.packet.mobiledgex.net/)-devdattacloudletvcdaaa.packet.mobiledgex.net-common-internal-port","ExternalAddrIsFloating":false},{"MacAddress":"00:50:56:01:29:e4","InternalAddr":"139.178.87.4","ExternalAddr":"139.178.87.4","Network":"ext-net","PortName":"devdattacloudletvcdaaa.packet.mobiledgex.net-ext-net-port","ExternalAddrIsFloating":false}],"ID":"urn:vcloud:vm:3acc6e35-e0df-4206-bd3a-e70bddf8edd0","Name":"devdattacloudletvcdaaa.packet.mobiledgex.net","Status":"ACTIVE"}}


ec controller CreateTrustPolicy cloudletorg=packet name=TP123 'outboundsecurityrules:0.protocol=TCp outboundsecurityrules:0.portrangemin=5555 outboundsecurityrules:0.remotecidr=55.55.55.55/24'

ec controller  UpdateCloudlet cloudletorg=packet cloudlet=devdattaCloudletVcdAAA trustpolicy=TP123



devdatta@Dajgaonkar-MAC:~/go/src/github.com/mobiledgex/edge-cloud-infra/mgmt/vault (master)$ ./vssh 139.178.87.4

1) iptables comparison, without diffs  v/s with diffs,  attached to jira.

2) traffic tests

## without diffs :
ubuntu@devdattacloudletvcdaaa:~ ping google.com
PING google.com (142.251.32.174) 56(84) bytes of data.
64 bytes from dfw28s30-in-f14.1e100.net (142.251.32.174): icmp_seq=1 ttl=117 time=0.414 ms
64 bytes from dfw28s30-in-f14.1e100.net (142.251.32.174): icmp_seq=2 ttl=117 time=0.484 ms
64 bytes from dfw28s30-in-f14.1e100.net (142.251.32.174): icmp_seq=3 ttl=117 time=0.424 ms
64 bytes from dfw28s30-in-f14.1e100.net (142.251.32.174): icmp_seq=4 ttl=117 time=0.449 ms
^C
--- google.com ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3045ms
rtt min/avg/max/mdev = 0.414/0.442/0.484/0.037 ms
ubuntu@devdattacloudletvcdaaa:~

## with diffs:
ubuntu@devdattacloudletvcdaaa:~ while true; do curl google.com; sleep 1; done
curl: (6) Could not resolve host: google.com
curl: (6) Could not resolve host: google.com
^C
ubuntu@devdattacloudletvcdaaa:~ ping google.com
ping: google.com: Temporary failure in name resolution
ubuntu@devdattacloudletvcdaaa:~ ping 8.8.8.8
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
ping: sendmsg: Operation not permitted
ping: sendmsg: Operation not permitted
ping: sendmsg: Operation not permitted
ping: sendmsg: Operation not permitted
ping: sendmsg: Operation not permitted
^C
--- 8.8.8.8 ping statistics ---
5 packets transmitted, 0 received, 100% packet loss, time 4085ms

