### PR TITLE
EDGECLOUD-5617: CreateCloudlet fails while writing crm access key for VMPool

### DIFF
--- a/crm-platforms/vmpool/vmpool-provider.go
+++ b/crm-platforms/vmpool/vmpool-provider.go
@@ -198,7 +198,7 @@ func (o *VMPoolPlatform) createVMsInternal(ctx context.Context, markedVMs map[st
 		accessKey, ok := vmAccessKeys[vm.InternalName]
 		if ok && accessKey != "" {
 			log.SpanLog(ctx, log.DebugLevelInfra, "Setting up access key file", "vm", vm.Name)
-			err = pc.CreateDir(ctx, client, "/root/accesskey", pc.Overwrite)
+			err = pc.CreateDir(ctx, client, "/root/accesskey", pc.Overwrite, pc.SudoOn)
 			if err != nil {
 				return fmt.Errorf("Failed to created /root/accesskey directory, %v", err)
 			}

--- a/infracommon/metallb.go
+++ b/infracommon/metallb.go
@@ -129,7 +129,7 @@ func ConfigureMetalLb(ctx context.Context, client ssh.Client, clusterInst *edgep
 		return err
 	}
 	dir := k8smgmt.GetNormalizedClusterName(clusterInst)
-	err = pc.CreateDir(ctx, client, dir, pc.NoOverwrite)
+	err = pc.CreateDir(ctx, client, dir, pc.NoOverwrite, pc.NoSudo)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

### Issues Fixed

* EDGECLOUD-5617: CreateCloudlet fails while writing crm access key for VMPool

### Description
* For VMPool, we need sudo permissions to create `/root/accesskeys` directory