### PR TITLE
init context for rootLB certs

### DIFF
--- a/vmlayer/lb.go
+++ b/vmlayer/lb.go
@@ -627,6 +627,7 @@ func (v *VMPlatform) GetAllRootLBClients(ctx context.Context) (map[string]ssh.Cl
 	log.SpanLog(ctx, log.DebugLevelInfra, "GetAllRootLBClients")
 	rootlbClients, err := v.GetRootLBClients(ctx)
 	if err != nil {
+		log.SpanLog(ctx, log.DebugLevelInfra, "error getting dedicated client", "err", err)
 		return nil, fmt.Errorf("Unable to get dedicated rootlb Clients - %v", err)
 	}
 	// GetRootLBClients gets only the dedicated rootlbs.  We need the shared one also
@@ -636,6 +637,7 @@ func (v *VMPlatform) GetAllRootLBClients(ctx context.Context) (map[string]ssh.Cl
 			// this can happen on startup
 			log.SpanLog(ctx, log.DebugLevelInfra, "shared rootlb does not exist")
 		} else {
+			log.SpanLog(ctx, log.DebugLevelInfra, "error getting sharedlb client", "err", err)
 			return nil, fmt.Errorf("Unable to get shared rootlb Client - %v", err)
 		}
 	} else {
@@ -666,6 +668,13 @@ func (v *VMPlatform) GetRootLBClientForClusterInstKey(ctx context.Context, clust
 func (v *VMPlatform) GetRootLBClients(ctx context.Context) (map[string]ssh.Client, error) {
 	if v.Caches == nil {
 		return nil, fmt.Errorf("caches is nil")
+	}
+	ctx, result, err := v.VMProvider.InitOperationContext(ctx, OperationInitStart)
+	if err != nil {
+		return nil, err
+	}
+	if result == OperationNewlyInitialized {
+		defer v.VMProvider.InitOperationContext(ctx, OperationInitComplete)
 	}
 	rootLBClients := make(map[string]ssh.Client)
 	clusterInstKeys := []edgeproto.ClusterInstKey{}


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5101 CRM fails to set up certs in root LBs occasionally

### Description

TEF had noticed some LBs with no Envoy certs. This was from a pretty long time ago, so I am not sure it's an identical issue, but I did notice in the logs that we get "error": "No VCD Client in Context" from the LB cert helper.  Fix is to init the context so we get the client setup in GetRootLBClients



