### PR TITLE
EDGECLOUD-6277 EDGECLOUD-6278 redact info for non-admins from controller show

### DIFF
--- a/mc/ormapi/api.go
+++ b/mc/ormapi/api.go
@@ -191,16 +191,16 @@ type Controller struct {
 	// Controller region name
 	Region string `gorm:"primary_key"`
 	// Controller API address or URL
-	Address string `gorm:"unique;not null"`
+	Address string `gorm:"unique;not null" json:",omitempty"`
 	// Controller notify address or URL
-	NotifyAddr string `gorm:"type:text"`
+	NotifyAddr string `gorm:"type:text" json:",omitempty"`
 	// InfluxDB address
-	InfluxDB string `gorm:"type:text"`
+	InfluxDB string `gorm:"type:text" json:",omitempty"`
 	// Thanos Query URL
-	ThanosMetrics string `gorm:"type:text"`
+	ThanosMetrics string `gorm:"type:text" json:",omitempty"`
 	// Unique DNS label for the region
 	// read only: true
-	DnsRegion string `gorm:"unique;not null"`
+	DnsRegion string `gorm:"unique;not null" json:",omitempty"`
 	// read only: true
 	CreatedAt time.Time `json:",omitempty"`
 	// read only: true


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6277 controller show for nonadmin should only return the region json tag
* EDGECLOUD-6278 non admin should not be able to do controller show by address

### Description

6277: Add "omitempty" json tags to api definition so the fact that fields like "controllerAddr" exist on the controller object are not show to the user.
6278: Ignore restricted fields for filtering if non-admin.