### PR TITLE
EDGECLOUD-6327: Stream progress for deleted objects should remain for a while

### DIFF
--- a/e2e-tests/testfiles/mc_add_delete.yml
+++ b/e2e-tests/testfiles/mc_add_delete.yml
@@ -279,6 +279,15 @@ tests:
     yaml2: '{{datadir2}}/mc_user3_empty_show.yml'
     filetype: mcdata
 
+- name: verify stream data for user3 deleted objects
+  actions: [mcapi-stream]
+  apifile: '{{datadir2}}/mc_user3_data.yml'
+  curuserfile: '{{datadir2}}/mc_user3.yml'
+  compareyaml:
+    yaml1: '{{outputdir}}/show-commands.yml'
+    yaml2: '{{datadir2}}/mc_user3_data_stream.yml'
+    filetype: mcstream
+
 - name: admin deletes reservable ClusterInst
   actions: [mcapi-delete]
   apifile: '{{datadir2}}/mc_admin_reservable.yml'


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-6327: Stream progress for deleted objects should remain for a while

### Description
* Refer PR: https://github.com/mobiledgex/edge-cloud/pull/1697