### PR TITLE
EDGECLOUD-6395 allow user to see org created event

### DIFF
--- a/e2e-tests/data/mc_user2_orgeventsshow_empty.yml
+++ b/e2e-tests/data/mc_user2_orgeventsshow_empty.yml
@@ -3,3 +3,22 @@
       orgs:
       - AcmeAppCo
     limit: 3
+  results:
+  - name: /api/v1/auth/org/create
+    org:
+    - AcmeAppCo
+    type: audit
+    mtags:
+      duration: ""
+      email: user2@email.com
+      hostname: ""
+      lineno: ""
+      method: POST
+      org: AcmeAppCo
+      remote-ip: 127.0.0.1
+      request: '{"Address":"123 Maple Street, Gainesville, FL 32604","Name":"AcmeAppCo","Phone":"123-123-1234","Type":"developer"}'
+      response: '{"message":"Organization created"}'
+      spanid: ""
+      status: "200"
+      traceid: ""
+      username: user2

--- a/mc/orm/auditlog.go
+++ b/mc/orm/auditlog.go
@@ -61,7 +61,7 @@ func logger(next echo.HandlerFunc) echo.HandlerFunc {
 		span.SetTag("level", "audit")
 		defer span.Finish()
 		ctx := log.ContextWithSpan(req.Context(), span)
-		ec := ormutil.NewEchoContext(c, ctx)
+		ec := ormutil.NewEchoContext(c, ctx, eventStart)
 
 		// The error handler injects the error into the response.
 		// This audit log needs the error to log it, but does not

--- a/mc/orm/org.go
+++ b/mc/orm/org.go
@@ -45,6 +45,9 @@ func CreateOrg(c echo.Context) error {
 	}
 	span := log.SpanFromContext(ctx)
 	span.SetTag("org", org.Name)
+	// make sure createdAt is the same as event start, so that
+	// it will show up in event show api.
+	org.CreatedAt = ormutil.GetEventStart(c)
 
 	err = CreateOrgObj(ctx, claims, &org)
 	if err != nil {

--- a/mc/ormutil/context.go
+++ b/mc/ormutil/context.go
@@ -2,6 +2,7 @@ package ormutil
 
 import (
 	"context"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/jinzhu/gorm"
@@ -24,22 +25,32 @@ type EchoContext struct {
 	ws         *websocket.Conn
 	wsRequest  []byte
 	wsResponse []string
+	eventStart time.Time
 }
 
-func NewEchoContext(c echo.Context, ctx context.Context) *EchoContext {
+func NewEchoContext(c echo.Context, ctx context.Context, eventStart time.Time) *EchoContext {
 	ec := EchoContext{
-		Context: c,
-		ctx:     ctx,
+		Context:    c,
+		ctx:        ctx,
+		eventStart: eventStart,
 	}
 	return &ec
 }
 
-func GetContext(c echo.Context) context.Context {
+func getEchoContext(c echo.Context) *EchoContext {
 	ec, ok := c.(*EchoContext)
 	if !ok {
 		panic("auditlog.go logger func should have wrapped echo.Context with EchoContext")
 	}
-	return ec.ctx
+	return ec
+}
+
+func GetContext(c echo.Context) context.Context {
+	return getEchoContext(c).ctx
+}
+
+func GetEventStart(c echo.Context) time.Time {
+	return getEchoContext(c).eventStart
 }
 
 func SetWs(c echo.Context, ws *websocket.Conn) {


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6395 orgcreate event not showing for user

### Description

Because the audit log timestamp for the create event is registered by the auditlog middleware, the timestamp is before the code that commits the org to postgres and sets the createdat timestamp. Therefore the filtering to prevent users from seeing data from before their org was created was also dropping the org created event.

To fix, explicitly set the createdat timestamp to match the event timestamp, that way the filtering does not drop the org created event for event show.