### PR TITLE
EDGECLOUD-6375, EDGECLOUD-6376 - Enforce ports, fix crash

### DIFF
--- a/operator-api-gw/tdg/tdg.go
+++ b/operator-api-gw/tdg/tdg.go
@@ -151,6 +151,9 @@ func (o *OperatorApiGw) DeletePrioritySession(ctx context.Context, req *dme.QosP
 	// Get a generic QosPrioritySessionReply, then build a QosPrioritySessionDeleteReply based on the httpStatus.
 	reply, err := sessionsclient.CallTDGQosPriorityAPI(ctx, sessionId, http.MethodDelete, o.Servers.QosSesAddr, qosSessionsApiKey, sesInfo)
 	log.SpanLog(ctx, log.DebugLevelDmereq, "Response from TDG:", "reply", reply, "err", err)
+	if err != nil {
+		return nil, err
+	}
 	deleteReply := new(dme.QosPrioritySessionDeleteReply)
 	if reply.HttpStatus == http.StatusNotFound {
 		deleteReply.Status = dme.QosPrioritySessionDeleteReply_QDEL_NOT_FOUND


### PR DESCRIPTION
### Issues Fixed

* EDGECLOUD-6375 DME crashing when deleting a qos session without profile
* EDGECLOUD-6376 DME should not allow QOS create session without a port number

### Description
- There were a couple of places an error could occur, and not be caught and returned (e.g. buildQosUrl call), and this would result in a crash as execution continued without valid data. All errors are now returned instead of continuing.
- In the case where http.StatusBadRequest is received from the QOS API server (or simulator), return the actual error message received. This enforces the presence of the port parameter, with the check being performed by the API server.

e2e and/or unit tests forthcoming...