### PR TITLE
EDGECLOUD-6281 fix gitlab get user for user delete

### DIFF
--- a/e2e-tests/int-process/process_defs.go
+++ b/e2e-tests/int-process/process_defs.go
@@ -15,6 +15,7 @@ type MC struct {
 	NotifyAddrs             string
 	RolesFile               string
 	LdapAddr                string
+	GitlabAddr              string
 	NotifySrvAddr           string
 	ConsoleProxyAddr        string
 	AlertResolveTimeout     string

--- a/e2e-tests/int-process/process_local.go
+++ b/e2e-tests/int-process/process_local.go
@@ -53,6 +53,10 @@ func (p *MC) StartLocal(logfile string, opts ...process.StartOp) error {
 		args = append(args, "--ldapAddr")
 		args = append(args, p.LdapAddr)
 	}
+	if p.GitlabAddr != "" {
+		args = append(args, "--gitlabAddr")
+		args = append(args, p.GitlabAddr)
+	}
 	if p.NotifySrvAddr != "" {
 		args = append(args, "--notifySrvAddr")
 		args = append(args, p.NotifySrvAddr)

--- a/mc/orm/appstore_sync_test.go
+++ b/mc/orm/appstore_sync_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,6 +175,56 @@ func TestAppStoreApi(t *testing.T) {
 	rtf := NewArtifactoryMock(artifactoryAddr)
 	// mock gitlab
 	gm := NewGitlabMock(gitlabAddr)
+
+	// basic direct api tests
+	for user, _ := range testEntries[0].Users {
+		userObj := ormapi.User{
+			Name:  user,
+			Email: user + "@email.com",
+		}
+		// gitlab create user
+		err := gitlabCreateLDAPUser(ctx, &userObj)
+		require.Nil(t, err, user)
+		// check that we can get user
+		gitlabUser, err := gitlabGetLDAPUser(user)
+		require.Nil(t, err, user)
+		require.Equal(t, user, gitlabUser.Name)
+		// create again should fail
+		err = gitlabCreateLDAPUser(ctx, &userObj)
+		require.NotNil(t, err, user)
+		// delete user
+		err = gitlabDeleteLDAPUser(ctx, user)
+		require.Nil(t, err, user)
+		// user should not exist
+		_, err = gitlabGetLDAPUser(user)
+		require.NotNil(t, err, user)
+		// delete again should fail
+		err = gitlabDeleteLDAPUser(ctx, user)
+		require.NotNil(t, err, user)
+
+		// artifactory create user
+		err = artifactoryCreateLDAPUser(ctx, &userObj)
+		require.Nil(t, err, user)
+		// check that we can get user
+		artUsers, err := artifactoryListUsers(ctx)
+		require.Nil(t, err, user)
+		_, found := artUsers[strings.ToLower(user)]
+		require.True(t, found, user)
+		// create again should fail
+		err = artifactoryCreateLDAPUser(ctx, &userObj)
+		require.NotNil(t, err, user)
+		// delete user
+		err = artifactoryDeleteLDAPUser(ctx, user)
+		require.Nil(t, err, user)
+		// user should not exist
+		artUsers, err = artifactoryListUsers(ctx)
+		require.Nil(t, err, user)
+		_, found = artUsers[strings.ToLower(user)]
+		require.False(t, found, user)
+		// delete again should fail
+		err = artifactoryDeleteLDAPUser(ctx, user)
+		require.NotNil(t, err, user)
+	}
 
 	// create "missing" data in MC but not in Art/Gitlab
 	for _, v := range missingEntries {

--- a/mc/orm/gitlab_test.go
+++ b/mc/orm/gitlab_test.go
@@ -150,6 +150,9 @@ func (s *GitlabMock) registerCreateUser() {
 			if opt.Email != nil {
 				user.Email = *opt.Email
 			}
+			// gitlab does not set the provider in the user.Provider
+			// field, it is set with the Identities.Provider field.
+			// Leave user.Provider blank.
 			if opt.Provider != nil && opt.ExternUID != nil {
 				identity := gitlab.UserIdentity{
 					Provider:  *opt.Provider,
@@ -158,9 +161,6 @@ func (s *GitlabMock) registerCreateUser() {
 				ids := make([]*gitlab.UserIdentity, 0)
 				ids = append(ids, &identity)
 				user.Identities = ids
-			}
-			if opt.Provider != nil {
-				user.Provider = *opt.Provider
 			}
 			s.users[user.ID] = &user
 			log.DebugLog(log.DebugLevelApi, "gitlab mock created user", "user", user)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6281 user delete is not deleting the user from gitlab

### Description

My recent change to add a user lookup to verify the user is an LDAP user on gitlab delete user was wrong, as it failed because the provider was specified without the external UID. Instead just verify the user is LDAP from the returned identities.