### PR TITLE
EDGECLOUD-6236 Users can delete AlertReceviers from other orgs

### DIFF
--- a/mc/orm/alertmgr_api.go
+++ b/mc/orm/alertmgr_api.go
@@ -162,6 +162,12 @@ func DeleteAlertReceiver(c echo.Context) error {
 			ResourceUsers, ActionManage); err != nil {
 			return err
 		}
+
+		// also check that the user specified is is part of the org
+		if err := authorized(ctx, in.User, org, ResourceAlert, ActionView); err != nil {
+			return err
+		}
+
 	} else {
 		in.User = claims.Username
 	}

--- a/mc/orm/alertmgr_api_test.go
+++ b/mc/orm/alertmgr_api_test.go
@@ -83,6 +83,20 @@ func testDeleteAlertReceiver(mcClient *mctestclient.Client, uri, token, region, 
 
 }
 
+func testDeleteAlertReceiverWithClusterOrg(mcClient *mctestclient.Client, uri, token, region, org, name, rType, severity, username string) (int, error) {
+	in := &edgeproto.AppInstKey{}
+	in.ClusterInstKey.Organization = org
+	dat := &ormapi.AlertReceiver{}
+	dat.Severity = severity
+	dat.Type = rType
+	dat.Name = name
+	dat.AppInst = *in
+	dat.User = username
+
+	status, err := mcClient.DeleteAlertReceiver(uri, token, dat)
+	return status, err
+}
+
 func badPermTestAlertReceivers(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string) {
 	status, err := testCreateAlertReceiver(mcClient, uri, token, region, org, "testAlert", "email", "error", "", "", nil, nil)
 	require.NotNil(t, err)
@@ -135,6 +149,10 @@ func userPermTestAlertReceivers(t *testing.T, mcClient *mctestclient.Client, uri
 	require.Equal(t, http.StatusForbidden, status)
 	// Developer cannot delete other user's receiver
 	status, err = testDeleteAlertReceiver(mcClient, uri, devToken, region, devOrg, "mgrReceiver", "email", "error", devMgr)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusForbidden, status)
+	// user cannot delete receiver from another org
+	status, err = testDeleteAlertReceiverWithClusterOrg(mcClient, uri, devMgrToken, region, devOrg, "mgrReceiver", "email", "error", "otheruser")
 	require.NotNil(t, err)
 	require.Equal(t, http.StatusForbidden, status)
 	// Manager can delete other user's receiver


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6236 Users can delete AlertReceviers from other orgs

### Description
Pushing change for 3.0 hf branch

Add a check for provided username against the org specified in the api. Added unit-test for this case as well.