### PR TITLE
EDGECLOUD-6269 check for 201 return from Gitlab user create

### DIFF
--- a/mc/orm/gitlab.go
+++ b/mc/orm/gitlab.go
@@ -69,7 +69,7 @@ func gitlabCreateLDAPUser(ctx context.Context, user *ormapi.User) error {
 		CanCreateGroup:   &_false,
 	}
 	_, resp, err := gitlabClient.Users.CreateUser(&opts)
-	if err == nil && resp.StatusCode != http.StatusOK {
+	if err == nil && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		if resp.StatusCode == http.StatusConflict {
 			// user already exists
 			err = fmt.Errorf("gitlab create user failed, user already exists")

--- a/mc/orm/gitlab_test.go
+++ b/mc/orm/gitlab_test.go
@@ -164,7 +164,7 @@ func (s *GitlabMock) registerCreateUser() {
 			}
 			s.users[user.ID] = &user
 			log.DebugLog(log.DebugLevelApi, "gitlab mock created user", "user", user)
-			return httpmock.NewJsonResponse(200, user)
+			return httpmock.NewJsonResponse(201, user)
 		},
 	)
 }


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6269 User create fails with "Gitlab create user failed: 201" error

### Description

Gitlab create user returns 201 (created) instead of 200 (success), so the success check needed to be fixed.