### PR TITLE
EDGECLOUD-6357 Failed to get public cert from vault for rootlb

### DIFF
--- a/ansible/qa/list
+++ b/ansible/qa/list
@@ -15,7 +15,7 @@ vault_vm_hostname=vault-{{ deploy_environ }}.mobiledgex.net
 vault_ha_domain="vault-{{ deploy_environ }}.mobiledgex.net"
 vault_port=443
 monitor_version=latest
-letsencrypt_env=staging
+letsencrypt_env=production
 locver_url="http://mexdemo.locsim.mobiledgex.net:8889/verifyLocation"
 toksrv_url="http://mexdemo.tok.mobiledgex.net:9999/its?followURL=https://dme.mobiledgex.net/verifyLoc"
 dme_carrier=TDG

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -4,6 +4,7 @@ vault_checksum: sha256:2a6958e6c8d6566d8d529fe5ef9378534903305d0f00744d526232d1c
 vault_letsencrypt_plugin: "{{ artifactory_address }}/binaries/vault-letsencrypt-plugin/1.1/letsencrypt-plugin"
 vault_letsencrypt_plugin_sha256sum: e111a2db44059d0e460178ec25eaab72c7b44667d5a0f89fcae18d37ad86155d
 certgen_image_version: 2019-11-01
+app_dns_root: mobiledgex.net
 
 vault_github_teams:
   - name: edge-cloud-development-team

--- a/ansible/roles/vault/tasks/main.yml
+++ b/ansible/roles/vault/tasks/main.yml
@@ -172,6 +172,7 @@
       LETSENCRYPT_ENV: "{{ le_env }}"
       CF_USER: "{{ cloudflare_account_email }}"
       CF_APIKEY: "{{ cloudflare_account_api_token }}"
+      DOMAIN: "{{ app_dns_root }}"
       NS1_APIKEY: "{{ ns1_apikey }}"
   tags: certgen
 


### PR DESCRIPTION
Configure the vault cert plugin to accept cert requests for the right
domain for each setup, like mobiledgex-qa.net for QA.

Also switch QA to production LetsEncrypt certs.
