### PR TITLE
EDGECLOUD-5791: Cloudlet envvars are maintained in chef & controller leading to inconsistencies

### DIFF
--- a/chefmgmt/chef.go
+++ b/chefmgmt/chef.go
@@ -520,6 +520,11 @@ func GetChefCloudletAttributes(ctx context.Context, cloudlet *edgeproto.Cloudlet
 		default:
 			return nil, fmt.Errorf("invalid service type: %s, valid service types are [%v]", serviceType, PlatformServices)
 		}
+
+		// Set envvars to nil as envvars will only be managed from controller and
+		// CRM on start up will get the envvars from controller (etcd)
+		envVars = nil
+
 		chefArgs := GetChefArgs(serviceCmdArgs)
 		serviceObj["args"] = chefArgs
 		chefDockerArgs := GetChefDockerArgs(dockerArgs)


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-5791: Cloudlet envvars are maintained in chef & controller leading to inconsistencies

### Description
* On CRM/Shepherd start up, it gets envvar from cloudlet object received via notify framework (comes from etcd) and also fetches envvar set by Chef
  * CRM: https://github.com/mobiledgex/edge-cloud-infra/blob/330adbfe065fe41c12ac4dd7f26c7bdb7ad1decd/infracommon/common-platform.go#L42
  * Shepherd: https://github.com/mobiledgex/edge-cloud-infra/blob/330adbfe065fe41c12ac4dd7f26c7bdb7ad1decd/shepherd/shepherd.go#L609
* If an envvar say `k1` is set to `v1` in controller, and `v2` in chef, then Chef envvar will overwrite what is stored in controller and hence a user will always have to update this in two places. Updating in chef leads to restart of CRM/Shepherd as well.
* Since these envvars are for the platform which gets brought up after nodeMgr.Init(), it is okay to get these envvars from controller. In case a user ever wants to set some envvar before `nodeMgr.Init()`, they can always use Chef to set it up
* Removed chef envvar setup as part of cloudlet bringup
* For chef envvars in existing cloudlets, we'll have to manually remove the envvars which are not required so that we don't end-up messing up any existing cloudlet