### PR TITLE
TrustPolicy on VCD not blocking egress ports correctly - SetupRootLB …

### DIFF
--- a/vmlayer/lb.go
+++ b/vmlayer/lb.go
@@ -587,7 +587,12 @@ func (v *VMPlatform) SetupRootLB(
 	}
 	log.SpanLog(ctx, log.DebugLevelInfra, "DNS A record activated", "name", rootLBName)
 	// perform provider specific prep of the rootLB
-	return v.VMProvider.PrepareRootLB(ctx, client, rootLBName, infracommon.GetServerSecurityGroupName(rootLBName), TrustPolicy, updateCallback)
+	secGrpName := infracommon.GetServerSecurityGroupName(rootLBName)
+	if v.VMProperties.IptablesBasedFirewall {
+		// when using iptables for firewall, we use a common secgrp for cloudlet-wide and per-LB
+		secGrpName = infracommon.TrustPolicySecGrpNameLabel
+	}
+	return v.VMProvider.PrepareRootLB(ctx, client, rootLBName, secGrpName, TrustPolicy, updateCallback)
 }
 
 // This function copies resource-tracker from crm to rootLb - we need this to provide docker metrics


### PR DESCRIPTION
…secGrpName init to a common secgrp

### Issues Fixed

* EDGECLOUD-6220 TrustPolicy on VCD not blocking egress ports correctly

### Description

During last 2 commits, one thing was missed for VCD.
I always used iptables-restore to pump in a saved copy of iptables from 3.0 release.
This was done to save time to re-setup vApp, VMs etc.

Further my test case was slightly different. I always added a TP later (after cloudlet was created).
By that time rootLB was already setup.
So this issue was not seen.

Fix is self explanatory.


### Unit-test

tested on real VCD.




Cli to recreate the issue
==========================

ec controller CreateTrustPolicy cloudletorg=packet name=TP123 'outboundsecurityrules:0.protocol=TCp outboundsecurityrules:0.portrangemin=5555 outboundsecurityrules:0.remotecidr=55.55.55.55/24'


 ec controller UpdateSettings createclusterinsttimeout=40m createappinsttimeout=40m deleteclusterinsttimeout=40m deleteappinsttimeout=40m updatecloudlettimeout=40m createcloudlettimeout=40m updatetrustpolicytimeout=40m updatecloudlettimeout=20m;      ec controller CreateCloudlet cloudletorg=packet cloudlet=devdattaCloudletVcdAAA location.latitude=1 location.longitude=2 numdynamicips=20 physicalname=jimorg platformtype=PlatformTypeVcd  crmoverride=IgnoreCrmAndTransientState  trustpolicy=TP123



Logs before fix
===============
2022-03-21T12:51:14.055+0530	INFO	37b5004703d2872f	vcd/vcd-security.go:204	PrepareRootLB	{"rootLBName": "devdattacloudletvcdaaa.packet.mobiledgex.net", "secGrpName": "devdattacloudletvcdaaa.packet.mobiledgex.net-sg"}
2022-03-21T12:51:14.055+0530	INFO	37b5004703d2872f	vcd/vcd-security.go:213	PrepareRootLB have TrustPolicy	{"trustPolicy": "key:<organization:\"packet\" name:\"TP123\" > outbound_security_rules:<protocol:\"TCP\" port_range_min:5555 port_range_max:5555 remote_cidr:\"55.55.55.55/24\" > "}
2022-03-21T12:52:22.029+0530	INFO	37b5004703d2872f	vcd/vcd-security.go:238	PrepareRootLB SetupIptableRulesForRootLB complete	{"rootLBName": "devdattacloudletvcdaaa.packet.mobiledgex.net", "time": "1m7.973035548s"}



ubuntu@devdattacloudletvcdaaa:~ sudo iptables-save >   1

ubuntu@devdattacloudletvcdaaa:~ cat 1 | grep 5555
-A FORWARD -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label devdattacloudletvcdaaa.packet.mobiledgex.net-sg" -j ACCEPT
-A OUTPUT -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label devdattacloudletvcdaaa.packet.mobiledgex.net-sg" -j ACCEPT
ubuntu@devdattacloudletvcdaaa:~



ubuntu@devdattacloudletvcdaaa:~ cat 1 | grep label
-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A INPUT -i lo -m comment --comment "label default-rules" -j ACCEPT
-A INPUT -s 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 22 -m comment --comment "label rootlb-networking" -j ACCEPT
-A INPUT -s 106.215.109.134/32 -p tcp -m tcp --dport 22 -m comment --comment "label rootlb-ssh" -j ACCEPT
-A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A FORWARD -o lo -m comment --comment "label default-rules" -j ACCEPT
-A FORWARD -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label devdattacloudletvcdaaa.packet.mobiledgex.net-sg" -j ACCEPT
-A FORWARD -d 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A OUTPUT -o lo -m comment --comment "label default-rules" -j ACCEPT
-A OUTPUT -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label devdattacloudletvcdaaa.packet.mobiledgex.net-sg" -j ACCEPT
-A OUTPUT -d 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
ubuntu@devdattacloudletvcdaaa:~



