### PR TITLE
Fix MC config upgrade

### DIFF
--- a/mc/orm/config.go
+++ b/mc/orm/config.go
@@ -46,6 +46,7 @@ func InitConfig(ctx context.Context) error {
 		return err
 	}
 
+	config = ormapi.Config{ID: config.ID}
 	err = db.First(&config).Error
 	if err != nil {
 		return err
@@ -103,6 +104,10 @@ func InitConfig(ctx context.Context) error {
 	}
 	if config.WebsocketTokenValidDuration == 0 {
 		config.WebsocketTokenValidDuration = defaultConfig.WebsocketTokenValidDuration
+		save = true
+	}
+	if config.NotifyEmailAddress == "" {
+		config.NotifyEmailAddress = defaultConfig.NotifyEmailAddress
 		save = true
 	}
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6264 Unable to login to Console UI. Developer Tools shows HTTP 400 "{"message":"No bearer token found"}"

### Description
* `db.First` was using `defaultConfig` as filter, which might not match with what is present in DB and hence it was using `defaultConfig` rather than what is there in DB
* Fixed the code & added unit-test for the same