### PR TITLE
EDGECLOUD-5854: Enable Operators to see/download GPU License config after GPU Driver has been created

### DIFF
--- a/mc/ctrlclient/cloudlet.ctrl.go
+++ b/mc/ctrlclient/cloudlet.ctrl.go
@@ -226,6 +226,17 @@ func GetGPUDriverBuildURLObj(ctx context.Context, rc *ormutil.RegionContext, obj
 	return api.GetGPUDriverBuildURL(ctx, obj)
 }
 
+func GetGPUDriverLicenseConfigObj(ctx context.Context, rc *ormutil.RegionContext, obj *edgeproto.GPUDriverKey, connObj ClientConnMgr) (*edgeproto.Result, error) {
+	conn, err := connObj.GetRegionConn(ctx, rc.Region)
+	if err != nil {
+		return nil, err
+	}
+	api := edgeproto.NewGPUDriverApiClient(conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
+	return api.GetGPUDriverLicenseConfig(ctx, obj)
+}
+
 func CreateCloudletStream(ctx context.Context, rc *ormutil.RegionContext, obj *edgeproto.Cloudlet, connObj ClientConnMgr, cb func(res *edgeproto.Result) error) error {
 	conn, err := connObj.GetRegionConn(ctx, rc.Region)
 	if err != nil {
@@ -535,6 +546,17 @@ func GenerateAccessKeyObj(ctx context.Context, rc *ormutil.RegionContext, obj *e
 	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
 	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
 	return api.GenerateAccessKey(ctx, obj)
+}
+
+func GetCloudletGPUDriverLicenseConfigObj(ctx context.Context, rc *ormutil.RegionContext, obj *edgeproto.CloudletKey, connObj ClientConnMgr) (*edgeproto.Result, error) {
+	conn, err := connObj.GetRegionConn(ctx, rc.Region)
+	if err != nil {
+		return nil, err
+	}
+	api := edgeproto.NewCloudletApiClient(conn)
+	log.SpanLog(ctx, log.DebugLevelApi, "start controller api")
+	defer log.SpanLog(ctx, log.DebugLevelApi, "finish controller api")
+	return api.GetCloudletGPUDriverLicenseConfig(ctx, obj)
 }
 
 type ShowCloudletInfoAuthz interface {

--- a/mc/mcctl/mctestclient/mctestclient_generatedfuncs.go
+++ b/mc/mcctl/mctestclient/mctestclient_generatedfuncs.go
@@ -1062,6 +1062,22 @@ func (s *Client) GenerateAccessKey(uri string, token string, in *ormapi.RegionCl
 	return &out, rundata.RetStatus, rundata.RetError
 }
 
+func (s *Client) GetCloudletGPUDriverLicenseConfig(uri string, token string, in *ormapi.RegionCloudletKey) (*edgeproto.Result, int, error) {
+	rundata := RunData{}
+	rundata.Uri = uri
+	rundata.Token = token
+	rundata.In = in
+	var out edgeproto.Result
+	rundata.Out = &out
+
+	apiCmd := ormctl.MustGetCommand("GetCloudletGPUDriverLicenseConfig")
+	s.ClientRun.Run(apiCmd, &rundata)
+	if rundata.RetError != nil {
+		return nil, rundata.RetStatus, rundata.RetError
+	}
+	return &out, rundata.RetStatus, rundata.RetError
+}
+
 // Generating group CloudletInfo
 
 func (s *Client) ShowCloudletInfo(uri string, token string, in *ormapi.RegionCloudletInfo) ([]edgeproto.CloudletInfo, int, error) {
@@ -2371,6 +2387,22 @@ func (s *Client) GetGPUDriverBuildURL(uri string, token string, in *ormapi.Regio
 	rundata.Out = &out
 
 	apiCmd := ormctl.MustGetCommand("GetGPUDriverBuildURL")
+	s.ClientRun.Run(apiCmd, &rundata)
+	if rundata.RetError != nil {
+		return nil, rundata.RetStatus, rundata.RetError
+	}
+	return &out, rundata.RetStatus, rundata.RetError
+}
+
+func (s *Client) GetGPUDriverLicenseConfig(uri string, token string, in *ormapi.RegionGPUDriverKey) (*edgeproto.Result, int, error) {
+	rundata := RunData{}
+	rundata.Uri = uri
+	rundata.Token = token
+	rundata.In = in
+	var out edgeproto.Result
+	rundata.Out = &out
+
+	apiCmd := ormctl.MustGetCommand("GetGPUDriverLicenseConfig")
 	s.ClientRun.Run(apiCmd, &rundata)
 	if rundata.RetError != nil {
 		return nil, rundata.RetStatus, rundata.RetError

--- a/mc/mcctl/ormctl/cloudlet.mc2.go
+++ b/mc/mcctl/ormctl/cloudlet.mc2.go
@@ -145,6 +145,21 @@ var GetGPUDriverBuildURLCmd = &ApiCommand{
 	Path:         "/auth/ctrl/GetGPUDriverBuildURL",
 	ProtobufApi:  true,
 }
+
+var GetGPUDriverLicenseConfigCmd = &ApiCommand{
+	Name:         "GetGPUDriverLicenseConfig",
+	Use:          "getlicenseconfig",
+	Short:        "Get GPU Driver License Config. Returns the license config specific to GPU driver",
+	RequiredArgs: "region " + strings.Join(GPUDriverKeyRequiredArgs, " "),
+	OptionalArgs: strings.Join(GPUDriverKeyOptionalArgs, " "),
+	AliasArgs:    strings.Join(GPUDriverKeyAliasArgs, " "),
+	SpecialArgs:  &GPUDriverKeySpecialArgs,
+	Comments:     addRegionComment(GPUDriverKeyComments),
+	ReqData:      &ormapi.RegionGPUDriverKey{},
+	ReplyData:    &edgeproto.Result{},
+	Path:         "/auth/ctrl/GetGPUDriverLicenseConfig",
+	ProtobufApi:  true,
+}
 var GPUDriverApiCmds = []*ApiCommand{
 	CreateGPUDriverCmd,
 	DeleteGPUDriverCmd,
@@ -153,6 +168,7 @@ var GPUDriverApiCmds = []*ApiCommand{
 	AddGPUDriverBuildCmd,
 	RemoveGPUDriverBuildCmd,
 	GetGPUDriverBuildURLCmd,
+	GetGPUDriverLicenseConfigCmd,
 }
 
 const GPUDriverGroup = "GPUDriver"
@@ -477,6 +493,21 @@ var GenerateAccessKeyCmd = &ApiCommand{
 	Path:         "/auth/ctrl/GenerateAccessKey",
 	ProtobufApi:  true,
 }
+
+var GetCloudletGPUDriverLicenseConfigCmd = &ApiCommand{
+	Name:         "GetCloudletGPUDriverLicenseConfig",
+	Use:          "getgpudriverlicenseconfig",
+	Short:        "Get Cloudlet Specific GPU Driver License Config. Returns the license config associated with the cloudlet",
+	RequiredArgs: "region " + strings.Join(CloudletKeyRequiredArgs, " "),
+	OptionalArgs: strings.Join(CloudletKeyOptionalArgs, " "),
+	AliasArgs:    strings.Join(CloudletKeyAliasArgs, " "),
+	SpecialArgs:  &CloudletKeySpecialArgs,
+	Comments:     addRegionComment(CloudletKeyComments),
+	ReqData:      &ormapi.RegionCloudletKey{},
+	ReplyData:    &edgeproto.Result{},
+	Path:         "/auth/ctrl/GetCloudletGPUDriverLicenseConfig",
+	ProtobufApi:  true,
+}
 var CloudletApiCmds = []*ApiCommand{
 	CreateCloudletCmd,
 	DeleteCloudletCmd,
@@ -495,6 +526,7 @@ var CloudletApiCmds = []*ApiCommand{
 	GetOrganizationsOnCloudletCmd,
 	RevokeAccessKeyCmd,
 	GenerateAccessKeyCmd,
+	GetCloudletGPUDriverLicenseConfigCmd,
 }
 
 const CloudletGroup = "Cloudlet"

--- a/mc/orm/alert.mc2.go
+++ b/mc/orm/alert.mc2.go
@@ -763,6 +763,17 @@ func addControllerApis(method string, group *echo.Group) {
 	//   403: forbidden
 	//   404: notFound
 	group.Match([]string{method}, "/ctrl/GetGPUDriverBuildURL", GetGPUDriverBuildURL)
+	// swagger:route POST /auth/ctrl/GetGPUDriverLicenseConfig GPUDriverKey GetGPUDriverLicenseConfig
+	// Get GPU Driver License Config.
+	//  Returns the license config specific to GPU driver
+	// Security:
+	//   Bearer:
+	// responses:
+	//   200: success
+	//   400: badRequest
+	//   403: forbidden
+	//   404: notFound
+	group.Match([]string{method}, "/ctrl/GetGPUDriverLicenseConfig", GetGPUDriverLicenseConfig)
 	// swagger:route POST /auth/ctrl/CreateCloudlet Cloudlet CreateCloudlet
 	// Create Cloudlet.
 	//  Sets up Cloudlet services on the Operators compute resources, and integrated as part of MobiledgeX edge resource portfolio. These resources are managed from the Edge Controller.
@@ -1073,6 +1084,17 @@ func addControllerApis(method string, group *echo.Group) {
 	//   403: forbidden
 	//   404: notFound
 	group.Match([]string{method}, "/ctrl/GenerateAccessKey", GenerateAccessKey)
+	// swagger:route POST /auth/ctrl/GetCloudletGPUDriverLicenseConfig CloudletKey GetCloudletGPUDriverLicenseConfig
+	// Get Cloudlet Specific GPU Driver License Config.
+	//  Returns the license config associated with the cloudlet
+	// Security:
+	//   Bearer:
+	// responses:
+	//   200: success
+	//   400: badRequest
+	//   403: forbidden
+	//   404: notFound
+	group.Match([]string{method}, "/ctrl/GetCloudletGPUDriverLicenseConfig", GetCloudletGPUDriverLicenseConfig)
 	// swagger:route POST /auth/ctrl/ShowCloudletInfo CloudletInfo ShowCloudletInfo
 	// Show CloudletInfos.
 	// Security:

--- a/mc/orm/cloudlet_mc2_test.go
+++ b/mc/orm/cloudlet_mc2_test.go
@@ -257,6 +257,39 @@ func badRegionGetGPUDriverBuildURL(t *testing.T, mcClient *mctestclient.Client, 
 	_ = out
 }
 
+var _ = edgeproto.GetFields
+
+func badPermGetGPUDriverLicenseConfig(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+	_, status, err := testutil.TestPermGetGPUDriverLicenseConfig(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
+	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badGetGPUDriverLicenseConfig(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+	_, st, err := testutil.TestPermGetGPUDriverLicenseConfig(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
+func goodPermGetGPUDriverLicenseConfig(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+	_, status, err := testutil.TestPermGetGPUDriverLicenseConfig(mcClient, uri, token, region, org, modFuncs...)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, status)
+}
+
+func badRegionGetGPUDriverLicenseConfig(t *testing.T, mcClient *mctestclient.Client, uri, token, org string, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+	out, status, err := testutil.TestPermGetGPUDriverLicenseConfig(mcClient, uri, token, "bad region", org, modFuncs...)
+	require.NotNil(t, err)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
+	_ = out
+}
+
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
 func badPermTestGPUDriver(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.GPUDriver)) {
@@ -337,6 +370,30 @@ func permTestGPUDriverBuildMember(t *testing.T, mcClient *mctestclient.Client, u
 	badPermTestGPUDriverBuildMember(t, mcClient, uri, token2, region, org1, modFuncs...)
 	goodPermTestGPUDriverBuildMember(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
 	goodPermTestGPUDriverBuildMember(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
+}
+
+// This tests the user cannot modify the object because the obj belongs to
+// an organization that the user does not have permissions for.
+func badPermTestGPUDriverApiGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+	badPermGetGPUDriverLicenseConfig(t, mcClient, uri, token, region, org, modFuncs...)
+}
+
+// This tests the user can modify the object because the obj belongs to
+// an organization that the user has permissions for.
+func goodPermTestGPUDriverApiGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+	goodPermGetGPUDriverLicenseConfig(t, mcClient, uri, token, region, org, modFuncs...)
+	// make sure region check works
+	badRegionGetGPUDriverLicenseConfig(t, mcClient, uri, token, org, modFuncs...)
+}
+
+// Test permissions for user with token1 who should have permissions for
+// modifying obj1, and user with token2 who should have permissions for obj2.
+// They should not have permissions to modify each other's objects.
+func permTestGPUDriverApiGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+	badPermTestGPUDriverApiGPUDriverKey(t, mcClient, uri, token1, region, org2, modFuncs...)
+	badPermTestGPUDriverApiGPUDriverKey(t, mcClient, uri, token2, region, org1, modFuncs...)
+	goodPermTestGPUDriverApiGPUDriverKey(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestGPUDriverApiGPUDriverKey(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }
 
 var _ = edgeproto.GetFields
@@ -900,6 +957,39 @@ func badRegionGenerateAccessKey(t *testing.T, mcClient *mctestclient.Client, uri
 	_ = out
 }
 
+var _ = edgeproto.GetFields
+
+func badPermGetCloudletGPUDriverLicenseConfig(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, status, err := testutil.TestPermGetCloudletGPUDriverLicenseConfig(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Forbidden")
+	require.Equal(t, http.StatusForbidden, status)
+}
+
+func badGetCloudletGPUDriverLicenseConfig(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, status int, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, st, err := testutil.TestPermGetCloudletGPUDriverLicenseConfig(mcClient, uri, token, region, org, modFuncs...)
+	require.NotNil(t, err)
+	require.Equal(t, status, st)
+}
+
+func goodPermGetCloudletGPUDriverLicenseConfig(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
+	_, status, err := testutil.TestPermGetCloudletGPUDriverLicenseConfig(mcClient, uri, token, region, org, modFuncs...)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, status)
+}
+
+func badRegionGetCloudletGPUDriverLicenseConfig(t *testing.T, mcClient *mctestclient.Client, uri, token, org string, modFuncs ...func(*edgeproto.CloudletKey)) {
+	out, status, err := testutil.TestPermGetCloudletGPUDriverLicenseConfig(mcClient, uri, token, "bad region", org, modFuncs...)
+	require.NotNil(t, err)
+	if err.Error() == "Forbidden" {
+		require.Equal(t, http.StatusForbidden, status)
+	} else {
+		require.Contains(t, err.Error(), "\"bad region\" not found")
+		require.Equal(t, http.StatusBadRequest, status)
+	}
+	_ = out
+}
+
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
 func badPermTestCloudlet(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, targetCloudlet *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.Cloudlet)) {
@@ -987,6 +1077,7 @@ func badPermTestCloudletApiCloudletKey(t *testing.T, mcClient *mctestclient.Clie
 	badPermGetOrganizationsOnCloudlet(t, mcClient, uri, token, region, org, modFuncs...)
 	badPermRevokeAccessKey(t, mcClient, uri, token, region, org, modFuncs...)
 	badPermGenerateAccessKey(t, mcClient, uri, token, region, org, modFuncs...)
+	badPermGetCloudletGPUDriverLicenseConfig(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 // This tests the user can modify the object because the obj belongs to
@@ -997,12 +1088,14 @@ func goodPermTestCloudletApiCloudletKey(t *testing.T, mcClient *mctestclient.Cli
 	goodPermGetOrganizationsOnCloudlet(t, mcClient, uri, token, region, org, modFuncs...)
 	goodPermRevokeAccessKey(t, mcClient, uri, token, region, org, modFuncs...)
 	goodPermGenerateAccessKey(t, mcClient, uri, token, region, org, modFuncs...)
+	goodPermGetCloudletGPUDriverLicenseConfig(t, mcClient, uri, token, region, org, modFuncs...)
 	// make sure region check works
 	badRegionGetCloudletManifest(t, mcClient, uri, token, org, modFuncs...)
 	badRegionShowFlavorsForCloudlet(t, mcClient, uri, token, org, modFuncs...)
 	badRegionGetOrganizationsOnCloudlet(t, mcClient, uri, token, org, modFuncs...)
 	badRegionRevokeAccessKey(t, mcClient, uri, token, org, modFuncs...)
 	badRegionGenerateAccessKey(t, mcClient, uri, token, org, modFuncs...)
+	badRegionGetCloudletGPUDriverLicenseConfig(t, mcClient, uri, token, org, modFuncs...)
 }
 
 // Test permissions for user with token1 who should have permissions for

--- a/mc/orm/stream_mc2_test.go
+++ b/mc/orm/stream_mc2_test.go
@@ -231,13 +231,13 @@ func permTestClusterInstKey(t *testing.T, mcClient *mctestclient.Client, uri, to
 
 // This tests the user cannot modify the object because the obj belongs to
 // an organization that the user does not have permissions for.
-func badPermTestGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+func badPermTestStreamObjApiGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.GPUDriverKey)) {
 	badPermStreamGPUDriver(t, mcClient, uri, token, region, org, modFuncs...)
 }
 
 // This tests the user can modify the object because the obj belongs to
 // an organization that the user has permissions for.
-func goodPermTestGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+func goodPermTestStreamObjApiGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token, region, org string, showcount int, modFuncs ...func(*edgeproto.GPUDriverKey)) {
 	goodPermStreamGPUDriver(t, mcClient, uri, token, region, org, modFuncs...)
 	// make sure region check works
 	badRegionStreamGPUDriver(t, mcClient, uri, token, org, modFuncs...)
@@ -246,9 +246,9 @@ func goodPermTestGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, 
 // Test permissions for user with token1 who should have permissions for
 // modifying obj1, and user with token2 who should have permissions for obj2.
 // They should not have permissions to modify each other's objects.
-func permTestGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.GPUDriverKey)) {
-	badPermTestGPUDriverKey(t, mcClient, uri, token1, region, org2, modFuncs...)
-	badPermTestGPUDriverKey(t, mcClient, uri, token2, region, org1, modFuncs...)
-	goodPermTestGPUDriverKey(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
-	goodPermTestGPUDriverKey(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
+func permTestStreamObjApiGPUDriverKey(t *testing.T, mcClient *mctestclient.Client, uri, token1, token2, region, org1, org2 string, showcount int, modFuncs ...func(*edgeproto.GPUDriverKey)) {
+	badPermTestStreamObjApiGPUDriverKey(t, mcClient, uri, token1, region, org2, modFuncs...)
+	badPermTestStreamObjApiGPUDriverKey(t, mcClient, uri, token2, region, org1, modFuncs...)
+	goodPermTestStreamObjApiGPUDriverKey(t, mcClient, uri, token1, region, org1, showcount, modFuncs...)
+	goodPermTestStreamObjApiGPUDriverKey(t, mcClient, uri, token2, region, org2, showcount, modFuncs...)
 }

--- a/mc/orm/testutil/cloudlet_mc2_testutil.go
+++ b/mc/orm/testutil/cloudlet_mc2_testutil.go
@@ -130,6 +130,21 @@ func TestPermGetGPUDriverBuildURL(mcClient *mctestclient.Client, uri, token, reg
 	return TestGetGPUDriverBuildURL(mcClient, uri, token, region, in, modFuncs...)
 }
 
+func TestGetGPUDriverLicenseConfig(mcClient *mctestclient.Client, uri, token, region string, in *edgeproto.GPUDriverKey, modFuncs ...func(*edgeproto.GPUDriverKey)) (*edgeproto.Result, int, error) {
+	dat := &ormapi.RegionGPUDriverKey{}
+	dat.Region = region
+	dat.GPUDriverKey = *in
+	for _, fn := range modFuncs {
+		fn(&dat.GPUDriverKey)
+	}
+	return mcClient.GetGPUDriverLicenseConfig(uri, token, dat)
+}
+func TestPermGetGPUDriverLicenseConfig(mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.GPUDriverKey)) (*edgeproto.Result, int, error) {
+	in := &edgeproto.GPUDriverKey{}
+	in.Organization = org
+	return TestGetGPUDriverLicenseConfig(mcClient, uri, token, region, in, modFuncs...)
+}
+
 func (s *TestClient) CreateGPUDriver(ctx context.Context, in *edgeproto.GPUDriver) ([]edgeproto.Result, error) {
 	inR := &ormapi.RegionGPUDriver{
 		Region:    s.Region,
@@ -208,6 +223,18 @@ func (s *TestClient) GetGPUDriverBuildURL(ctx context.Context, in *edgeproto.GPU
 		GPUDriverBuildMember: *in,
 	}
 	out, status, err := s.McClient.GetGPUDriverBuildURL(s.Uri, s.Token, inR)
+	if err == nil && status != 200 {
+		err = fmt.Errorf("status: %d\n", status)
+	}
+	return out, err
+}
+
+func (s *TestClient) GetGPUDriverLicenseConfig(ctx context.Context, in *edgeproto.GPUDriverKey) (*edgeproto.Result, error) {
+	inR := &ormapi.RegionGPUDriverKey{
+		Region:       s.Region,
+		GPUDriverKey: *in,
+	}
+	out, status, err := s.McClient.GetGPUDriverLicenseConfig(s.Uri, s.Token, inR)
 	if err == nil && status != 200 {
 		err = fmt.Errorf("status: %d\n", status)
 	}
@@ -481,6 +508,21 @@ func TestPermGenerateAccessKey(mcClient *mctestclient.Client, uri, token, region
 	return TestGenerateAccessKey(mcClient, uri, token, region, in, modFuncs...)
 }
 
+func TestGetCloudletGPUDriverLicenseConfig(mcClient *mctestclient.Client, uri, token, region string, in *edgeproto.CloudletKey, modFuncs ...func(*edgeproto.CloudletKey)) (*edgeproto.Result, int, error) {
+	dat := &ormapi.RegionCloudletKey{}
+	dat.Region = region
+	dat.CloudletKey = *in
+	for _, fn := range modFuncs {
+		fn(&dat.CloudletKey)
+	}
+	return mcClient.GetCloudletGPUDriverLicenseConfig(uri, token, dat)
+}
+func TestPermGetCloudletGPUDriverLicenseConfig(mcClient *mctestclient.Client, uri, token, region, org string, modFuncs ...func(*edgeproto.CloudletKey)) (*edgeproto.Result, int, error) {
+	in := &edgeproto.CloudletKey{}
+	in.Organization = org
+	return TestGetCloudletGPUDriverLicenseConfig(mcClient, uri, token, region, in, modFuncs...)
+}
+
 func (s *TestClient) CreateCloudlet(ctx context.Context, in *edgeproto.Cloudlet) ([]edgeproto.Result, error) {
 	inR := &ormapi.RegionCloudlet{
 		Region:   s.Region,
@@ -611,6 +653,18 @@ func (s *TestClient) GenerateAccessKey(ctx context.Context, in *edgeproto.Cloudl
 		CloudletKey: *in,
 	}
 	out, status, err := s.McClient.GenerateAccessKey(s.Uri, s.Token, inR)
+	if err == nil && status != 200 {
+		err = fmt.Errorf("status: %d\n", status)
+	}
+	return out, err
+}
+
+func (s *TestClient) GetCloudletGPUDriverLicenseConfig(ctx context.Context, in *edgeproto.CloudletKey) (*edgeproto.Result, error) {
+	inR := &ormapi.RegionCloudletKey{
+		Region:      s.Region,
+		CloudletKey: *in,
+	}
+	out, status, err := s.McClient.GetCloudletGPUDriverLicenseConfig(s.Uri, s.Token, inR)
 	if err == nil && status != 200 {
 		err = fmt.Errorf("status: %d\n", status)
 	}

--- a/mc/ormapi/cloudlet.mc2.go
+++ b/mc/ormapi/cloudlet.mc2.go
@@ -117,6 +117,33 @@ type swaggerGetGPUDriverBuildURL struct {
 	Body RegionGPUDriverBuildMember
 }
 
+// Request summary for GetGPUDriverLicenseConfig
+// swagger:parameters GetGPUDriverLicenseConfig
+type swaggerGetGPUDriverLicenseConfig struct {
+	// in: body
+	Body RegionGPUDriverKey
+}
+
+type RegionGPUDriverKey struct {
+	// Region name
+	// required: true
+	Region string
+	// GPUDriverKey in region
+	GPUDriverKey edgeproto.GPUDriverKey
+}
+
+func (s *RegionGPUDriverKey) GetRegion() string {
+	return s.Region
+}
+
+func (s *RegionGPUDriverKey) GetObj() interface{} {
+	return &s.GPUDriverKey
+}
+
+func (s *RegionGPUDriverKey) GetObjName() string {
+	return "GPUDriverKey"
+}
+
 // Request summary for CreateCloudlet
 // swagger:parameters CreateCloudlet
 type swaggerCreateCloudlet struct {
@@ -399,6 +426,13 @@ type swaggerRevokeAccessKey struct {
 // Request summary for GenerateAccessKey
 // swagger:parameters GenerateAccessKey
 type swaggerGenerateAccessKey struct {
+	// in: body
+	Body RegionCloudletKey
+}
+
+// Request summary for GetCloudletGPUDriverLicenseConfig
+// swagger:parameters GetCloudletGPUDriverLicenseConfig
+type swaggerGetCloudletGPUDriverLicenseConfig struct {
 	// in: body
 	Body RegionCloudletKey
 }

--- a/mc/ormapi/stream.mc2.go
+++ b/mc/ormapi/stream.mc2.go
@@ -87,23 +87,3 @@ type swaggerStreamGPUDriver struct {
 	// in: body
 	Body RegionGPUDriverKey
 }
-
-type RegionGPUDriverKey struct {
-	// Region name
-	// required: true
-	Region string
-	// GPUDriverKey in region
-	GPUDriverKey edgeproto.GPUDriverKey
-}
-
-func (s *RegionGPUDriverKey) GetRegion() string {
-	return s.Region
-}
-
-func (s *RegionGPUDriverKey) GetObj() interface{} {
-	return &s.GPUDriverKey
-}
-
-func (s *RegionGPUDriverKey) GetObjName() string {
-	return "GPUDriverKey"
-}


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5854: Enable Operators to see/download GPU License config after GPU Driver has been created

### Description
* Auto-gen'd files for PR: https://github.com/mobiledgex/edge-cloud/pull/1717