After fix
=========



ubuntu@devdattacloudletvcdaaa:~ grep  5555  1
-A FORWARD -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label trust-policy" -j ACCEPT
-A OUTPUT -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label trust-policy" -j ACCEPT
ubuntu@devdattacloudletvcdaaa:~
ubuntu@devdattacloudletvcdaaa:~ grep label 1
-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A INPUT -i lo -m comment --comment "label default-rules" -j ACCEPT
-A INPUT -s 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 22 -m comment --comment "label rootlb-networking" -j ACCEPT
-A INPUT -s 106.215.109.134/32 -p tcp -m tcp --dport 22 -m comment --comment "label rootlb-ssh" -j ACCEPT
-A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A FORWARD -o lo -m comment --comment "label default-rules" -j ACCEPT
-A FORWARD -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label trust-policy" -j ACCEPT
-A FORWARD -d 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A OUTPUT -o lo -m comment --comment "label default-rules" -j ACCEPT
-A OUTPUT -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label trust-policy" -j ACCEPT
-A OUTPUT -d 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
ubuntu@devdattacloudletvcdaaa:~



devdatta@Dajgaonkar-MAC:~ grep PrepareRootLB /tmp/devdattaCrmVcdAAA.log  | grep   secGrpName
2022-03-21T13:19:56.643+0530	INFO	132e4cdec4167dc5	vcd/vcd-security.go:204	PrepareRootLB	{"rootLBName": "devdattacloudletvcdaaa.packet.mobiledgex.net", "secGrpName": "trust-policy"}
devdatta@Dajgaonkar-MAC:~



After removing trust policy

sudo iptables-save > 2
ubuntu@devdattacloudletvcdaaa:~ grep  5555  2
ubuntu@devdattacloudletvcdaaa:~


ubuntu@devdattacloudletvcdaaa:~ grep label 2
-A INPUT -s 10.101.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A INPUT -i lo -m comment --comment "label default-rules" -j ACCEPT
-A INPUT -s 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A INPUT -p tcp -m tcp --dport 22 -m comment --comment "label rootlb-networking" -j ACCEPT
-A INPUT -s 106.215.109.134/32 -p tcp -m tcp --dport 22 -m comment --comment "label rootlb-ssh" -j ACCEPT
-A FORWARD -m comment --comment "label trust-policy" -j ACCEPT
-A FORWARD -d 10.101.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A FORWARD -o lo -m comment --comment "label default-rules" -j ACCEPT
-A FORWARD -d 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A OUTPUT -m comment --comment "label trust-policy" -j ACCEPT
-A OUTPUT -d 10.101.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
-A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment "label default-rules" -j ACCEPT
-A OUTPUT -o lo -m comment --comment "label default-rules" -j ACCEPT
-A OUTPUT -d 10.201.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
ubuntu@devdattacloudletvcdaaa:~

ubuntu@devdattacloudletvcdaaa:~ diff 1 2
1c1
< # Generated by iptables-save v1.6.1 on Mon Mar 21 07:55:46 2022
---
> # Generated by iptables-save v1.6.1 on Mon Mar 21 08:06:45 2022
3,6c3,6
< :PREROUTING ACCEPT [86:4594]
< :INPUT ACCEPT [56:3288]
< :OUTPUT ACCEPT [359:25188]
< :POSTROUTING ACCEPT [163:11252]
---
> :PREROUTING ACCEPT [180:9829]
> :INPUT ACCEPT [78:4660]
> :OUTPUT ACCEPT [1523:112383]
> :POSTROUTING ACCEPT [199:13679]
13,14c13,14
< # Completed on Mon Mar 21 07:55:46 2022
< # Generated by iptables-save v1.6.1 on Mon Mar 21 07:55:46 2022
---
> # Completed on Mon Mar 21 08:06:45 2022
> # Generated by iptables-save v1.6.1 on Mon Mar 21 08:06:45 2022
16c16
< :INPUT DROP [30:1306]
---
> :INPUT DROP [22:1299]
18c18
< :OUTPUT DROP [196:13936]
---
> :OUTPUT DROP [0:0]
22a23
> -A INPUT -s 10.101.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
29a31,32
> -A FORWARD -m comment --comment "label trust-policy" -j ACCEPT
> -A FORWARD -d 10.101.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
32d34
< -A FORWARD -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label trust-policy" -j ACCEPT
39a42,43
> -A OUTPUT -m comment --comment "label trust-policy" -j ACCEPT
> -A OUTPUT -d 10.101.0.0/16 -m comment --comment "label rootlb-networking" -j ACCEPT
42d45
< -A OUTPUT -d 55.55.55.0/24 -p tcp -m tcp --dport 5555 -m comment --comment "label trust-policy" -j ACCEPT
51c54
< # Completed on Mon Mar 21 07:55:46 2022
---
> # Completed on Mon Mar 21 08:06:45 2022
ubuntu@devdattacloudletvcdaaa:~

