### PR TITLE
Fix MC cleanup crash on CTRL-C

### DIFF
--- a/mc/mc.go
+++ b/mc/mc.go
@@ -57,7 +57,6 @@ func main() {
 	nodeMgr.InitFlags()
 	flag.Parse()
 	log.SetDebugLevelStrs(*debugLevels)
-	defer nodeMgr.Finish()
 
 	sigChan = make(chan os.Signal, 1)
 


### PR DESCRIPTION
* This is not a severe issue, but the following crash on `CTRL-C` was irritating me :)
```
panic: close of closed channel

goroutine 1 [running]:
github.com/mobiledgex/edge-cloud/cloudcommon/node.(*NodeMgr).Finish(0x812d120)
	/Users/ashishjain/go/src/github.com/mobiledgex/edge-cloud/cloudcommon/node/nodemgr.go:200 +0xba
main.main()
	/Users/ashishjain/go/src/github.com/mobiledgex/edge-cloud-infra/mc/mc.go:120 +0x7b1
```
* Looks like `nodeMgr.Finish()` was being called in two places. Since we already call it as part of server stop: https://github.com/mobiledgex/edge-cloud-infra/blob/master/mc/orm/server.go#L1089, I have removed it from main code.