### PR TITLE
vsphere image is always .qcow now

### DIFF
--- a/crm-platforms/vsphere/vsphere-cloudlet.go
+++ b/crm-platforms/vsphere/vsphere-cloudlet.go
@@ -24,20 +24,7 @@ func (v *VSpherePlatform) SaveCloudletAccessVars(ctx context.Context, cloudlet *
 }
 
 func (v *VSpherePlatform) GetCloudletImageSuffix(ctx context.Context) string {
-	// we use a common image as of 4.4.0 and beyond
-	vers := v.vmProperties.CommonPf.PlatformConfig.VMImageVersion
-	if vers == "" {
-		vers = vmlayer.MEXInfraVersion
-	}
-	// note this string compare would fail for something like 4.10.x, but is only intended for short term purposes
-	// and should be removed after 4.4.0 has time to soak
-	if vers >= "4.4.0" {
-		log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletImageSuffix returning generic suffix post 4.4.0", "vers", vers)
-		return ".qcow2"
-	}
-	// older loads are specific per platform
-	log.SpanLog(ctx, log.DebugLevelInfra, "GetCloudletImageSuffix returning vsphere specific suffix pre 4.4.0", "vers", vers)
-	return "-vsphere.qcow2"
+	return ".qcow2"
 }
 
 //CreateImageFromUrl downloads image from URL and then imports to the datastore


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6304 vsphere cloudlet create is looking for mobiledgex-v4.10.0-vsphere.qcow2

### Description

During the transition time from multiple images to a single image for all platforms, vSphere code had logic to check the image version was higher than "4.4.0" for using the single .qcow image.  This check stopped working properly once we got to 4.10.0 because it's a string compare.

Remove this check as it was needed short term only.