### PR TITLE
EDGECLOUD-6285: Fix websocket error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ mc/orm/testAlertMgrConfig.yml
 *.auto.tfvars.json
 
 version/version.go
+
+# redis
+dump.rdb

--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -1497,6 +1497,13 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 		// the callback func is only called when data is read back.
 		// Test Websocket connection
 		wsuri := "ws://" + addr + "/ws/api/v1"
+		// validate the error is received with appropriate error code on invalid token
+		status, err = restClient.PostJsonStreamOut(wsuri+"/auth/ctrl/CreateClusterInst",
+			"invalidToken", &dat, &wsOut, func() {
+			})
+		require.NotNil(t, err, "invalid token error")
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Equal(t, "Invalid or expired jwt", err.Error())
 		status, err = restClient.PostJsonStreamOut(wsuri+"/auth/ctrl/CreateClusterInst",
 			token, &dat, &wsOut, func() {
 				// got a result, trigger next result


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6285: Fix websocket error handling

### Description
* On auth failure, the error was not handled correctly. For WebSocket, we must send the error along with the error code to the remote client. And also, send a message to close the connection normally.