### PR TITLE
EDGECLOUD-6295 Upgrade base image to address CVE-2022-0778

### DIFF
--- a/chef/policyfiles/base.lock.json
+++ b/chef/policyfiles/base.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "6e273af328005c89813649e709cec098816a679f820ea433da013baa9cd2c04b",
+  "revision_id": "460415f8f146457d698cc07c358c2255201d0474ad633b77a763002dd259465c",
   "name": "base",
   "run_list": [
     "recipe[chef_client_updater::default]",
@@ -82,9 +82,9 @@
   },
   "default_attributes": {
     "upgrade_mobiledgex_package": {
-      "repo": "https://apt.mobiledgex.net/cirrus/2022-02-25"
+      "repo": "https://apt.mobiledgex.net/cirrus/2022-03-16"
     },
-    "mobiledgeXPackageVersion": "4.9.2",
+    "mobiledgeXPackageVersion": "4.10.0",
     "chef_client_updater": {
       "version": "17.6.18"
     }

--- a/chef/policyfiles/base.rb
+++ b/chef/policyfiles/base.rb
@@ -17,8 +17,8 @@ cookbook 'set_security_policies', '= 1.0.0'
 cookbook 'setup_teleport', '= 1.1.0'
 cookbook 'upgrade_mobiledgex_package', '= 1.1.1'
 
-default['upgrade_mobiledgex_package']['repo'] = "https://apt.mobiledgex.net/cirrus/2022-02-25"
-default['mobiledgeXPackageVersion'] = '4.9.2'
+default['upgrade_mobiledgex_package']['repo'] = "https://apt.mobiledgex.net/cirrus/2022-03-16"
+default['mobiledgeXPackageVersion'] = '4.10.0'
 
 # Set chef-client version
 # IMP: Version of chef client here needs to match the version in the base image.

--- a/openstack-tenant/packages/mobiledgex/Makefile
+++ b/openstack-tenant/packages/mobiledgex/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = mobiledgex
-VERSION = 4.9.2
+VERSION = 4.10.0
 DISTRIBUTION = cirrus
 COMPONENT = main
 

--- a/openstack-tenant/packages/mobiledgex/dependencies
+++ b/openstack-tenant/packages/mobiledgex/dependencies
@@ -1,7 +1,7 @@
 chef                            =17.6.18-1
 crictl                          =1.16.1
 curl                            >=7.58.0-2ubuntu3.8
-docker-ce                       =5:20.10.12~3-0~ubuntu-bionic
+docker-ce                       =5:20.10.13~3-0~ubuntu-bionic
 docker-compose                  =1.24.1-mobiledgex1
 libpam-google-authenticator     =20170702-1
 helm                            =3.4.2
@@ -14,7 +14,7 @@ jq                              >=1.5+dfsg-2
 kubeadm                         =1.18.20-00
 kubectl                         =1.18.20-00
 kubelet                         =1.18.20-00
-linux-image-virtual             =4.15.0.169.158
+linux-image-virtual             =4.15.0.171.160
 nfs-kernel-server               =1:1.3.4-2.1ubuntu5.5
 nvidia-container-runtime        =3.8.1-1
 nvidia-container-toolkit        =1.8.1-1

--- a/version/package-version.go
+++ b/version/package-version.go
@@ -1,3 +1,3 @@
 package version
 
-var MobiledgeXPackageVersion = "4.9.2"
+var MobiledgeXPackageVersion = "4.10.0"

--- a/vmlayer/props.go
+++ b/vmlayer/props.go
@@ -44,7 +44,7 @@ const MINIMUM_VCPUS uint64 = 2
 var ImageFormatQcow2 = "qcow2"
 var ImageFormatVmdk = "vmdk"
 
-var MEXInfraVersion = "4.9.2"
+var MEXInfraVersion = "4.10.0"
 var ImageNamePrefix = "mobiledgex-v"
 var DefaultOSImageName = ImageNamePrefix + MEXInfraVersion
 


### PR DESCRIPTION
Also includes small changes to `build.sh` to add validation for necessary chef changes.