### PR TITLE
EDGECLOUD-6395 filter org events truncate timestamp to microsecs

### DIFF
--- a/e2e-tests/data/mc_user2_eventsshow.yml
+++ b/e2e-tests/data/mc_user2_eventsshow.yml
@@ -58,3 +58,7 @@
   match:
     tags:
       username: user2
+- limit: 3
+  match:
+    names:
+    - /api/v1/auth/org/create

--- a/e2e-tests/data/mc_user2_eventsshow_exp.yml
+++ b/e2e-tests/data/mc_user2_eventsshow_exp.yml
@@ -756,3 +756,45 @@
       status: "200"
       traceid: ""
       username: user2
+- search:
+    match:
+      names:
+      - /api/v1/auth/org/create
+    limit: 3
+  results:
+  - name: /api/v1/auth/org/create
+    org:
+    - Samsung
+    type: audit
+    mtags:
+      duration: ""
+      email: user2@email.com
+      hostname: ""
+      lineno: ""
+      method: POST
+      org: Samsung
+      remote-ip: 127.0.0.1
+      request: '{"Address":"1 Samstreet, Samsung Town, South Korea","Name":"Samsung","Phone":"123-123-1234","Type":"developer"}'
+      response: '{"message":"Organization created"}'
+      spanid: ""
+      status: "200"
+      traceid: ""
+      username: user2
+  - name: /api/v1/auth/org/create
+    org:
+    - AcmeAppCo
+    type: audit
+    mtags:
+      duration: ""
+      email: user2@email.com
+      hostname: ""
+      lineno: ""
+      method: POST
+      org: AcmeAppCo
+      remote-ip: 127.0.0.1
+      request: '{"Address":"123 Maple Street, Gainesville, FL 32604","Name":"AcmeAppCo","Phone":"123-123-1234","Type":"developer"}'
+      response: '{"message":"Organization created"}'
+      spanid: ""
+      status: "200"
+      traceid: ""
+      username: user2

--- a/mc/orm/auditlog.go
+++ b/mc/orm/auditlog.go
@@ -61,6 +61,11 @@ func logger(next echo.HandlerFunc) echo.HandlerFunc {
 		span.SetTag("level", "audit")
 		defer span.Finish()
 		ctx := log.ContextWithSpan(req.Context(), span)
+		// postgres saves time in microseconds, while ElasticSearch
+		// saves them in nanoseconds. In order to compare them for
+		// event filtering by org createdat time, truncate timestamp
+		// to microseconds.
+		eventStart = eventStart.Truncate(time.Microsecond)
 		ec := ormutil.NewEchoContext(c, ctx, eventStart)
 
 		// The error handler injects the error into the response.


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6395 orgcreate event not showing for user

### Description

Looks like ElasticSearch stores timestamps in nanosecond precision while Postgres stores in microsec precision. Thus a timestamp with non-zero nanoseconds will appear to happen in ES later than in Postgres, even with the same source timestamp, because the postgres timestamp gets truncated to microseconds.

Not sure why this is not showing up in local e2e testing, even though ES should be storing in nanosec. But in any case, the fix is to truncate the source timestamp so that both ES and Postgres timestamps match exactly.
