### PR TITLE
EDGECLOUD-6258  Sensitive info in metrics error message

### DIFF
--- a/mc/orm/ctrl_test.go
+++ b/mc/orm/ctrl_test.go
@@ -698,6 +698,7 @@ func testControllerClientRun(t *testing.T, ctx context.Context, clientRun mctest
 	goodPermTestClusterInst(t, mcClient, uri, tokenDev3, ctrl.Region, org1, tc3, dcnt)
 	goodPermTestMetrics(t, mcClient, uri, tokenDev3, tokenOper3, ctrl.Region, org1, org3)
 	goodPermTestEvents(t, mcClient, uri, tokenDev3, tokenOper3, ctrl.Region, org1, org3)
+	testInvalidOrgForCloudletUsage(t, mcClient, uri, tokenAd, ctrl.Region, org1)
 
 	// test users with different roles
 	goodPermTestCloudlet(t, mcClient, uri, tokenOper3, ctrl.Region, org3, ccount)

--- a/mc/orm/influx_test.go
+++ b/mc/orm/influx_test.go
@@ -72,6 +72,21 @@ func testPermShowClientMetrics(mcClient *mctestclient.Client, uri, token, region
 	return mcClient.ShowClientApiUsageMetrics(uri, token, dat)
 }
 
+func testPermShowCloudletUsage(mcClient *mctestclient.Client, uri, token, region, org, selector string, data *edgeproto.CloudletKey) (*ormapi.AllMetrics, int, error) {
+	in := &edgeproto.CloudletKey{}
+	if data != nil {
+		in = data
+	} else {
+		in.Name = "testcloudlet"
+		in.Organization = org
+	}
+	dat := &ormapi.RegionCloudletMetrics{}
+	dat.Region = region
+	dat.Selector = selector
+	dat.Cloudlet = *in
+	return mcClient.ShowCloudletUsage(uri, token, dat)
+}
+
 func testPassCheckPermissionsAndGetCloudletList(t *testing.T, ctx context.Context, username, region string, devOrgs []string,
 	resource string, cloudletKeys []edgeproto.CloudletKey, expectedCloudlets []string) {
 
@@ -246,6 +261,15 @@ func goodPermTestMetrics(t *testing.T, mcClient *mctestclient.Client, uri, devTo
 	list, status, err = testPermShowClusterMetrics(mcClient, uri, operToken, region, operOrg, "utilization", &cluster)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "Invalid cluster")
+	require.Equal(t, http.StatusBadRequest, status)
+}
+
+func testInvalidOrgForCloudletUsage(t *testing.T, mcClient *mctestclient.Client, uri, adminToken, region, operOrg string) {
+	// bad cloudlet name check
+	invalidCloudlet := edgeproto.CloudletKey{Organization: "InvalidCloudletOrg"}
+	_, status, err := testPermShowCloudletUsage(mcClient, uri, adminToken, region, operOrg, "resourceusage", &invalidCloudlet)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Cloudlet does not exist")
 	require.Equal(t, http.StatusBadRequest, status)
 }
 


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6258  Sensitive info in metrics error message
* EDGECLOUD-5584 cloudletusage metrics gives db error when using unknown cloudlet org 

### Description

Check that we have at least one platform type to prevent invalid influxDB query
