### PR TITLE
Hosted Artifactory instance for QA testing

### DIFF
--- a/ansible/qa/group_vars/all
+++ b/ansible/qa/group_vars/all
@@ -1,3 +1,4 @@
+mc_artifactory_address: https://mexqa.jfrog.io/artifactory
 jaeger_hostname: jaeger-{{ deploy_environ }}.mobiledgex.net
 jaeger_endpoint: "https://{{ jaeger_hostname }}:14268/api/traces"
 console_vnc_hostname: console-qa-vnc.mobiledgex.net


### PR DESCRIPTION
This is only for user management tests. The amount of storage space
available is not sufficient for even a single VM image.
