### PR TITLE
fix shepherd when no oauth in effect

### DIFF
--- a/crm-platforms/vcd/vcd.go
+++ b/crm-platforms/vcd/vcd.go
@@ -115,9 +115,11 @@ func (v *VcdPlatform) InitProvider(ctx context.Context, caches *platform.Caches,
 			}
 		}
 	case vmlayer.ProviderInitPlatformStartShepherd:
-		err := v.WaitForOauthTokenViaNotify(ctx, v.vmProperties.CommonPf.PlatformConfig.CloudletKey)
-		if err != nil {
-			return err
+		if v.GetVcdOauthSgwUrl() != "" {
+			err := v.WaitForOauthTokenViaNotify(ctx, v.vmProperties.CommonPf.PlatformConfig.CloudletKey)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	v.initDebug(v.vmProperties.CommonPf.PlatformConfig.NodeMgr, stage)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6304 shepherd vcd startup with no oauth fail

### Description

After CRM H/A changes, shepherd does not start unless oauth is specified