### PR TITLE
Show appropriate error for missing record errors from DB

### DIFF
--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -2788,6 +2788,14 @@ func testUserApiKeys(t *testing.T, ctx context.Context, ds *testutil.DummyServer
 	require.Contains(t, err.Error(), "Invalid permission specified", "err match")
 	require.Equal(t, http.StatusBadRequest, status, "bad request")
 
+	// invalid org should throw appropriate error
+	validOrg := userApiKeyObj.Org
+	userApiKeyObj.Org = "invalidOrg"
+	_, status, err = mcClient.CreateUserApiKey(uri, token1, &userApiKeyObj)
+	require.NotNil(t, err, "invalid org specified")
+	require.Contains(t, err.Error(), "Invalid org specified", "err match")
+	userApiKeyObj.Org = validOrg
+
 	// user should be able to create api key if action, resource input are correct
 	testRemoveUserRole(t, mcClient, uri, token, operOrg.Name, "OperatorViewer", user1.Name, Success)
 	testAddUserRole(t, mcClient, uri, token, operOrg.Name, "OperatorManager", user1.Name, Success)
@@ -2910,6 +2918,12 @@ func testUserApiKeys(t *testing.T, ctx context.Context, ds *testutil.DummyServer
 	require.NotNil(t, err, "delete user")
 	require.Equal(t, http.StatusForbidden, status, "forbidden")
 	require.Contains(t, err.Error(), "Forbidden", "err matches")
+
+	// deletion with invalid API key id should fail with appropriate error
+	delInvalidKeyObj := ormapi.CreateUserApiKey{UserApiKey: ormapi.UserApiKey{Id: "invalidAPIKeyId"}}
+	_, err = mcClient.DeleteUserApiKey(uri, token1, &delInvalidKeyObj)
+	require.NotNil(t, err, "invalid api key id")
+	require.Contains(t, err.Error(), "API key ID not found", "err matches")
 
 	// deletion of apikey should result in deletion of respective roles
 	delKeyObj = ormapi.CreateUserApiKey{UserApiKey: ormapi.UserApiKey{Id: resp.Id}}

--- a/mc/orm/user.go
+++ b/mc/orm/user.go
@@ -1161,9 +1161,12 @@ func CreateUserApiKey(c echo.Context) error {
 	// verify that specified org exists
 	org := ormapi.Organization{}
 	org.Name = apiKeyObj.Org
-	err = db.Where(&org).First(&org).Error
-	if err != nil {
-		return ormutil.DbErr(err)
+	res := db.Where(&org).First(&org)
+	if res.RecordNotFound() {
+		return fmt.Errorf("Invalid org specified")
+	}
+	if res.Error != nil {
+		return ormutil.DbErr(res.Error)
 	}
 
 	lookupOrg := apiKeyObj.Org
@@ -1256,9 +1259,12 @@ func DeleteUserApiKey(c echo.Context) error {
 		return fmt.Errorf("Missing API key ID")
 	}
 	apiKeyObj := ormapi.UserApiKey{Id: lookup.Id}
-	err = db.Where(&apiKeyObj).First(&apiKeyObj).Error
-	if err != nil {
-		return ormutil.DbErr(err)
+	res := db.Where(&apiKeyObj).First(&apiKeyObj)
+	if res.RecordNotFound() {
+		return fmt.Errorf("API key ID not found")
+	}
+	if res.Error != nil {
+		return ormutil.DbErr(res.Error)
 	}
 	apiKeyRole := getApiKeyRoleName(apiKeyObj.Id)
 	err = enforcer.RemovePolicy(ctx, apiKeyRole)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6210: Createuserapikey with a bad org name giving "Database error, record not found" error
* EDGECLOUD-6212: Deleteuserapikey giving "Database error, record not found" when given a bad apikeyid