### PR TITLE
update az cli

### DIFF
--- a/docker/Dockerfile.edge-cloud-base-image
+++ b/docker/Dockerfile.edge-cloud-base-image
@@ -54,7 +54,7 @@ RUN curl -sL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
 RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" >/etc/apt/sources.list.d/kubernetes.list
 
 RUN apt-get update && apt-get install -y \
-	azure-cli=2.0.75-1~bionic \
+	azure-cli=2.34.1-1~bionic \
 	google-cloud-sdk=267.0.0-0 \
 	kubectl=1.16.2-00 \
 	qemu-utils=1:2.11+dfsg-1ubuntu7.38


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5753  k8s cluster creation fails on Azure

### Description

Microsoft made an Azure change a while ago which caused our current version of az-cli to fail on cluster creation. Fix is to update the version in the base docker image.
